### PR TITLE
Pass Python version to mamba correctly

### DIFF
--- a/.github/workflows/Conda-app.yml
+++ b/.github/workflows/Conda-app.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           environment-name: DeepForest
           environment-file: environment.yml
-          python-version: "${{ matrix.python-version }}"
+          extra-specs: "python=${{ matrix.python-version }}"
           cache-env: true
           cache-downloads: true
 


### PR DESCRIPTION
python-version is not yet supported by the mamba action.

See:
* https://github.com/mamba-org/provision-with-micromamba#extra-specs
* https://github.com/mamba-org/provision-with-micromamba/blob/e2b397b12d0a38069451664382b769c9456e3d6d/action.yml#L121-L152