### PR TITLE
standardize the way we refer to a model in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,12 +81,14 @@ m.evaluate(csv_file=m.config["validation"]["csv_file"], root_dir=m.config["valid
 ## Predict a single image
 
 ```Python
-from deepforest import main
-csv_file = '/Users/benweinstein/Documents/DeepForest/deepforest/data/OSBS_029.tif'
-df = m.predict_file(csv_file, root_dir = os.path.dirname(csv_file))
+#Create a sample 3 band image
+image = np.random.random((400,400,3)).astype("float32")
+prediction = m.predict_image(image = image)
 ```
 
 ## Predict a large tile
+
+Split the large tile into small pieces, predict each piece and re-assemble
 
 ```Python
 predicted_boxes = m.predict_tile(raster_path = raster_path,
@@ -95,7 +97,7 @@ predicted_boxes = m.predict_tile(raster_path = raster_path,
                                         return_plot = False)
 ```
 
-## Evaluate a file of annotations using intersection-over-union
+## Evaluate a file of annotations using intersection-over-union as an metric of accuracy
 
 ```Python
 csv_file = get_data("example.csv")

--- a/README.md
+++ b/README.md
@@ -83,13 +83,13 @@ m.evaluate(csv_file=m.config["validation"]["csv_file"], root_dir=m.config["valid
 ```Python
 from deepforest import main
 csv_file = '/Users/benweinstein/Documents/DeepForest/deepforest/data/OSBS_029.tif'
-df = trained_model.predict_file(csv_file, root_dir = os.path.dirname(csv_file))
+df = m.predict_file(csv_file, root_dir = os.path.dirname(csv_file))
 ```
 
 ## Predict a large tile
 
 ```Python
-predicted_boxes = trained_model.predict_tile(raster_path = raster_path,
+predicted_boxes = m.predict_tile(raster_path = raster_path,
                                         patch_size = 300,
                                         patch_overlap = 0.5,
                                         return_plot = False)


### PR DESCRIPTION
@agentmorris noticed that we alternate 'm' versus 'trained_model' in the github README. In general, I tend to use 'm' for a deepforest model instance. 