### PR TITLE
Cleanup tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ current_bird_release.csv
 *.pl
 *.pt
 tests/__pycache__
+tests/data/*
 *.wp*
 lightning_logs/*
 *.prof

--- a/deepforest/preprocess.py
+++ b/deepforest/preprocess.py
@@ -78,15 +78,13 @@ def select_annotations(annotations, windows, index, allow_empty=False):
     offset = 40
     selected_annotations = annotations[(annotations.xmin > (window_xmin - offset)) &
                                        (annotations.xmin < (window_xmax)) &
-                                       (annotations.xmax >
-                                        (window_xmin)) & (annotations.ymin >
-                                                          (window_ymin - offset)) &
+                                       (annotations.xmax > (window_xmin)) &
+                                       (annotations.ymin > (window_ymin - offset)) &
                                        (annotations.xmax < (window_xmax + offset)) &
-                                       (annotations.ymin <
-                                        (window_ymax)) & (annotations.ymax >
-                                                          (window_ymin)) &
-                                       (annotations.ymax <
-                                        (window_ymax + offset))].copy(deep=True)
+                                       (annotations.ymin < (window_ymax)) &
+                                       (annotations.ymax > (window_ymin)) &
+                                       (annotations.ymax < (window_ymax + offset))].copy(
+                                           deep=True)
     # change the image name
     image_basename = os.path.splitext("{}".format(annotations.image_path.unique()[0]))[0]
     selected_annotations.image_path = "{}_{}.png".format(image_basename, index)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 #Fixtures model to only download model once
 # download latest release
 import pytest
-from deepforest import utilities
+from deepforest import utilities, main
 from deepforest import get_data
 import os
 
@@ -12,3 +12,38 @@ def download_release():
     print("running fixtures")
     utilities.use_release()
     assert os.path.exists(get_data("NEON.pt"))
+
+@pytest.fixture()
+def two_class_m():
+    m = main.deepforest(num_classes=2,label_dict={"Alive":0,"Dead":1})
+    m.config["train"]["csv_file"] = get_data("testfile_multi.csv") 
+    m.config["train"]["root_dir"] = os.path.dirname(get_data("testfile_multi.csv"))
+    m.config["train"]["fast_dev_run"] = True
+    m.config["batch_size"] = 2
+        
+    m.config["validation"]["csv_file"] = get_data("testfile_multi.csv") 
+    m.config["validation"]["root_dir"] = os.path.dirname(get_data("testfile_multi.csv"))
+    m.config["validation"]["val_accuracy_interval"] = 1
+
+    m.create_trainer()
+    
+    return m
+
+@pytest.fixture()
+def m(download_release):
+    m = main.deepforest()
+    m.config["train"]["csv_file"] = get_data("example.csv") 
+    m.config["train"]["root_dir"] = os.path.dirname(get_data("example.csv"))
+    m.config["train"]["fast_dev_run"] = True
+    m.config["batch_size"] = 2
+        
+    m.config["validation"]["csv_file"] = get_data("example.csv") 
+    m.config["validation"]["root_dir"] = os.path.dirname(get_data("example.csv"))
+    m.config["workers"] = 0 
+    m.config["validation"]["val_accuracy_interval"] = 1
+    m.config["train"]["epochs"] = 2
+    
+    m.create_trainer()
+    m.use_release(check_release=False)
+    
+    return m

--- a/tests/test_IoU.py
+++ b/tests/test_IoU.py
@@ -10,9 +10,7 @@ import shapely
 import geopandas as gpd
 import pandas as pd
 
-def test_compute_IoU(download_release, tmpdir):
-    m = main.deepforest()
-    m.use_release(check_release=False)
+def test_compute_IoU(m, download_release, tmpdir):
     csv_file = get_data("OSBS_029.csv")
     predictions = m.predict_file(csv_file=csv_file, root_dir=os.path.dirname(csv_file))
     ground_truth = pd.read_csv(csv_file)

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -14,7 +14,7 @@ def m(download_release):
     m = main.deepforest()
     m.config["train"]["csv_file"] = get_data("example.csv") 
     m.config["train"]["root_dir"] = os.path.dirname(get_data("example.csv"))
-    m.config["train"]["fast_dev_run"] = False
+    m.config["train"]["fast_dev_run"] = True
     m.config["batch_size"] = 2
     m.config["workers"] = 0
     m.config["validation"]["csv_file"] = get_data("example.csv") 

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -5,50 +5,24 @@ import glob
 import os
 import pytest
 from pytorch_lightning.callbacks import ModelCheckpoint
-
 from deepforest import get_data
-from .conftest import download_release
-
-@pytest.fixture()
-def m(download_release):
-    m = main.deepforest()
-    m.config["train"]["csv_file"] = get_data("example.csv") 
-    m.config["train"]["root_dir"] = os.path.dirname(get_data("example.csv"))
-    m.config["train"]["fast_dev_run"] = True
-    m.config["batch_size"] = 2
-    m.config["workers"] = 0
-    m.config["validation"]["csv_file"] = get_data("example.csv") 
-    m.config["validation"]["root_dir"] = os.path.dirname(get_data("example.csv"))
-    
-    m.use_release(check_release=False)
-    
-    return m
 
 def test_log_images(m, tmpdir):
     im_callback = callbacks.images_callback(csv_file=m.config["validation"]["csv_file"], root_dir=m.config["validation"]["root_dir"], savedir=tmpdir)
     m.create_trainer(callbacks=[im_callback])
     m.trainer.fit(m)
-
     saved_images = glob.glob("{}/*.png".format(tmpdir))
     assert len(saved_images) == 1
     
-
-def test_log_images_multiclass(m, tmpdir):
-    m = main.deepforest(num_classes=2, label_dict={"Alive":0,"Dead":1})
-    m.config["train"]["csv_file"] = get_data("testfile_multi.csv") 
-    m.config["train"]["root_dir"] = os.path.dirname(get_data("testfile_multi.csv"))
-    m.config["batch_size"] = 2
-       
-    m.config["validation"]["csv_file"] = get_data("testfile_multi.csv") 
-    m.config["validation"]["root_dir"] = os.path.dirname(get_data("testfile_multi.csv"))
-
-    im_callback = callbacks.images_callback(csv_file=m.config["validation"]["csv_file"], root_dir=m.config["validation"]["root_dir"], savedir=tmpdir)
-    m.create_trainer(callbacks=[im_callback])
-    m.max_steps = 1
-    m.trainer.fit(m)
+def test_log_images_multiclass(two_class_m, tmpdir):
+    im_callback = callbacks.images_callback(
+        csv_file=two_class_m.config["validation"]["csv_file"],
+        root_dir=two_class_m.config["validation"]["root_dir"],
+        savedir=tmpdir)
+    two_class_m.create_trainer(callbacks=[im_callback])
+    two_class_m.trainer.fit(two_class_m)
     saved_images = glob.glob("{}/*.png".format(tmpdir))
     assert len(saved_images) == 1
-
 
 def test_create_checkpoint(m, tmpdir):    
     checkpoint_callback = ModelCheckpoint(
@@ -61,15 +35,3 @@ def test_create_checkpoint(m, tmpdir):
     m.use_release()
     m.create_trainer(callbacks = [checkpoint_callback])
     m.trainer.fit(m)
-
-def test_create_no_checkpoint(m, tmpdir):    
-    m.use_release()
-    m.create_trainer()
-    m.trainer.fit(m)  
-    
-    assert True
-    
-def test_iou_callback(m):
-    m.config["train"]["fast_dev_run"] = False
-    m.create_trainer(limit_train_batches=1)
-    m.trainer.fit(m)      

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -14,8 +14,9 @@ def m(download_release):
     m = main.deepforest()
     m.config["train"]["csv_file"] = get_data("example.csv") 
     m.config["train"]["root_dir"] = os.path.dirname(get_data("example.csv"))
-    m.config["train"]["fast_dev_run"] = True
+    m.config["train"]["fast_dev_run"] = False
     m.config["batch_size"] = 2
+    m.config["workers"] = 0
     m.config["validation"]["csv_file"] = get_data("example.csv") 
     m.config["validation"]["root_dir"] = os.path.dirname(get_data("example.csv"))
     
@@ -43,7 +44,7 @@ def test_log_images_multiclass(m, tmpdir):
 
     im_callback = callbacks.images_callback(csv_file=m.config["validation"]["csv_file"], root_dir=m.config["validation"]["root_dir"], savedir=tmpdir)
     m.create_trainer(callbacks=[im_callback])
-    m.max_steps = 2
+    m.max_steps = 1
     m.trainer.fit(m)
     saved_images = glob.glob("{}/*.png".format(tmpdir))
     assert len(saved_images) == 1

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -20,7 +20,6 @@ def multi_class():
     
     return csv_file
 
-
 @pytest.mark.parametrize("csv_file,label_dict",[(single_class(), {"Tree":0}), (multi_class(),{"Alive":0,"Dead":1})])
 def test_TreeDataset(csv_file, label_dict):
     root_dir = os.path.dirname(get_data("OSBS_029.png"))
@@ -66,8 +65,6 @@ def test_single_class_with_empty(tmpdir):
     #Second image has no annotations
     assert torch.sum(ds[1][2]["boxes"]) == 0
     
-
-
 @pytest.mark.parametrize("augment",[True,False])
 def test_TreeDataset_transform(augment):
     csv_file = get_data("example.csv")

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -9,13 +9,6 @@ import pytest
 import pandas as pd
 import numpy as np
 
-@pytest.fixture()
-def m(download_release):
-    m = main.deepforest()
-    m.use_release(check_release=False)
-    
-    return m
-
 def test_evaluate_image(m):
     csv_file = get_data("OSBS_029.csv")
     predictions = m.predict_file(csv_file=csv_file, root_dir=os.path.dirname(csv_file))
@@ -42,9 +35,8 @@ def test_evaluate(m):
     assert "score" in results["results"].columns
     assert results["results"].true_label.unique() == "Tree"
 
-def test_evaluate_multi(m):
+def test_evaluate_multi():
     csv_file = get_data("testfile_multi.csv")
-    m = main.deepforest(num_classes=2,label_dict={"Alive":0,"Dead":1})
     ground_truth = pd.read_csv(csv_file)
     ground_truth["label"] = ground_truth.label.astype("category").cat.codes
     
@@ -57,9 +49,8 @@ def test_evaluate_multi(m):
     assert results["results"].shape[0] == ground_truth.shape[0]
     assert results["class_recall"].shape == (2,4)
     
-def test_evaluate_save_images(m, tmpdir):
+def test_evaluate_save_images(tmpdir):
     csv_file = get_data("testfile_multi.csv")
-    m = main.deepforest(num_classes=2,label_dict={"Alive":0,"Dead":1})
     ground_truth = pd.read_csv(csv_file)
     ground_truth["label"] = ground_truth.label.astype("category").cat.codes
     
@@ -70,7 +61,7 @@ def test_evaluate_save_images(m, tmpdir):
     results = evaluate.evaluate(predictions=predictions, ground_df=ground_truth, root_dir=os.path.dirname(csv_file), savedir=tmpdir)     
     assert all([os.path.exists("{}/{}".format(tmpdir,x)) for x in ground_truth.image_path])
 
-def test_evaluate_empty():
+def test_evaluate_empty(m):
     m = main.deepforest()
     m.config["score_thresh"] = 0.8
     csv_file = get_data("OSBS_029.csv")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -24,41 +24,6 @@ from PIL import Image
 from .conftest import download_release
 
 @pytest.fixture()
-def two_class_m():
-    m = main.deepforest(num_classes=2,label_dict={"Alive":0,"Dead":1})
-    m.config["train"]["csv_file"] = get_data("testfile_multi.csv") 
-    m.config["train"]["root_dir"] = os.path.dirname(get_data("testfile_multi.csv"))
-    m.config["train"]["fast_dev_run"] = True
-    m.config["batch_size"] = 2
-        
-    m.config["validation"]["csv_file"] = get_data("testfile_multi.csv") 
-    m.config["validation"]["root_dir"] = os.path.dirname(get_data("testfile_multi.csv"))
-    m.config["validation"]["val_accuracy_interval"] = 1
-
-    m.create_trainer()
-    
-    return m
-
-@pytest.fixture()
-def m(download_release):
-    m = main.deepforest()
-    m.config["train"]["csv_file"] = get_data("example.csv") 
-    m.config["train"]["root_dir"] = os.path.dirname(get_data("example.csv"))
-    m.config["train"]["fast_dev_run"] = True
-    m.config["batch_size"] = 2
-        
-    m.config["validation"]["csv_file"] = get_data("example.csv") 
-    m.config["validation"]["root_dir"] = os.path.dirname(get_data("example.csv"))
-    m.config["workers"] = 0 
-    m.config["validation"]["val_accuracy_interval"] = 1
-    m.config["train"]["epochs"] = 2
-    
-    m.create_trainer()
-    m.use_release(check_release=False)
-    
-    return m
-
-@pytest.fixture()
 def raster_path():
     return get_data(path='OSBS_029.tif')    
     

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -73,11 +73,9 @@ def test_shapefile_to_annotations(tmpdir):
     shp = utilities.shapefile_to_annotations(shapefile="{}/annotations.shp".format(tmpdir), rgb=image_path, savedir=tmpdir, convert_to_boxes=False)
     assert shp.shape[0] == 2
     
-def test_boxes_to_shapefile_projected(download_release):
+def test_boxes_to_shapefile_projected(m):
     img = get_data("OSBS_029.tif")
     r = rio.open(img)
-    m = main.deepforest()
-    m.use_release(check_release=False)
     df = m.predict_image(path=img)
     gdf = utilities.boxes_to_shapefile(df, root_dir=os.path.dirname(img), projected=True)
     
@@ -89,12 +87,9 @@ def test_boxes_to_shapefile_projected(download_release):
     gdf = utilities.boxes_to_shapefile(df.iloc[:1,], root_dir=os.path.dirname(img), projected=True)
     assert gdf.shape[0] == 1
 
-def test_boxes_to_shapefile_projected_from_predict_tile(download_release):
+def test_boxes_to_shapefile_projected_from_predict_tile(m):
     img = get_data("OSBS_029.tif")
     r = rio.open(img)
-    m = main.deepforest()
-    m.create_trainer()
-    m.use_release(check_release=False)
     df = m.predict_tile(raster_path=img)
     gdf = utilities.boxes_to_shapefile(df, root_dir=os.path.dirname(img), projected=True)
     
@@ -107,11 +102,9 @@ def test_boxes_to_shapefile_projected_from_predict_tile(download_release):
     assert gdf.shape[0] == 1
     
 @pytest.mark.parametrize("flip_y_axis", [True, False])
-def test_boxes_to_shapefile_unprojected(download_release, flip_y_axis):
+def test_boxes_to_shapefile_unprojected(m, flip_y_axis):
     img = get_data("OSBS_029.png")
     r = rio.open(img)
-    m = main.deepforest()
-    m.use_release(check_release=False)
     df = m.predict_image(path=img)
     gdf = utilities.boxes_to_shapefile(df, root_dir=os.path.dirname(img), projected=False, flip_y_axis=flip_y_axis)
     

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -6,21 +6,6 @@ import os
 import pytest
 import numpy as np
 
-@pytest.fixture()
-def m():
-    m = main.deepforest()
-    m.config["train"]["csv_file"] = get_data("example.csv") 
-    m.config["train"]["root_dir"] = os.path.dirname(get_data("example.csv"))
-    m.config["train"]["fast_dev_run"] = True
-    m.config["batch_size"] = 2
-       
-    m.config["validation"]["csv_file"] = get_data("example.csv") 
-    m.config["validation"]["root_dir"] = os.path.dirname(get_data("example.csv"))
-       
-    m.create_trainer()
-    
-    return m
-
 def test_format_boxes(m):
     ds = m.val_dataloader()
     batch = next(iter(ds))
@@ -47,7 +32,6 @@ def test_plot_predictions(m, tmpdir,label):
 
         assert image.dtype == "uint8"
         
-    
 def test_plot_prediction_dataframe(m, tmpdir):
     ds = m.val_dataloader()
     batch = next(iter(ds))


### PR DESCRIPTION
The current tests were too slow. I improved this

* Moving model definition to conftests.py to reduce duplication. 
* Set workers to 0 to deactivate pytest parallel fit. This one is a bit a mystery why it improves performance during tests, but not during normal model fitting.