### PR TITLE
Add thickness and color choices for evaluate function  

### DIFF
--- a/deepforest/deepforest.py
+++ b/deepforest/deepforest.py
@@ -271,7 +271,11 @@ class deepforest:
                            annotations,
                            comet_experiment=None,
                            iou_threshold=0.5,
-                           max_detections=200):
+                           max_detections=200,
+                           color_annotation=(0,0,0),
+                           color_detection=None,
+                           thickness_annotate=1,
+                           thickness_detect=1):
         """Evaluate prediction model using a csv fit_generator.
 
         Args:
@@ -281,7 +285,10 @@ class deepforest:
             iou_threshold(float): IoU Threshold to count for a positive detection
                 (defaults to 0.5)
             max_detections (int): Maximum number of bounding box predictions
-
+            color_annotation  : The color used for manual annotation, by default is black.
+            color_detection   : The color used for model prediction label, by default the color from keras_retinanet.utils.colors.label_color will be used.
+            thickness_annotate: The thickness of the lines to draw a annotation box with.
+            thickness_detect  : The thickness of the lines to draw a detection box with.
         Return:
             mAP: Mean average precision of the evaluated data
         """
@@ -306,7 +313,11 @@ class deepforest:
                                       score_threshold=args.score_threshold,
                                       max_detections=max_detections,
                                       save_path=args.save_path,
-                                      comet_experiment=comet_experiment)
+                                      comet_experiment=comet_experiment,
+                                      color_annotation=color_annotation,
+                                      color_detection=color_detection,
+                                      thickness_annotate=thickness_annotate,
+                                      thickness_detect=thickness_detect)
 
         # print evaluation
         total_instances = []

--- a/deepforest/keras_retinanet/utils/visualization.py
+++ b/deepforest/keras_retinanet/utils/visualization.py
@@ -81,7 +81,7 @@ def draw_detections(image, boxes, scores, labels, color=None, label_to_name=None
         #draw_caption(image, boxes[i, :], caption)
 
 
-def draw_annotations(image, annotations, color=(0, 0, 0), label_to_name=None):
+def draw_annotations(image, annotations, color=(0, 0, 0), label_to_name=None, thickness=1):
     """ Draws annotations in an image.
 
     # Arguments
@@ -89,6 +89,7 @@ def draw_annotations(image, annotations, color=(0, 0, 0), label_to_name=None):
         annotations   : A [N, 5] matrix (x1, y1, x2, y2, label) or dictionary containing bboxes (shaped [N, 4]) and labels (shaped [N]).
         color         : The color of the boxes. By default the color from keras_retinanet.utils.colors.label_color will be used.
         label_to_name : (optional) Functor for mapping a label to a name.
+        thickness     : The thickness of the lines to draw boxes with.
     """
     if isinstance(annotations, np.ndarray):
         annotations = {'bboxes': annotations[:, :4], 'labels': annotations[:, 4]}
@@ -102,4 +103,4 @@ def draw_annotations(image, annotations, color=(0, 0, 0), label_to_name=None):
         c       = color if color is not None else label_color(label)
         #caption = '{}'.format(label_to_name(label) if label_to_name else label)
         #draw_caption(image, annotations['bboxes'][i], caption)
-        draw_box(image, annotations['bboxes'][i], color=c)
+        draw_box(image, annotations['bboxes'][i], color=c, thickness=thickness)


### PR DESCRIPTION
I found out the default color is not colorblind-friendly, especially when you work on the forest that background is green and the bounding box is red. So I think to give people more flexibility to choose their desire color and also make the bounding box thickness big enough to see.