### PR TITLE
Update predict functions to align with pytorch lightning API

### DIFF
--- a/deepforest/callbacks.py
+++ b/deepforest/callbacks.py
@@ -98,7 +98,7 @@ class iou_callback(Callback):
             self.log("box_recall", results["box_recall"])
             self.log("box_precision", results["box_precision"])
 
-            if not type(results["class_recall"]) == type(None):
+            if isinstance(a, pd.DataFrame):
                 for index, row in results["class_recall"].iterrows():
                     self.log(
                         "{}_Recall".format(pl_module.numeric_to_label_dict[row["label"]]),

--- a/deepforest/dataset.py
+++ b/deepforest/dataset.py
@@ -138,7 +138,7 @@ class TreeDataset(Dataset):
 
 class TileDataset(Dataset):
     def __init__(self, 
-                 tile: typing.Optional[np.ndarray]=None, 
+                 tile: typing.Optional[np.ndarray], 
                  preload_images: bool=False,
                  patch_size: int=400,
                  patch_overlap: float=0.05

--- a/deepforest/dataset.py
+++ b/deepforest/dataset.py
@@ -20,7 +20,10 @@ import albumentations as A
 from albumentations import functional as F
 from albumentations.pytorch import ToTensorV2
 import torch
+import typing
 from PIL import Image
+import rasterio as rio
+from deepforest import preprocess
 
 
 def get_transform(augment):
@@ -39,7 +42,6 @@ def get_transform(augment):
 
 
 class TreeDataset(Dataset):
-
     def __init__(self,
                  csv_file,
                  root_dir,
@@ -133,3 +135,45 @@ class TreeDataset(Dataset):
             # Mimic the train augmentation
             converted = self.image_converter(image=image)
             return converted["image"]
+
+class TileDataset(Dataset):
+    def __init__(self, 
+                 tile: typing.Optional[np.ndarray]=None, 
+                 preload_images: bool=False,
+                 patch_size: int=400,
+                 patch_overlap: float=0.05
+                 ):
+        """
+        Args:
+            tile: an in memory numpy array.
+            patch_size (int): The size for the crops used to cut the input raster into smaller pieces. This is given in pixels, not any geographic unit.
+            patch_overlap (float): The horizontal and vertical overlap among patches
+        Returns:
+            ds: a pytorch dataset
+        """
+        if not tile.shape[2] == 3:
+            raise ValueError("Only three band raster are accepted. Channels should be the final dimension. Input tile has shape {}. Check for transparent alpha channel and remove if present".format(tile.shape))
+        
+        self.image = tile
+        self.preload_images = preload_images
+        self.windows = preprocess.compute_windows(self.image, patch_size, patch_overlap)
+        
+        if self.preload_images:
+            self.crops = []
+            for window in self.windows:
+                crop = self.image[window.indices()]
+                crop = preprocess.preprocess_image(crop)                
+                self.crops.append(crop)
+            
+    def __len__(self):
+        return len(self.windows)
+                
+    def __getitem__(self, idx):
+        # Read image if not in memory
+        if self.preload_images:
+            crop = self.crops[idx]
+        else:
+            crop = self.image[self.windows[idx].indices()]
+            crop = preprocess.preprocess_image(crop)                            
+            
+        return crop    

--- a/deepforest/evaluate.py
+++ b/deepforest/evaluate.py
@@ -11,7 +11,7 @@ from PIL import Image
 from deepforest import IoU
 from deepforest.utilities import check_file
 from deepforest import visualize
-
+import warnings
 
 def evaluate_image(predictions, ground_df, root_dir, savedir=None):
     """
@@ -107,7 +107,7 @@ def evaluate(predictions, ground_df, root_dir, iou_threshold=0.4, savedir=None):
 
     check_file(ground_df)
     check_file(predictions)
-
+    
     # Run evaluation on all plots
     results = []
     box_recalls = []

--- a/deepforest/main.py
+++ b/deepforest/main.py
@@ -185,7 +185,6 @@ class deepforest(pl.LightningModule):
         Returns:
             ds: a pytorch dataset
         """
-
         ds = dataset.TreeDataset(csv_file=csv_file,
                                  root_dir=root_dir,
                                  transforms=self.transforms(augment=augment),
@@ -268,10 +267,6 @@ class deepforest(pl.LightningModule):
                             "from PIL, wrap in "
                             "np.array(image).astype(float32)".format(type(image)))
 
-            # Load on GPU is available
-        if self.current_device.type == "cuda":
-            self.model = self.model.to("cuda")
-
         self.model.eval()
         self.model.score_thresh = self.config["score_thresh"]
 
@@ -310,7 +305,6 @@ class deepforest(pl.LightningModule):
         Returns:
             df: pandas dataframe with bounding boxes, label and scores for each image in the csv file
         """
-        self.model = self.model.to(self.current_device)
         self.model.eval()
         self.model.score_thresh = self.config["score_thresh"]
 
@@ -366,10 +360,6 @@ class deepforest(pl.LightningModule):
             boxes (array): if return_plot, an image.
             Otherwise a numpy array of predicted bounding boxes, scores and labels
         """
-
-        # Load on GPU is available
-        if torch.cuda.is_available():
-            self.model = self.model.to("cuda")
 
         self.model.eval()
         self.model.score_thresh = self.config["score_thresh"]
@@ -505,10 +495,6 @@ class deepforest(pl.LightningModule):
         Returns:
             results: dict of ("results", "precision", "recall") for a given threshold
         """
-        # Load on GPU is available
-        if torch.cuda.is_available():
-            self.model = self.model.to("cuda")
-
         self.model.eval()
         self.model.score_thresh = self.config["score_thresh"]
 

--- a/deepforest/main.py
+++ b/deepforest/main.py
@@ -128,8 +128,8 @@ class deepforest(pl.LightningModule):
         if not self.config["validation"]["csv_file"] is None:
             if logger is not None:
                 lr_monitor = LearningRateMonitor(logging_interval='epoch')
-                iou_callback = iou_callback(self.config, every_n_epochs=self.config["validation"]["val_accuracy_interval"])
-                callbacks.append(iou_callback)
+                eval_callback = iou_callback(self.config, every_n_epochs=self.config["validation"]["val_accuracy_interval"])
+                callbacks.append(eval_callback)
                 callbacks.append(lr_monitor)
             limit_val_batches = 1.0
             num_sanity_val_steps = 2
@@ -581,7 +581,7 @@ class deepforest(pl.LightningModule):
                                         savedir=savedir)
 
         # replace classes if not NUll, wrap in try catch if no predictions
-        if not results["results"].empty:
+        if not results is None:
             results["results"]["predicted_label"] = results["results"][
                 "predicted_label"].apply(lambda x: self.numeric_to_label_dict[x]
                                          if not pd.isnull(x) else x)

--- a/deepforest/main.py
+++ b/deepforest/main.py
@@ -55,6 +55,9 @@ class deepforest(pl.LightningModule):
 
         self.num_classes = num_classes
         self.create_model()
+        
+        #Create a default trainer.
+        self.create_trainer()
 
         # Label encoder and decoder
         if not len(label_dict) == num_classes:

--- a/deepforest/main.py
+++ b/deepforest/main.py
@@ -3,29 +3,29 @@ import os
 import pandas as pd
 from PIL import Image
 import torch
+import typing
 
 import pytorch_lightning as pl
 from torch import optim
 import numpy as np
 
-from deepforest import utilities
-from deepforest import dataset
-from deepforest import get_data
-from deepforest import model
-from deepforest import predict
+from deepforest import dataset, visualize, get_data, utilities, model, predict
 from deepforest import evaluate as evaluate_iou
+from deepforest.callbacks import iou_callback
 from pytorch_lightning.callbacks import LearningRateMonitor
-
+import rasterio as rio
+import cv2
+import warnings
 
 class deepforest(pl.LightningModule):
     """Class for training and predicting tree crowns in RGB images
     """
 
     def __init__(self,
-                 num_classes=1,
-                 label_dict={"Tree": 0},
+                 num_classes: int = 1,
+                 label_dict: dict = {"Tree": 0},
                  transforms=None,
-                 config_file='deepforest_config.yml'):
+                 config_file: str = 'deepforest_config.yml'):
         """
         Args:
             num_classes (int): number of classes in the model
@@ -34,13 +34,6 @@ class deepforest(pl.LightningModule):
             self: a deepforest pytorch lightning module
         """
         super().__init__()
-
-        # Pytorch lightning handles the device,
-        # but we need one for adhoc methods like predict_image.
-        if torch.cuda.is_available():
-            self.current_device = torch.device("cuda")
-        else:
-            self.current_device = torch.device("cpu")
 
         # Read config file. Defaults to deepforest_config.yml in working directory.
         # Falls back to default installed version
@@ -94,7 +87,7 @@ class deepforest(pl.LightningModule):
         release_tag, self.release_state_dict = utilities.use_release(
             check_release=check_release)
         self.model.load_state_dict(
-            torch.load(self.release_state_dict, map_location=self.device))
+            torch.load(self.release_state_dict))
 
         # load saved model and tag release
         self.__release_version__ = release_tag
@@ -132,6 +125,8 @@ class deepforest(pl.LightningModule):
         if not self.config["validation"]["csv_file"] is None:
             if logger is not None:
                 lr_monitor = LearningRateMonitor(logging_interval='epoch')
+                iou_callback = iou_callback(self.config, every_n_epochs=self.config["validation"]["val_accuracy_interval"])
+                callbacks.append(iou_callback)
                 callbacks.append(lr_monitor)
             limit_val_batches = 1.0
             num_sanity_val_steps = 2
@@ -232,13 +227,29 @@ class deepforest(pl.LightningModule):
             loader = []
 
         return loader
-
+    
+    def predict_dataloader(self, ds):
+        """
+        Create a pytorch dataloader for prediction
+        Returns:
+        """
+        data_loader = torch.utils.data.DataLoader(
+            ds,
+            batch_size=self.config["batch_size"],
+            shuffle=False,
+            num_workers=self.config["workers"]
+        )
+        
+        return data_loader
+        
+        
     def predict_image(self,
-                      image=None,
-                      path=None,
-                      return_plot=False,
-                      color=None,
-                      thickness=1):
+                      image: typing.Optional[np.ndarray]=None,
+                      path: typing.Optional[str]=None,
+                      return_plot: bool = False,
+                      thickness: int = 1,
+                      color: typing.Optional[tuple] = (0, 165, 255)
+                      ):
         """Predict a single image with a deepforest model
                 
         Args:
@@ -251,14 +262,7 @@ class deepforest(pl.LightningModule):
             boxes: A pandas dataframe of predictions (Default)
             img: The input with predictions overlaid (Optional)
         """
-        if isinstance(image, str):
-            raise ValueError(
-                "Path provided instead of image. If you want to predict an image from disk, is path ="
-            )
-
         if path:
-            if not isinstance(path, str):
-                raise ValueError("Path expects a string path to image on disk")
             image = np.array(Image.open(path).convert("RGB")).astype("float32")
 
         # sanity checks on input images
@@ -269,26 +273,46 @@ class deepforest(pl.LightningModule):
 
         self.model.eval()
         self.model.score_thresh = self.config["score_thresh"]
+        
+        if image.dtype != "float32":
+            warnings.warn(f"Image type is {image.dtype}, transforming to float32. "
+                          f"This assumes that the range of pixel values is 0-255, as "
+                          f"opposed to 0-1.To suppress this warning, transform image "
+                          f"(image.astype('float32')")
+            image = image.astype("float32")
+        
+        image = torch.tensor(image, device=self.device).permute(2, 0, 1)
+        image = image / 255
+        
+        with torch.no_grad():
+            prediction = self.model(image.unsqueeze(0))
+    
+        # return None for no predictions
+        if len(prediction[0]["boxes"]) == 0:
+            return None
+    
+        df = visualize.format_boxes(prediction[0])
+        df = predict.across_class_nms(df, iou_threshold=self.config["nms_thresh"])
+    
+        if return_plot:
+            # Bring to gpu
+            image = image.cpu()
+    
+            # Cv2 likes no batch dim, BGR image and channels last, 0-255
+            image = np.array(image.squeeze(0))
+            image = np.rollaxis(image, 0, 3)
+            image = image[:, :, ::-1] * 255
+            image = image.astype("uint8")
+            image = visualize.plot_predictions(image, df, color=color, thickness=thickness)
+    
+            return image
+        else:
+            if path:
+                df["image_path"] = os.path.basename(path)
+            
+            df["label"] = df.label.apply(lambda x: self.numeric_to_label_dict[x])            
 
-        # Check if GPU is available and pass image to gpu
-        result = predict.predict_image(model=self.model,
-                                       image=image,
-                                       return_plot=return_plot,
-                                       device=self.current_device,
-                                       iou_threshold=self.config["nms_thresh"],
-                                       color=color,
-                                       thickness=thickness)
-
-        # Set labels to character from numeric if returning boxes df
-        if not return_plot:
-            if not result is None:
-                if path:
-                    result["image_path"] = os.path.basename(path)
-
-                result["label"] = result.label.apply(
-                    lambda x: self.numeric_to_label_dict[x])
-
-        return result
+        return df
 
     def predict_file(self, csv_file, root_dir, savedir=None, color=None, thickness=1):
         """Create a dataset and predict entire annotation file
@@ -307,20 +331,51 @@ class deepforest(pl.LightningModule):
         """
         self.model.eval()
         self.model.score_thresh = self.config["score_thresh"]
+        df = pd.read_csv(csv_file)
+        paths = df.image_path.unique()        
+        ds = dataset.TreeDataset(csv_file=csv_file,
+                                 root_dir=root_dir,
+                                 transforms=None,
+                                 train=False)
+        
+        batched_results = []
+        for i, batch in enumerate(self.predict_dataloader(ds)):
+            batch = self.transfer_batch_to_device(batch, self.device, dataloader_idx=0)
+            out = self.predict_step(batch, i)
+            batched_results.append(out)
+                    
+        #Flatten list from batched prediction
+        prediction_list = []
+        for batch in batched_results:
+            for boxes in batch:
+                prediction_list.append(boxes)
+    
+        results = []
+        for index, prediction in enumerate(prediction_list):
+            # If there is more than one class, apply NMS Loop through images and apply cross
+            if len(prediction.label.unique()) > 1:
+                prediction = predict.across_class_nms(prediction, iou_threshold=self.config["nms_thresh"])
+    
+            if savedir:
+                # Just predict the images, even though we have the annotations
+                image = np.array(Image.open("{}/{}".format(root_dir, paths[index])))[:, :, ::-1]
+                image = visualize.plot_predictions(image, prediction)
+    
+                # Plot annotations if they exist
+                annotations = df[df.image_path == paths[index]]
+    
+                image = visualize.plot_predictions(image,
+                                                   annotations,
+                                                   color=color,
+                                                   thickness=thickness)
+                cv2.imwrite("{}/{}.png".format(savedir, os.path.splitext(paths[index])[0]), image)
+    
+            prediction["image_path"] = paths[index]
+            results.append(prediction)
+    
+        results = pd.concat(results, ignore_index=True)
 
-        result = predict.predict_file(model=self.model,
-                                      csv_file=csv_file,
-                                      root_dir=root_dir,
-                                      savedir=savedir,
-                                      device=self.current_device,
-                                      iou_threshold=self.config["nms_thresh"],
-                                      color=color,
-                                      thickness=thickness)
-
-        # Set labels to character from numeric
-        result["label"] = result.label.apply(lambda x: self.numeric_to_label_dict[x])
-
-        return result
+        return results
 
     def predict_tile(self,
                      raster_path=None,
@@ -360,46 +415,57 @@ class deepforest(pl.LightningModule):
             boxes (array): if return_plot, an image.
             Otherwise a numpy array of predicted bounding boxes, scores and labels
         """
-
         self.model.eval()
         self.model.score_thresh = self.config["score_thresh"]
         self.model.nms_thresh = self.config["nms_thresh"]
-
-        result = predict.predict_tile(model=self.model,
-                                      raster_path=raster_path,
-                                      image=image,
-                                      patch_size=patch_size,
-                                      patch_overlap=patch_overlap,
-                                      iou_threshold=iou_threshold,
-                                      return_plot=return_plot,
-                                      mosaic=mosaic,
-                                      use_soft_nms=use_soft_nms,
-                                      sigma=sigma,
-                                      thresh=thresh,
-                                      device=self.current_device,
-                                      color=color,
-                                      thickness=thickness)
-
-        # edge case, if no boxes predictioned return None
-        if result is None:
-            print("No predictions made, returning None")
-            return None
-
-        # Set labels to character from numeric if returning boxes df
-        if not return_plot:
-            if mosaic:
-                result["label"] = result.label.apply(
-                    lambda x: self.numeric_to_label_dict[x])
-
+        
+        if (raster_path is None) and (image is None):
+            raise ValueError("Both tile and tile_path are None. Either supply a path to a tile on disk, or read one into memory!")
+        
+        if raster_path is None:
+            self.image = image
+        else:
+            self.image = rio.open(raster_path).read()
+            self.image = np.moveaxis(self.image, 0, 2)       
+                    
+        ds = dataset.TileDataset(tile=self.image, patch_overlap=patch_overlap, patch_size=patch_size)
+        batched_results = self.trainer.predict(self, self.predict_dataloader(ds))
+        
+        #Flatten list from batched prediction
+        results = []
+        for batch in batched_results:
+            for boxes in batch:
+                results.append(boxes)
+        
+        if mosaic:
+            results = predict.mosiac(results, ds.windows, use_soft_nms=use_soft_nms, sigma=sigma, thresh=thresh, iou_threshold=iou_threshold)
+            results["label"] = results.label.apply(
+                lambda x: self.numeric_to_label_dict[x])
+            if raster_path:
+                results["image_path"] = os.path.basename(raster_path)   
+            if return_plot:
+                # Draw predictions on BGR
                 if raster_path:
-                    result["image_path"] = os.path.basename(raster_path)
-            else:
-                for df, image in result:
-                    df["label"] = df.label.apply(lambda x: self.numeric_to_label_dict[x])
-
-                return result
-
-        return result
+                    tile = rio.open(raster_path).read()
+                drawn_plot = tile[:, :, ::-1]
+                drawn_plot = visualize.plot_predictions(tile,
+                                                   results,
+                                                   color=color,
+                                                   thickness=thickness)        
+                return drawn_plot
+        else:
+            for df in results:
+                df["label"] = df.label.apply(lambda x: self.numeric_to_label_dict[x])
+            
+            # TODO this is the 2nd time the crops are generated? Could be more efficient.
+            self.crops = []
+            for window in ds.windows:
+                crop = self.image[window.indices()]  
+                self.crops.append(crop)
+            
+            return list(zip(results, self.crops))
+                        
+        return results      
 
     def training_step(self, batch, batch_idx):
         """Train on a loaded dataset
@@ -426,7 +492,8 @@ class deepforest(pl.LightningModule):
         except:
             print("Empty batch encountered, skipping")
             return None
-
+        
+        #Get loss from "train" mode, but don't allow optimization
         self.model.train()
         with torch.no_grad():
             loss_dict = self.model.forward(images, targets)
@@ -440,24 +507,15 @@ class deepforest(pl.LightningModule):
 
         return losses
 
-    def on_train_epoch_end(self):
-        if not self.config["validation"]["csv_file"] == None:
-            if (self.current_epoch +
-                    1) % self.config["validation"]["val_accuracy_interval"] == 0:
-                results = self.evaluate(csv_file=self.config["validation"]["csv_file"],
-                                        root_dir=self.config["validation"]["root_dir"])
-                self.log("box_recall", results["box_recall"])
-                self.log("box_precision", results["box_precision"])
-
-                if not type(results["class_recall"]) == type(None):
-                    for index, row in results["class_recall"].iterrows():
-                        self.log(
-                            "{}_Recall".format(self.numeric_to_label_dict[row["label"]]),
-                            row["recall"])
-                        self.log(
-                            "{}_Precision".format(
-                                self.numeric_to_label_dict[row["label"]]),
-                            row["precision"])
+    def predict_step(self, batch, batch_idx):
+        batch_results = self.model(batch)
+        
+        results = []
+        for result in batch_results:
+            boxes = visualize.format_boxes(result)
+            results.append(boxes)
+                
+        return results
 
     def configure_optimizers(self):
         optimizer = optim.SGD(self.model.parameters(),
@@ -498,12 +556,10 @@ class deepforest(pl.LightningModule):
         self.model.eval()
         self.model.score_thresh = self.config["score_thresh"]
 
-        predictions = predict.predict_file(model=self.model,
-                                           csv_file=csv_file,
-                                           root_dir=root_dir,
-                                           savedir=savedir,
-                                           device=self.current_device,
-                                           iou_threshold=self.config["nms_thresh"])
+        predictions = self.predict_file(
+            csv_file=csv_file,
+            root_dir=root_dir,
+            savedir=savedir)
 
         ground_df = pd.read_csv(csv_file)
         ground_df["label"] = ground_df.label.apply(lambda x: self.label_dict[x])

--- a/deepforest/predict.py
+++ b/deepforest/predict.py
@@ -1,20 +1,14 @@
 # Prediction utilities
 import cv2
 import pandas as pd
-from PIL import Image
 import numpy as np
-import os
-from tqdm import tqdm
 import warnings
 
 import torch
-import rasterio as rio
 from torchvision.ops import nms
 
 from deepforest import preprocess
 from deepforest import visualize
-from deepforest import dataset
-
 
 def predict_image(model,
                   image,
@@ -43,10 +37,10 @@ def predict_image(model,
                       f"opposed to 0-1.To suppress this warning, transform image "
                       f"(image.astype('float32')")
         image = image.astype("float32")
-    image = preprocess.preprocess_image(image, device=device)
+    image = preprocess.preprocess_image(image)
 
     with torch.no_grad():
-        prediction = model(image)
+        prediction = model(image.unsqueeze(0))
 
     # return None for no predictions
     if len(prediction[0]["boxes"]) == 0:
@@ -58,8 +52,7 @@ def predict_image(model,
 
     if return_plot:
         # Bring to gpu
-        if not device.type == "cpu":
-            image = image.cpu()
+        image = image.cpu()
 
         # Cv2 likes no batch dim, BGR image and channels last, 0-255
         image = np.array(image.squeeze(0))
@@ -73,212 +66,58 @@ def predict_image(model,
         return df
 
 
-def predict_file(model,
-                 csv_file,
-                 root_dir,
-                 savedir,
-                 device,
-                 iou_threshold=0.1,
-                 color=(0, 165, 255),
-                 thickness=1):
-    """Create a dataset and predict entire annotation file
+def mosiac(boxes, windows, use_soft_nms=False, sigma=0.5, thresh=0.001, iou_threshold=0.1):
+    # transform the coordinates to original system
+    
+    for index, window_boxes in enumerate(boxes):
+        xmin, ymin, xmax, ymax = windows[index].getRect()
+        window_boxes.xmin = window_boxes.xmin + xmin
+        window_boxes.xmax = window_boxes.xmax + xmin
+        window_boxes.ymin = window_boxes.ymin + ymin
+        window_boxes.ymax = window_boxes.ymax + ymin
+    
+    predicted_boxes = pd.concat(boxes)
+    print(
+        f"{predicted_boxes.shape[0]} predictions in overlapping windows, applying non-max supression"
+    )
+    # move prediciton to tensor
+    boxes = torch.tensor(predicted_boxes[["xmin", "ymin", "xmax", "ymax"]].values,
+                         dtype=torch.float32)
+    scores = torch.tensor(predicted_boxes.score.values, dtype=torch.float32)
+    labels = predicted_boxes.label.values
 
-    Csv file format is .csv file with the columns "image_path", "xmin","ymin","xmax","ymax" for the image name and bounding box position.
-    Image_path is the relative filename, not absolute path, which is in the root_dir directory. One bounding box per line.
-    If "label" column is present, these are assumed to be annotations and will be plotted in a different color than predictions
-
-    Args:
-        csv_file: path to csv file
-        root_dir: directory of images. If none, uses "image_dir" in config
-        savedir: Optional. Directory to save image plots.
-        device: pytorch device of 'cuda' or 'cpu' for gpu prediction. Set internally.
-        color: color of the bounding box as a tuple of BGR color, e.g. orange annotations is (0, 165, 255)
-        thickness: thickness of the rectangle border line in px
-    Returns:
-        df: pandas dataframe with bounding boxes, label and scores for each image in the csv file
-    """
-
-    model.eval()
-    df = pd.read_csv(csv_file)
-    # Dataloader (when not shuffled) returns a tensor for each image in order
-    paths = df.image_path.unique()
-    ds = dataset.TreeDataset(csv_file=csv_file,
-                             root_dir=root_dir,
-                             transforms=None,
-                             train=False)
-    prediction_list = []
-    with torch.no_grad():
-        for i in ds:
-            i = i.to(device)
-            prediction = model(torch.unsqueeze(i, 0))
-            prediction_list.append(prediction)
-
-    prediction_list = [item for sublist in prediction_list for item in sublist]
-
-    results = []
-    for index, prediction in enumerate(prediction_list):
-        # If there is more than one class, apply NMS Loop through images and apply cross
-        prediction = visualize.format_boxes(prediction)
-        if len(prediction.label.unique()) > 1:
-            prediction = across_class_nms(prediction, iou_threshold=iou_threshold)
-
-        if savedir:
-            # Just predict the images, even though we have the annotations
-            image = np.array(Image.open("{}/{}".format(root_dir,
-                                                       paths[index])))[:, :, ::-1]
-            image = visualize.plot_predictions(image, prediction)
-
-            # Plot annotations if they exist
-            annotations = df[df.image_path == paths[index]]
-
-            image = visualize.plot_predictions(image,
-                                               annotations,
-                                               color=color,
-                                               thickness=thickness)
-            cv2.imwrite("{}/{}.png".format(savedir,
-                                           os.path.splitext(paths[index])[0]), image)
-
-        prediction["image_path"] = paths[index]
-        results.append(prediction)
-
-    results = pd.concat(results, ignore_index=True)
-
-    return results
-
-
-def predict_tile(model,
-                 device,
-                 raster_path=None,
-                 image=None,
-                 patch_size=400,
-                 patch_overlap=0.05,
-                 iou_threshold=0.15,
-                 return_plot=False,
-                 mosaic=True,
-                 use_soft_nms=False,
-                 sigma=0.5,
-                 thresh=0.001,
-                 color=None,
-                 thickness=1):
-    """For images too large to input into the model, predict_tile cuts the
-    image into overlapping windows, predicts trees on each window and
-    reassambles into a single array.
-
-    Args:
-        model: pytorch model
-        device: pytorch device of 'cuda' or 'cpu' for gpu prediction. Set internally.
-        numeric_to_label_dict: dictionary in which keys are numeric integers and values are character labels
-        raster_path: Path to image on disk
-        image (array): Numpy image array in RGB channel order ranged from 0-255
-        patch_size: patch size default400,
-        patch_overlap: patch overlap default 0.15,
-        iou_threshold: Minimum iou overlap among predictions between
-            windows to be suppressed. Defaults to 0.14.
-            Lower values suppress more boxes at edges.
-        return_plot: Should the image be returned with the predictions drawn?
-        mosaic: If true, return a single annotations dataframe. If false, return a list of windows and predictions
-        use_soft_nms: whether to perform Gaussian Soft NMS or not, if false, default perform NMS.
-        sigma: variance of Gaussian function used in Gaussian Soft NMS
-        thresh: the score thresh used to filter bboxes after soft-nms performed
-
-    Returns:
-        boxes (array): if return_plot, an image.
-        windows (list): if mosaic = False, a two item tuple for each window of patch_size with predictions
-        Otherwise a numpy array of predicted bounding boxes, scores and labels
-    """
-
-    if image is not None:
-        pass
+    if not use_soft_nms:
+        # Performs non-maximum suppression (NMS) on the boxes according to
+        # their intersection-over-union (IoU).
+        bbox_left_idx = nms(boxes=boxes,
+                            scores=scores,
+                            iou_threshold=iou_threshold)
     else:
-        # load raster as image
-        image = rio.open(raster_path).read()
-        image = np.moveaxis(image, 0, 2)
+        # Performs soft non-maximum suppression (soft-NMS) on the boxes.
+        bbox_left_idx = soft_nms(boxes=boxes,
+                                 scores=scores,
+                                 sigma=sigma,
+                                 thresh=thresh)
 
-    # Compute sliding window index
-    windows = preprocess.compute_windows(image, patch_size, patch_overlap)
-    predicted_boxes = []
-    crops = []
+    bbox_left_idx = bbox_left_idx.numpy()
+    new_boxes, new_labels, new_scores = boxes[bbox_left_idx].type(
+        torch.int), labels[bbox_left_idx], scores[bbox_left_idx]
 
-    for index, window in enumerate(tqdm(windows)):
-        # crop window and predict
-        crop = image[windows[index].indices()]
-        crop = crop.astype('float32')
-        boxes = predict_image(model=model, image=crop, return_plot=False, device=device)
-        if boxes is not None:
-            if mosaic:
-                # transform the coordinates to original system
-                xmin, ymin, xmax, ymax = windows[index].getRect()
-                boxes.xmin = boxes.xmin + xmin
-                boxes.xmax = boxes.xmax + xmin
-                boxes.ymin = boxes.ymin + ymin
-                boxes.ymax = boxes.ymax + ymin
-            else:
-                crops.append(crop)
-            predicted_boxes.append(boxes)
+    # Recreate box dataframe
+    image_detections = np.concatenate([
+        new_boxes,
+        np.expand_dims(new_labels, axis=1),
+        np.expand_dims(new_scores, axis=1)
+    ],
+                                      axis=1)
 
-    if len(predicted_boxes) == 0:
-        print("No predictions made, returning None")
-        return None
-    if mosaic:
-        predicted_boxes = pd.concat(predicted_boxes)
-        # Non-max supression for overlapping boxes among window
-        if patch_overlap == 0:
-            mosaic_df = predicted_boxes
-        else:
-            print(
-                f"{predicted_boxes.shape[0]} predictions in overlapping windows, applying non-max supression"
-            )
-            # move prediciton to tensor
-            boxes = torch.tensor(predicted_boxes[["xmin", "ymin", "xmax", "ymax"]].values,
-                                 dtype=torch.float32)
-            scores = torch.tensor(predicted_boxes.score.values, dtype=torch.float32)
-            labels = predicted_boxes.label.values
+    mosaic_df = pd.DataFrame(
+        image_detections,
+        columns=["xmin", "ymin", "xmax", "ymax", "label", "score"])
 
-            if not use_soft_nms:
-                # Performs non-maximum suppression (NMS) on the boxes according to
-                # their intersection-over-union (IoU).
-                bbox_left_idx = nms(boxes=boxes,
-                                    scores=scores,
-                                    iou_threshold=iou_threshold)
-            else:
-                # Performs soft non-maximum suppression (soft-NMS) on the boxes.
-                bbox_left_idx = soft_nms(boxes=boxes,
-                                         scores=scores,
-                                         sigma=sigma,
-                                         thresh=thresh)
+    print(f"{mosaic_df.shape[0]} predictions kept after non-max suppression")
 
-            bbox_left_idx = bbox_left_idx.numpy()
-            new_boxes, new_labels, new_scores = boxes[bbox_left_idx].type(
-                torch.int), labels[bbox_left_idx], scores[bbox_left_idx]
-
-            # Recreate box dataframe
-            image_detections = np.concatenate([
-                new_boxes,
-                np.expand_dims(new_labels, axis=1),
-                np.expand_dims(new_scores, axis=1)
-            ],
-                                              axis=1)
-
-            mosaic_df = pd.DataFrame(
-                image_detections,
-                columns=["xmin", "ymin", "xmax", "ymax", "label", "score"])
-
-            print(f"{mosaic_df.shape[0]} predictions kept after non-max suppression")
-
-        if return_plot:
-            # Draw predictions on BGR
-            image = image[:, :, ::-1]
-            image = visualize.plot_predictions(image,
-                                               mosaic_df,
-                                               color=color,
-                                               thickness=thickness)
-            # Mantain consistancy with predict_image
-            return image
-        else:
-            return mosaic_df
-    else:
-        return list(zip(predicted_boxes, crops))
-
+    return mosaic_df
 
 def soft_nms(boxes, scores, sigma=0.5, thresh=0.001):
     """

--- a/deepforest/predict.py
+++ b/deepforest/predict.py
@@ -68,13 +68,12 @@ def predict_image(model,
 
 def mosiac(boxes, windows, use_soft_nms=False, sigma=0.5, thresh=0.001, iou_threshold=0.1):
     # transform the coordinates to original system
-    
-    for index, window_boxes in enumerate(boxes):
+    for index, _ in enumerate(boxes):
         xmin, ymin, xmax, ymax = windows[index].getRect()
-        window_boxes.xmin = window_boxes.xmin + xmin
-        window_boxes.xmax = window_boxes.xmax + xmin
-        window_boxes.ymin = window_boxes.ymin + ymin
-        window_boxes.ymax = window_boxes.ymax + ymin
+        boxes[index].xmin += xmin
+        boxes[index].xmax +=  xmin
+        boxes[index].ymin +=  ymin
+        boxes[index].ymax +=  ymin
     
     predicted_boxes = pd.concat(boxes)
     print(

--- a/deepforest/predict.py
+++ b/deepforest/predict.py
@@ -86,18 +86,18 @@ def mosiac(boxes, windows, use_soft_nms=False, sigma=0.5, thresh=0.001, iou_thre
     scores = torch.tensor(predicted_boxes.score.values, dtype=torch.float32)
     labels = predicted_boxes.label.values
 
-    if not use_soft_nms:
-        # Performs non-maximum suppression (NMS) on the boxes according to
-        # their intersection-over-union (IoU).
-        bbox_left_idx = nms(boxes=boxes,
-                            scores=scores,
-                            iou_threshold=iou_threshold)
-    else:
+    if use_soft_nms:
         # Performs soft non-maximum suppression (soft-NMS) on the boxes.
         bbox_left_idx = soft_nms(boxes=boxes,
                                  scores=scores,
                                  sigma=sigma,
                                  thresh=thresh)
+    else:
+        # Performs non-maximum suppression (NMS) on the boxes according to
+        # their intersection-over-union (IoU).
+        bbox_left_idx = nms(boxes=boxes,
+                            scores=scores,
+                            iou_threshold=iou_threshold)
 
     bbox_left_idx = bbox_left_idx.numpy()
     new_boxes, new_labels, new_scores = boxes[bbox_left_idx].type(

--- a/deepforest/preprocess.py
+++ b/deepforest/preprocess.py
@@ -15,9 +15,9 @@ import warnings
 import rasterio
 
 
-def preprocess_image(image, device):
+def preprocess_image(image):
     """Preprocess a single RGB numpy array as a prediction from channels last, to channels first"""
-    image = torch.tensor(image, device=device).permute(2, 0, 1).unsqueeze(0)
+    image = torch.tensor(image).permute(2, 0, 1)
     image = image / 255
 
     return image

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -11,6 +11,7 @@ pytorch_lightning
 torch
 pyyaml>=5.1.0
 pytest
+pytest-profiling
 matplotlib
 numpy
 recommonmark

--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,7 @@ dependencies:
   - recommonmark
   - pyyaml>=5.1.0
   - pytest
+  - pytest-profiling
   - numpydoc
   - geopandas
   - h5py

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -16,7 +16,9 @@ def m(download_release):
     m.config["train"]["root_dir"] = os.path.dirname(get_data("example.csv"))
     m.config["train"]["fast_dev_run"] = True
     m.config["batch_size"] = 2
-
+    m.config["validation"]["csv_file"] = get_data("example.csv") 
+    m.config["validation"]["root_dir"] = os.path.dirname(get_data("example.csv"))
+    
     m.use_release(check_release=False)
     
     return m

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -14,19 +14,16 @@ def m(download_release):
     m = main.deepforest()
     m.config["train"]["csv_file"] = get_data("example.csv") 
     m.config["train"]["root_dir"] = os.path.dirname(get_data("example.csv"))
-    m.config["train"]["fast_dev_run"] = False
+    m.config["train"]["fast_dev_run"] = True
     m.config["batch_size"] = 2
-       
-    m.config["validation"]["csv_file"] = get_data("example.csv") 
-    m.config["validation"]["root_dir"] = os.path.dirname(get_data("example.csv"))
-    
+
     m.use_release(check_release=False)
     
     return m
 
 def test_log_images(m, tmpdir):
     im_callback = callbacks.images_callback(csv_file=m.config["validation"]["csv_file"], root_dir=m.config["validation"]["root_dir"], savedir=tmpdir)
-    m.create_trainer(callbacks=[im_callback], limit_predict_batches=1)
+    m.create_trainer(callbacks=[im_callback])
     m.trainer.fit(m)
 
     saved_images = glob.glob("{}/*.png".format(tmpdir))
@@ -37,7 +34,6 @@ def test_log_images_multiclass(m, tmpdir):
     m = main.deepforest(num_classes=2, label_dict={"Alive":0,"Dead":1})
     m.config["train"]["csv_file"] = get_data("testfile_multi.csv") 
     m.config["train"]["root_dir"] = os.path.dirname(get_data("testfile_multi.csv"))
-    m.config["train"]["fast_dev_run"] = False
     m.config["batch_size"] = 2
        
     m.config["validation"]["csv_file"] = get_data("testfile_multi.csv") 

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -26,9 +26,9 @@ def m(download_release):
 
 def test_log_images(m, tmpdir):
     im_callback = callbacks.images_callback(csv_file=m.config["validation"]["csv_file"], root_dir=m.config["validation"]["root_dir"], savedir=tmpdir)
-    m.create_trainer(callbacks=[im_callback])
-    m.max_steps = 2
+    m.create_trainer(callbacks=[im_callback], limit_predict_batches=1)
     m.trainer.fit(m)
+
     saved_images = glob.glob("{}/*.png".format(tmpdir))
     assert len(saved_images) == 1
     
@@ -70,3 +70,7 @@ def test_create_no_checkpoint(m, tmpdir):
     
     assert True
     
+def test_iou_callback(m):
+    m.config["train"]["fast_dev_run"] = False
+    m.create_trainer(limit_train_batches=1)
+    m.trainer.fit(m)      

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -8,6 +8,7 @@ import torch
 import pandas as pd
 import numpy as np
 import tempfile
+import rasterio as rio
 
 def single_class():
     csv_file = get_data("example.csv")
@@ -115,7 +116,7 @@ def test_empty_collate():
         collated_batch = utilities.collate_fn([None, batch, batch])
         len(collated_batch[0]) == 2
 
-def test_predict_dataloader():
+def test_dataloader():
     csv_file = get_data("example.csv")
     root_dir = os.path.dirname(csv_file)
     ds = dataset.TreeDataset(csv_file=csv_file,
@@ -145,4 +146,16 @@ def test_multi_image_warning():
         batch = ds[i]
         collated_batch = utilities.collate_fn([None, batch, batch])
         len(collated_batch[0]) == 2
+        
+@pytest.mark.parametrize("preload_images",[True, False])
+def test_TileDataset(preload_images):
+    tile_path = get_data("2019_YELL_2_528000_4978000_image_crop2.png")
+    tile = rio.open(tile_path).read()
+    tile = np.moveaxis(tile, 0, 2)           
+    ds = dataset.TileDataset(tile=tile, preload_images=preload_images, patch_size=100, patch_overlap=0)
+    assert len(ds) > 0
+    
+    #assert crop shape
+    assert ds[1].shape == (3, 100, 100)
+    
         

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -193,6 +193,7 @@ def test_predict_tile(m, raster_path):
     
 def test_predict_tile_softnms(m, raster_path):
     #test soft-nms method
+    m.create_trainer()
     soft_nms_pred = m.predict_tile(raster_path = raster_path,
                                             patch_size = 300,
                                             patch_overlap = 0.1,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -57,6 +57,10 @@ def m(download_release):
     
     return m
 
+@pytest.fixture()
+def raster_path():
+    return get_data(path='OSBS_029.tif')    
+    
 def big_file():
     tmpdir = tempfile.gettempdir()
     csv_file = get_data("OSBS_029.csv")
@@ -104,6 +108,7 @@ def test_validation_step(m):
         assert p1[1].ne(p2[1]).sum() == 0
 
 def test_train_single(m):
+    m.config["train"]["fast_dev_run"] = False
     m.create_trainer()
     m.trainer.fit(m)
 
@@ -155,6 +160,8 @@ def test_predict_return_plot(m):
     assert isinstance(plot, np.ndarray)
 
 def test_predict_big_file(m, tmpdir):
+    m.config["train"]["fast_dev_run"] = False
+    m.create_trainer()    
     csv_file = big_file()
     original_file = pd.read_csv(csv_file)
     df = m.predict_file(csv_file=csv_file, root_dir = os.path.dirname(csv_file), savedir=tmpdir)
@@ -172,46 +179,45 @@ def test_predict_small_file(m, tmpdir):
     printed_plots = glob.glob("{}/*.png".format(tmpdir))
     assert len(printed_plots) == len(original_file.image_path.unique())
     
-def test_predict_tile(m):
-    #test raster prediction 
-    raster_path = get_data(path= 'OSBS_029.tif')
+def test_predict_tile(m, raster_path):
+    m.config["train"]["fast_dev_run"] = False
+    m.create_trainer()
     prediction = m.predict_tile(raster_path = raster_path,
                                             patch_size = 300,
-                                            patch_overlap = 0.5,
+                                            patch_overlap = 0.1,
                                             return_plot = False)
+    
     assert isinstance(prediction, pd.DataFrame)
     assert set(prediction.columns) == {"xmin","ymin","xmax","ymax","label","score","image_path"}
     assert not prediction.empty
-
+    
+def test_predict_tile_softnms(m, raster_path):
     #test soft-nms method
     soft_nms_pred = m.predict_tile(raster_path = raster_path,
                                             patch_size = 300,
-                                            patch_overlap = 0.5,
+                                            patch_overlap = 0.1,
                                             return_plot = False,
-                                            use_soft_nms =True)
+                                            use_soft_nms = True)
     assert isinstance(soft_nms_pred, pd.DataFrame)
     assert set(soft_nms_pred.columns) == {"xmin","ymin","xmax","ymax","label","score","image_path"}
     assert not soft_nms_pred.empty
 
+@pytest.mark.parametrize("patch_overlap",[0.1, 0])
+def test_predict_tile_from_array(m, patch_overlap, raster_path):
     #test predict numpy image
     image = np.array(Image.open(raster_path))
+    m.config["train"]["fast_dev_run"] = False
+    m.create_trainer()      
     prediction = m.predict_tile(image = image,
                                 patch_size = 300,
-                                patch_overlap = 0.5,
+                                patch_overlap = patch_overlap,
                                 return_plot = False)
     assert not prediction.empty
 
-    # Test no non-max suppression
-    prediction = m.predict_tile(raster_path = raster_path,
-                                       patch_size=300,
-                                       patch_overlap=0,
-                                       return_plot=False)
-    assert not prediction.empty
-    
-
-def test_predict_tile_no_mosaic(m):
+def test_predict_tile_no_mosaic(m, raster_path):
     #test no mosaic, return a tuple of crop and prediction
-    raster_path = get_data(path='OSBS_029.tif')    
+    m.config["train"]["fast_dev_run"] = False
+    m.create_trainer()      
     prediction = m.predict_tile(raster_path = raster_path,
                                        patch_size=300,
                                        patch_overlap=0,

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -80,7 +80,6 @@ def test_split_raster(config, tmpdir):
     annotations = utilities.xml_to_annotations(get_data("2019_YELL_2_528000_4978000_image_crop2.xml"))
     annotations.to_csv("{}/example.csv".format(tmpdir), index=False)
     #annotations.label = 0
-    #visualize.plot_prediction_dataframe(df=annotations, root_dir=os.path.dirname(get_data(".")), show=True)
     
     annotations_file = preprocess.split_raster(path_to_raster=raster,
                                                annotations_file="{}/example.csv".format(tmpdir),

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -93,6 +93,7 @@ def test_boxes_to_shapefile_projected_from_predict_tile(download_release):
     img = get_data("OSBS_029.tif")
     r = rio.open(img)
     m = main.deepforest()
+    m.create_trainer()
     m.use_release(check_release=False)
     df = m.predict_tile(raster_path=img)
     gdf = utilities.boxes_to_shapefile(df, root_dir=os.path.dirname(img), projected=True)


### PR DESCRIPTION
In response to #407, the goal of this PR is to remove any .to(CUDA) statements and let pytorch lightning manage devices. I sense that this will require updating the dataloaders for predict_image and predict_tile. I am testing locally on CPU and on HPC GPU.