### PR TITLE
 fixed basename extraction

### DIFF
--- a/deepforest/preprocess.py
+++ b/deepforest/preprocess.py
@@ -88,8 +88,7 @@ def select_annotations(annotations, windows, index, allow_empty=False):
                                                           (window_ymax + offset))]
 
     # change the image name
-    image_name = os.path.splitext("{}".format(annotations.image_path.unique()[0]))[0]
-    image_basename = os.path.splitext(image_name)[0]
+    image_basename = os.path.splitext("{}".format(annotations.image_path.unique()[0]))[0]
     selected_annotations.image_path = "{}_{}.png".format(image_basename, index)
 
     # If no matching annotations, return a line with the image name, but no


### PR DESCRIPTION
if image name contains more than one `.`dot (e.g. `my.sample.img.png`) the current code will extract wrong name from it.

The second `splitext` call in `select_annotations` is not necessary.