### PR TITLE
bug fix to close #441, only boxes which match should be included in class recall

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ current_release.csv
 *.pt
 tests/__pycache__
 *.wp*
+lightning_logs/*
+*.prof

--- a/deepforest/evaluate.py
+++ b/deepforest/evaluate.py
@@ -154,7 +154,9 @@ def evaluate(predictions, ground_df, root_dir, iou_threshold=0.4, savedir=None):
     box_precision = np.mean(box_precisions)
     box_recall = np.mean(box_recalls)
 
-    class_recall = compute_class_recall(results)
+    # Only matching boxes are considered in class recall
+    matched_results = results[results.match==True]
+    class_recall = compute_class_recall(matched_results)
 
     return {
         "results": results,

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -83,3 +83,23 @@ def test_evaluate_empty():
     
     df = pd.read_csv(csv_file)
     assert results["results"].shape[0] == df.shape[0]
+
+@pytest.fixture
+def sample_results():
+    # Create a sample DataFrame for testing
+    data = {
+        'true_label': [1, 1, 2],
+        'predicted_label': [1, 2, 1]
+    }
+    return pd.DataFrame(data)
+
+def test_compute_class_recall(sample_results):
+    # Test case with sample data
+    expected_recall = pd.DataFrame({
+        'label': [1, 2],
+        'recall': [0.5, 0],
+        'precision': [0.5, 0],
+        'size': [2, 1]
+    }).reset_index(drop=True)
+
+    assert evaluate.compute_class_recall(sample_results).equals(expected_recall)


### PR DESCRIPTION
@ethanwhite noticed this error, related to #441. The class recall needs to only considered boxes that match in the prediction dataframe.