### PR TITLE
Create deep copy when selecting annotations in preprocess

### DIFF
--- a/deepforest/preprocess.py
+++ b/deepforest/preprocess.py
@@ -83,8 +83,8 @@ def select_annotations(annotations, windows, index, allow_empty=False):
                                        (annotations.xmax < (window_xmax + offset)) &
                                        (annotations.ymin < (window_ymax)) &
                                        (annotations.ymax > (window_ymin)) &
-                                       (annotations.ymax < (window_ymax + offset))]
-
+                                       (annotations.ymax < (window_ymax + offset))].copy(
+                                           deep=True)
     # change the image name
     image_basename = os.path.splitext("{}".format(annotations.image_path.unique()[0]))[0]
     selected_annotations.image_path = "{}_{}.png".format(image_basename, index)

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -51,7 +51,7 @@ def test_evaluate_multi(m):
     #Manipulate the data to create some false positives
     predictions = ground_truth.copy()
     predictions["score"] = 1
-    predictions.label.loc[[36,35,34]] = 0
+    predictions.iloc[[36, 35, 34], predictions.columns.get_indexer(['label'])]
     results = evaluate.evaluate(predictions=predictions, ground_df=ground_truth, root_dir=os.path.dirname(csv_file))     
         
     assert results["results"].shape[0] == ground_truth.shape[0]
@@ -66,7 +66,7 @@ def test_evaluate_save_images(m, tmpdir):
     #Manipulate the data to create some false positives
     predictions = ground_truth.copy()
     predictions["score"] = 1
-    predictions.label.loc[[36,35,34]] = 0
+    predictions.iloc[[36, 35, 34], predictions.columns.get_indexer(['label'])]
     results = evaluate.evaluate(predictions=predictions, ground_df=ground_truth, root_dir=os.path.dirname(csv_file), savedir=tmpdir)     
     assert all([os.path.exists("{}/{}".format(tmpdir,x)) for x in ground_truth.image_path])
 


### PR DESCRIPTION
`preprocess::select_annotations()` is unclear about whether it is trying to
change `annotations` in place or create a new data frame. The return
docs indicate a data frame and given the kind of work that's happening it
appears that a new data frame is what we want. This makes changes makes
that explicit by making a deep copy after the sub setting.

This should be carefully reviewed by @bw4sz because if the intent of the original
code is to modify in place then this isn't the correct solution.

Also fixes another SettingWithCopy issue in the tests.

This depends on #434 since it touches the same lines, so #434 should be merged and then I can refresh this.