### PR TITLE
updated argument pretrained to weights as per torchvision v0.13

### DIFF
--- a/deepforest/model.py
+++ b/deepforest/model.py
@@ -1,12 +1,13 @@
 # Model
 import torchvision
 from torchvision.models.detection.retinanet import RetinaNet
+from torchvision.models.detection.retinanet import RetinaNet_ResNet50_FPN_Weights
 from torchvision.models.detection.retinanet import AnchorGenerator
 
 
 def load_backbone():
     """A torch vision retinanet model"""
-    backbone = torchvision.models.detection.retinanet_resnet50_fpn(pretrained=True)
+    backbone = torchvision.models.detection.retinanet_resnet50_fpn(weights=RetinaNet_ResNet50_FPN_Weights.DEFAULT)
 
     # load the model onto the computation device
     return backbone


### PR DESCRIPTION
Resolves #369 

This warning was caused because the argument `pretrained` used in `deepforest/model.py` is deprecated since torchvision v0.13 and the expected argument is `weights` as mentioned in the [docs](https://pytorch.org/vision/master/models/generated/torchvision.models.detection.retinanet_resnet50_fpn.html)

I made the changes and built locally, here's the output : 
![Screenshot from 2023-02-09 16-13-44](https://user-images.githubusercontent.com/94868003/217791364-444fce91-1025-40b3-8576-ec4511a1535e.png)

If there are any other changes to merge this PR please let me know, Thanks!