### PR TITLE
Defining specific version of h5py (2.10.0)

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - pytest
   - numpydoc
   - cython>=0.28
-  - h5py
+  - h5py=2.10.0
   - xmltodict
   - tqdm
   - numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 
 cython>=0.28
-h5py
+h5py==2.10.0
 numpy
 numpydoc
 matplotlib

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ setup(name=NAME,
       packages=find_packages(),
       include_package_data=True,
       cmdclass         = {'build_ext': BuildExtension},
-      install_requires=["tensorflow==1.14.0","keras==2.3.0","keras-resnet==0.1.0","h5py","matplotlib","opencv-python","Pillow","pandas","pyyaml","progressbar2","six","scipy","slidingwindow","tqdm","xmltodict"],
+      install_requires=["tensorflow==1.14.0","keras==2.3.0","keras-resnet==0.1.0","h5py==2.10.0","matplotlib","opencv-python","Pillow","pandas","pyyaml","progressbar2","six","scipy","slidingwindow","tqdm","xmltodict"],
       ext_modules    = extensions,
       setup_requires = ["cython>=0.28", "numpy>=1.14.0"],
       zip_safe=False)


### PR DESCRIPTION
I installed DeepForest today and it looks like the newest versions of h5py (3.0.0 and 3.1.0) [cause issues](https://github.com/tensorflow/tensorflow/issues/44467) with Keras models in TensorFlow. Here's a [discussion](https://stackoverflow.com/questions/53740577/does-any-one-got-attributeerror-str-object-has-no-attribute-decode-whi) of the issue on Stack Overflow as well.

Here's the error I got after running the suggested [test script](https://github.com/mlevans/DeepForest#prediction). Please note that this originates from running the "use_release" method in the DeepForest main module:
```
File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/keras/engine/saving.py", 
line 273, in _deserialize_model
    model_config = json.loads(model_config.decode('utf-8'))
AttributeError: 'str' object has no attribute 'decode'
```

In this pull request, I've set the h5py version to 2.10.0 in three files. This resolves the issue for me.

Thank you!