### PR TITLE
Ignore warnings generated due to light weight testing

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+filterwarnings =
+    ignore:The number of training batches \(1\) is smaller than the logging interval
+    ignore:The dataloader, train_dataloader, does not have many workers which may be a bottleneck
+    ignore:The dataloader, val_dataloader, does not have many workers which may be a bottleneck
+    ignore:The dataloader, predict_dataloader, does not have many workers which may be a bottleneck


### PR DESCRIPTION
We use small numbers of batches and workers for testing. This triggers some warnings related to optimal production performance. This change keeps them out of the test logs.