### PR TITLE
Support for images with no annotations for RetinaNet training

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(name=NAME,
       packages=find_packages(),
       include_package_data=True,
       install_requires=[
-          "torch", "torchvision", "matplotlib", "Pillow>6.2.0", "pandas", "progressbar2", "six", "scipy>1.5", "slidingwindow","geopandas",'rasterio','rtree',"pytorch_lightning",
+          "torch", "torchvision>=0.9.0", "matplotlib", "Pillow>6.2.0", "pandas", "progressbar2", "six", "scipy>1.5", "slidingwindow","geopandas",'rasterio','rtree',"pytorch_lightning",
           "tqdm", "xmltodict", "numpy","imagecodecs","albumentations"
       ],
       zip_safe=False)


### PR DESCRIPTION
Hi, this is the fix for #216

I fixed this error:

```
File "/.../python/lib/python3.8/site-packages/torch/utils/data/_utils/worker.py", line 287, in _worker_loop
  data = fetcher.fetch(index)
File "/.../python/lib/python3.8/site-packages/torch/utils/data/_utils/fetch.py", line 44, in fetch
  data = [self.dataset[idx] for idx in possibly_batched_index]
File "/.../python/lib/python3.8/site-packages/torch/utils/data/_utils/fetch.py", line 44, in <listcomp>
  data = [self.dataset[idx] for idx in possibly_batched_index]
File "/.../python/lib/python3.8/site-packages/deepforest/dataset.py", line 81, in __getitem__
  targets["labels"] = image_annotations.label.apply(
File "/.../python/lib/python3.8/site-packages/pandas/core/series.py", line 4356, in apply
  return SeriesApply(self, func, convert_dtype, args, kwargs).apply()
File "/.../python/lib/python3.8/site-packages/pandas/core/apply.py", line 1036, in apply
  return self.apply_standard()
File "/.../python/lib/python3.8/site-packages/pandas/core/apply.py", line 1092, in apply_standard
  mapped = lib.map_infer(
File "pandas/_libs/lib.pyx", line 2859, in pandas._libs.lib.map_infer
File "/.../python/lib/python3.8/site-packages/deepforest/dataset.py", line 82, in <lambda>
   lambda x: self.label_dict[x]).values.astype(int)
```

Now for each empty training image with no annotations you should just add a single row to CSV with an empty label and correct image_path. Other columns (like xmin, ... ymax) will have no effect, they can be empty or equal to zero.