### PR TITLE
Move ignoring setup.py in testing to conftest.py

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,3 @@ exclude = docs
 
 [aliases]
 test = pytest
-
-[tool:pytest]
-collect_ignore = ['setup.py']
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,9 +5,10 @@ from deepforest import utilities
 from deepforest import get_data
 import os
 
+collect_ignore = ['setup.py']
+
 @pytest.fixture(scope="session")
 def download_release():
     print("running fixtures")
     utilities.use_release()
     assert os.path.exists(get_data("NEON.pt"))
-    


### PR DESCRIPTION
The config setting in setup.py was being ignored with the warning: `PytestConfigWarning: Unknown config option: collect_ignore`

This moves it to conftest.py, which is the location recommended in the docs: https://docs.pytest.org/en/4.6.x/reference.html#collect-ignore