### PR TITLE
Explicitly setting the datatype of targets['labels'] to an int64

### DIFF
--- a/deepforest/dataset.py
+++ b/deepforest/dataset.py
@@ -79,7 +79,7 @@ class TreeDataset(Dataset):
             
             # Labels need to be encoded
             targets["labels"] = image_annotations.label.apply(
-                lambda x: self.label_dict[x]).values.astype(int)
+                lambda x: self.label_dict[x]).values.astype(np.int64)
     
             augmented = self.transform(image=image, bboxes=targets["boxes"], category_ids=targets["labels"])
             image = augmented["image"]


### PR DESCRIPTION
Instead of assuming the default int would be 64bits

targets["labels"] is used during training to index a tensor, and in pytorch the indexing must be performed with int64's

As seen in #201 
https://github.com/weecology/DeepForest/issues/201#issuecomment-880319824