### PR TITLE
Increase min version for torchvision

### DIFF
--- a/.github/workflows/Conda-app.yml
+++ b/.github/workflows/Conda-app.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - 3.9
+          - "3.10"
         os:
           - "ubuntu-latest"
 

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -25,7 +25,7 @@ sphinx_rtd_theme
 sphinx_markdown_tables
 tqdm
 twine
-torchvision >= 0.9.0
+torchvision>=0.13
 xmltodict
 comet_ml
 imagecodecs

--- a/environment.yml
+++ b/environment.yml
@@ -27,7 +27,7 @@ dependencies:
   - rasterio
   - psutil
   - pytorch
-  - torchvision>=0.9.0
+  - torchvision>=0.13
   - slidingwindow
   - bumpversion
   - pip:

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(name=NAME,
       include_package_data=True,
       install_requires=[
           "torch",
-          "torchvision>0.9.0",
+          "torchvision>=0.13",
           "matplotlib",
           "Pillow>6.2.0",
           "pandas",


### PR DESCRIPTION
Bump the min torchvision version to match the changes made to address pytorch warnings in cb05b95.