### PR TITLE
Improve image dtype warnings

### DIFF
--- a/deepforest/predict.py
+++ b/deepforest/predict.py
@@ -31,7 +31,7 @@ def predict_image(model, image, return_plot, device, iou_threshold=0.1, color=No
     """
     
     if image.dtype !="float32":
-        warnings.warn("Image type is {}, transforming to float32. This assumes that the range of pixel values is 0-255, as opposed to 0-1.To suppress this warning, transform image (image.astype('float32')")
+        warnings.warn(f"Image type is {image.dtype}, transforming to float32. This assumes that the range of pixel values is 0-255, as opposed to 0-1.To suppress this warning, transform image (image.astype('float32')")
         image = image.astype("float32")
     image = preprocess.preprocess_image(image, device=device)
     
@@ -179,6 +179,7 @@ def predict_tile(model,
     for index, window in enumerate(tqdm(windows)):
         # crop window and predict
         crop = image[windows[index].indices()]
+        crop = crop.astype('float32')
 
         # crop is RGB channel order, change to BGR?
         boxes = predict_image(model=model, image=crop, return_plot=False, device=device)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -135,6 +135,7 @@ def test_predict_image_fromarray(m):
 def test_predict_return_plot(m):
     image = get_data(path="2019_YELL_2_528000_4978000_image_crop2.png")
     image = np.array(Image.open(image))
+    image = image.astype('float32')
     plot = m.predict_image(image = image, return_plot=True)
     assert isinstance(plot, np.ndarray)
 


### PR DESCRIPTION
predict_image throws a warning if the dtype != 'float32'. This warning
currently throws on every use of predict_tile since the dtype isn't loaded
as 'float32'. This change:

1. Converts to float32 in predict_tile before calling predict_image
2. Fixes the warning to report the dtype if it is not float32
3. Updates a test to convert to float32 to avoid the warning