### PR TITLE
Use latest sphinx

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -16,7 +16,7 @@ numpy
 recommonmark
 rasterio
 rtree
-sphinx >= 1.8
+sphinx
 slidingwindow
 opencv-python
 sphinx_rtd_theme

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,7 +38,8 @@ with urllib.request.urlopen(readme_url) as response:
             file_obj.write(line)
 file_obj.close()
 
-needs_sphinx = "1.8"
+# if minimal version required
+needs_sphinx = "4.2"
 
 autodoc_default_options = {
     'members': None,


### PR DESCRIPTION
It seems that sphinx version has some compatibility issues  on readthedocs server. 

Error 
`TypeError: 'generator' object is not reversible` and objects can't be transformed.
Updating to newer versions may help