### PR TITLE
create new post-processing workflow

### DIFF
--- a/deepforest/visualize.py
+++ b/deepforest/visualize.py
@@ -108,7 +108,8 @@ def plot_predictions(image, df, color=None, thickness=1):
         image: a numpy array with drawn annotations
     """    
     if image.shape[0] == 3:
-        raise ValueError("Input images must be channels last format [h, w, 3] not channels first [3, h, w], use np.rollaxis(image, 0, 3) to invert")
+        warnings.warn("Input images must be channels last format [h, w, 3] not channels first [3, h, w], using np.rollaxis(image, 0, 3) to invert!")
+        image = np.rollaxis(image, 0, 3)
     if image.dtype == "float32":
         image = image.astype("uint8")
     image = image.copy()

--- a/docs/bird_detector.md
+++ b/docs/bird_detector.md
@@ -18,8 +18,8 @@ For more information, or specific questions about the bird detection, please cre
 
 ```
 from deepforest import main
-from deepforest.utilities import project_boxes
 from deepforest.visualize import plot_predictions
+from deepforest.utilities import boxes_to_shapefile
 
 import rasterio as rio
 import geopandas as gpd
@@ -28,7 +28,6 @@ import os
 import matplotlib.pyplot as plt
 import numpy as np
 from shapely import geometry
-
 
 PATH_TO_DIR = "/Users/benweinstein/Dropbox/Weecology/everglades_species/easyidp/HiddenLittle_03_24_2022"
 files = glob("{}/*.JPG".format(PATH_TO_DIR))
@@ -50,9 +49,8 @@ for path in files:
     fig = plot_predictions(df=boxes, image=image)   
     plt.imshow(fig)
     
-    boxes['geometry'] = boxes.apply(
-           lambda x: geometry.box(x.xmin, -x.ymin, x.xmax, -x.ymax), axis=1)    
-    shp = gpd.GeoDataFrame(boxes, geometry="geometry")
+    #Create a shapefile, in this case img data was unprojected
+    shp = boxes_to_shapefile(boxes, root_dir=PATH_TO_DIR, projected=False)
     
     #Get name of image and save a .shp in the same folder
     basename = os.path.splitext(os.path.basename(path))[0]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -142,7 +142,7 @@ def test_predict_image_fromarray(m):
     image = np.array(Image.open(image_path).convert("RGB"))
     prediction = m.predict_image(image = image)    
     assert isinstance(prediction, pd.DataFrame)
-    assert set(prediction.columns) == {"xmin","ymin","xmax","ymax","label","score","image_path"}
+    assert set(prediction.columns) == {"xmin","ymin","xmax","ymax","label","score"}
 
 def test_predict_return_plot(m):
     image = get_data(path="2019_YELL_2_528000_4978000_image_crop2.png")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -129,7 +129,7 @@ def test_predict_image_fromfile(m):
     prediction = m.predict_image(path = path)
     
     assert isinstance(prediction, pd.DataFrame)
-    assert set(prediction.columns) == {"xmin","ymin","xmax","ymax","label","score"}
+    assert set(prediction.columns) == {"xmin","ymin","xmax","ymax","label","score","image_path"}
 
 def test_predict_image_fromarray(m):
     image_path = get_data(path="2019_YELL_2_528000_4978000_image_crop2.png")
@@ -142,7 +142,7 @@ def test_predict_image_fromarray(m):
     image = np.array(Image.open(image_path).convert("RGB"))
     prediction = m.predict_image(image = image)    
     assert isinstance(prediction, pd.DataFrame)
-    assert set(prediction.columns) == {"xmin","ymin","xmax","ymax","label","score"}
+    assert set(prediction.columns) == {"xmin","ymin","xmax","ymax","label","score","image_path"}
 
 def test_predict_return_plot(m):
     image = get_data(path="2019_YELL_2_528000_4978000_image_crop2.png")

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -4,6 +4,7 @@ import os
 import pytest
 import pandas as pd
 import rasterio as rio
+from shapely import geometry
 
 from deepforest import get_data
 from deepforest import utilities
@@ -34,7 +35,7 @@ def test_use_release(download_release):
 def test_use_bird_release(download_release):
     # Download latest model from github release
     release_tag, state_dict = utilities.use_bird_release()
-    assert os.path.exists(get_data("bird.pt"))
+    assert os.path.exists(get_data("bird.pt"))    
     
 def test_float_warning(config):
     """Users should get a rounding warning when adding annotations with floats"""
@@ -50,13 +51,29 @@ def test_project_boxes():
     assert df.shape[0] == gdf.shape[0]
     
 
-def test_annotations_to_shapefile(download_release):
+def test_boxes_to_shapefile_projected(download_release):
     img = get_data("OSBS_029.tif")
     r = rio.open(img)
-    transform = r.transform 
-    crs = r.crs
     m = main.deepforest()
     m.use_release(check_release=False)
     df = m.predict_image(path=img)
-    gdf = utilities.annotations_to_shapefile(df, transform=transform, crs=crs)
-    assert df.shape[0] == gdf.shape[0]
+    gdf = utilities.boxes_to_shapefile(df, root_dir=os.path.dirname(img), projected=True)
+    
+    #Confirm that each boxes within image bounds
+    geom = geometry.box(*r.bounds)
+    assert all(gdf.geometry.apply(lambda x: geom.intersects(geom)).values)
+    
+
+@pytest.mark.parametrize("flip_y_axis", [True, False])
+def test_boxes_to_shapefile_unprojected(download_release, flip_y_axis):
+    img = get_data("OSBS_029.png")
+    r = rio.open(img)
+    m = main.deepforest()
+    m.use_release(check_release=False)
+    df = m.predict_image(path=img)
+    gdf = utilities.boxes_to_shapefile(df, root_dir=os.path.dirname(img), projected=False, flip_y_axis=flip_y_axis)
+    
+    #Confirm that each boxes within image bounds
+    geom = geometry.box(*r.bounds)
+    assert all(gdf.geometry.apply(lambda x: geom.intersects(geom)).values)
+    gdf.to_file("/Users/benweinstein/Downloads/test_{}.shp".format(flip_y_axis))

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -76,4 +76,3 @@ def test_boxes_to_shapefile_unprojected(download_release, flip_y_axis):
     #Confirm that each boxes within image bounds
     geom = geometry.box(*r.bounds)
     assert all(gdf.geometry.apply(lambda x: geom.intersects(geom)).values)
-    gdf.to_file("/Users/benweinstein/Downloads/test_{}.shp".format(flip_y_axis))


### PR DESCRIPTION
This closes #352, #351, #350 by creating a new boxes_to_shapefile function. 

* Added deprecation warnings to previous functions
* Add tests for projected and unprojected data
* Added reflect y axis functionality to align with GDAL's (and therefore QGIS), somewhat bizarre convention on negative y coordinate for reading .png and other non-projected data.

In this process I also cleaned up #328 by adding image path on predict_image
and rolled images to last when encountering data.