### PR TITLE
Add tree crop image

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,10 +1,11 @@
 version: 2
 
 build:
-  image: latest
+  os: ubuntu-22.04
+  tools:
+    python: "3.7"
 
 python:
-  version: 3.7
   install:
     - requirements: dev_requirements.txt
 submodules:


### PR DESCRIPTION
"build.image" is deprecated. Use "build.os"
https://docs.readthedocs.io/en/stable/config-file/v2.html#build-os