### PR TITLE
Display number of predicted objects in plot title

### DIFF
--- a/deepforest/deepforest.py
+++ b/deepforest/deepforest.py
@@ -409,7 +409,8 @@ class deepforest:
                      patch_size=400,
                      patch_overlap=0.05,
                      iou_threshold=0.15,
-                     return_plot=False):
+                     return_plot=False,
+                     show=False):
         """For images too large to input into the model, predict_tile cuts the
         image into overlapping windows, predicts trees on each window and
         reassambles into a single array.
@@ -424,6 +425,8 @@ class deepforest:
                 windows to be suppressed. Defaults to 0.5.
                 Lower values suppress more boxes at edges.
             return_plot: Should the image be returned with the predictions drawn?
+            show (bool): Plot the predicted image with bounding boxes.
+                Ignored if return_plot=False
 
         Returns:
             boxes (array): if return_plot, an image.
@@ -504,6 +507,10 @@ class deepforest:
             # Draw predictions
             for box in mosaic_df[["xmin", "ymin", "xmax", "ymax"]].values:
                 draw_box(numpy_image, box, [0, 0, 255])
+
+            if show:
+                plt.imshow(numpy_image[:, :, ::-1])
+                plt.show()
 
             # Mantain consistancy with predict_image
             return numpy_image

--- a/deepforest/deepforest.py
+++ b/deepforest/deepforest.py
@@ -388,7 +388,7 @@ class deepforest:
                 raise ValueError("No input specified. deepforest.predict_image() requires either a numpy_image array or a path to a file to read.")
 
         #Predict
-        prediction = predict.predict_image(self.prediction_model,
+        prediction, marked_image = predict.predict_image(self.prediction_model,
                                            image_path=image_path,
                                            raw_image=numpy_image,
                                            return_plot=return_plot,
@@ -397,9 +397,15 @@ class deepforest:
                                            classes=self.labels)
 
         # cv2 channel order to matplotlib order
-        if return_plot & show:
-            plt.imshow(prediction[:, :, ::-1])
-            plt.show()
+        if return_plot:
+            if show:
+                num_pred_objects = len(prediction.index)
+                # Display number of predictions in plot title
+                plt.title("{} Objects Predicted".format(num_pred_objects))
+                plt.imshow(marked_image[:, :, ::-1])
+                plt.show()
+
+            return marked_image
 
         return prediction
 
@@ -509,6 +515,9 @@ class deepforest:
                 draw_box(numpy_image, box, [0, 0, 255])
 
             if show:
+                num_pred_objects = len(mosaic_df.index)
+                # Display number of predictions in plot title
+                plt.title("{} Objects Predicted".format(num_pred_objects))
                 plt.imshow(numpy_image[:, :, ::-1])
                 plt.show()
 

--- a/deepforest/predict.py
+++ b/deepforest/predict.py
@@ -41,10 +41,10 @@ def predict_image(model,
         thickness: thickness of boundingbox default 1
 
     Returns:
+        image_detections: np.array of image_boxes,
+            image_scores, image_labels
         raw_image (array): If return_plot is TRUE, the image with the overlaid
             boxes is returned
-        image_detections: If return_plot is FALSE, a np.array of image_boxes,
-            image_scores, image_labels
     """
     # Check for raw_image
     if raw_image is not None:
@@ -116,9 +116,9 @@ def predict_image(model,
                         score_threshold=score_threshold,
                         color=color,
                         thickness=thickness)
-        return numpy_image
+        return df, numpy_image
     else:
-        return df
+        return df, None
 
 
 def non_max_suppression(sess,


### PR DESCRIPTION
When there are many predictions in an image, it is hard to know how many predictions were made. Using `predict_image` and `predict_tile` with show parameter only display a marked image in pyplot, with no info about the number of predictions which could be helpful for visible and manual cross-checking the predictions.

This PR allows showing the number of predictions in the title of pyplot. Example title - "6 Objects Predicted"