### PR TITLE
Close #511, replaced convert_to_boxes with geometry_type

### DIFF
--- a/deepforest/utilities.py
+++ b/deepforest/utilities.py
@@ -251,7 +251,7 @@ def shapefile_to_annotations(shapefile,
     Convert a shapefile of annotations into annotations csv file for DeepForest training and evaluation
 
     Geometry Handling:
-    The geometry_type is the form of the objects in the given shapefile it can be "boundingbox" or "point".
+    The geometry_type is the form of the objects in the given shapefile. It can be "boundingbox" or "point".
     If geometry_type is set to "boundingbox" (default) then the bounding boxes in the shapefile will be used as is and transferred over
     to the annotations file. However, if the geometry_type is "point" then a bounding box will be created in its place that's centered on
     the original point with an apothem equal to buffer_size.

--- a/deepforest/utilities.py
+++ b/deepforest/utilities.py
@@ -262,14 +262,15 @@ def shapefile_to_annotations(shapefile,
         rgb: Path to the RGB image on disk
         savedir: Directory to save csv files
         buffer_size: size of point to box expansion in map units of the target object, meters for projected data, pixels for unprojected data. The buffer_size is added to each side of the x,y point to create the box. 
-        geometry_type (bbox): Specifies the spatial representation used in the shapefile; can be "bbox" or "point"
+        geometry_type: Specifies the spatial representation used in the shapefile; can be "bbox" or "point"
     Returns:
         results: a pandas dataframe
     """
 
     # Verify the geometry_type is valid
     if geometry_type not in ["bbox", "point"]:
-        raise ValueError(f"Invalid argument for 'geometry_type'. Expected 'point' or 'bbox'.")
+        raise ValueError(
+            "Invalid argument for 'geometry_type'. Expected 'point' or 'bbox'.")
 
     # Read shapefile
     gdf = gpd.read_file(shapefile)

--- a/deepforest/utilities.py
+++ b/deepforest/utilities.py
@@ -245,24 +245,33 @@ def xml_to_annotations(xml_path):
 def shapefile_to_annotations(shapefile,
                              rgb,
                              buffer_size=0.5,
-                             convert_to_boxes=False,
+                             geometry_type="boundingbox",
                              savedir="."):
     """
     Convert a shapefile of annotations into annotations csv file for DeepForest training and evaluation
+
+    Geometry Handling:
+    The geometry_type is the form of the objects in the given shapefile it can be "boundingbox" or "point".
+    If geometry_type is set to "boundingbox" (default) then the bounding boxes in the shapefile will be used as is and transferred over
+    to the annotations file. However, if the geometry_type is "point" then a bounding box will be created in its place that's centered on
+    the original point with an apothem equal to buffer_size.
+    
     Args:
         shapefile: Path to a shapefile on disk. If a label column is present, it will be used, else all labels are assumed to be "Tree"
         rgb: Path to the RGB image on disk
         savedir: Directory to save csv files
         buffer_size: size of point to box expansion in map units of the target object, meters for projected data, pixels for unprojected data. The buffer_size is added to each side of the x,y point to create the box. 
-        convert_to_boxes (False): If True, convert the point objects in the shapefile into bounding boxes with size 'buffer_size'.  
+        geometry_type (boundingbox): Specifies the spatial representation used in the shapefile; can be 'boundingbox' or 'point'
     Returns:
         results: a pandas dataframe
+
+
     """
     # Read shapefile
     gdf = gpd.read_file(shapefile)
 
     # define in image coordinates and buffer to create a box
-    if convert_to_boxes:
+    if geometry_type == 'point':
         gdf["geometry"] = [
             shapely.geometry.Point(x, y)
             for x, y in zip(gdf.geometry.x.astype(float), gdf.geometry.y.astype(float))

--- a/deepforest/utilities.py
+++ b/deepforest/utilities.py
@@ -245,33 +245,37 @@ def xml_to_annotations(xml_path):
 def shapefile_to_annotations(shapefile,
                              rgb,
                              buffer_size=0.5,
-                             geometry_type="boundingbox",
+                             geometry_type="bbox",
                              savedir="."):
     """
     Convert a shapefile of annotations into annotations csv file for DeepForest training and evaluation
 
     Geometry Handling:
-    The geometry_type is the form of the objects in the given shapefile. It can be "boundingbox" or "point".
-    If geometry_type is set to "boundingbox" (default) then the bounding boxes in the shapefile will be used as is and transferred over
-    to the annotations file. However, if the geometry_type is "point" then a bounding box will be created in its place that's centered on
-    the original point with an apothem equal to buffer_size.
+    The geometry_type is the form of the objects in the given shapefile. It can be "bbox" or "point".
+    If geometry_type is set to "bbox" (default) then the bounding boxes in the shapefile will be used as is and transferred over
+    to the annotations file. If the geometry_type is "point" then a bounding box will be created for each 
+    point that is centered on the point location and has an apothem equal to buffer_size, resulting in a bounding box with dimensions of 2 
+    times the value of buffer_size.
     
     Args:
         shapefile: Path to a shapefile on disk. If a label column is present, it will be used, else all labels are assumed to be "Tree"
         rgb: Path to the RGB image on disk
         savedir: Directory to save csv files
         buffer_size: size of point to box expansion in map units of the target object, meters for projected data, pixels for unprojected data. The buffer_size is added to each side of the x,y point to create the box. 
-        geometry_type (boundingbox): Specifies the spatial representation used in the shapefile; can be 'boundingbox' or 'point'
+        geometry_type (bbox): Specifies the spatial representation used in the shapefile; can be "bbox" or "point"
     Returns:
         results: a pandas dataframe
-
-
     """
+
+    # Verify the geometry_type is valid
+    if geometry_type not in ["bbox", "point"]:
+        raise ValueError(f"Invalid argument for 'geometry_type'. Expected 'point' or 'bbox'.")
+
     # Read shapefile
     gdf = gpd.read_file(shapefile)
 
     # define in image coordinates and buffer to create a box
-    if geometry_type == 'point':
+    if geometry_type == "point":
         gdf["geometry"] = [
             shapely.geometry.Point(x, y)
             for x, y in zip(gdf.geometry.x.astype(float), gdf.geometry.y.astype(float))

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -70,7 +70,7 @@ def test_shapefile_to_annotations(tmpdir):
     
     gdf.to_file("{}/annotations.shp".format(tmpdir))
     image_path = get_data("OSBS_029.tif")
-    shp = utilities.shapefile_to_annotations(shapefile="{}/annotations.shp".format(tmpdir), rgb=image_path, savedir=tmpdir, geometry_type="boundingbox")
+    shp = utilities.shapefile_to_annotations(shapefile="{}/annotations.shp".format(tmpdir), rgb=image_path, savedir=tmpdir, geometry_type="bbox")
     assert shp.shape[0] == 2
     
 def test_boxes_to_shapefile_projected(m):

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -58,7 +58,7 @@ def test_shapefile_to_annotations_convert_to_boxes(tmpdir):
     gdf = gpd.GeoDataFrame(df, geometry="geometry")
     gdf.to_file("{}/annotations.shp".format(tmpdir))
     image_path = get_data("OSBS_029.tif")
-    shp = utilities.shapefile_to_annotations(shapefile="{}/annotations.shp".format(tmpdir), rgb=image_path, savedir=tmpdir, convert_to_boxes=True)
+    shp = utilities.shapefile_to_annotations(shapefile="{}/annotations.shp".format(tmpdir), rgb=image_path, savedir=tmpdir, geometry_type="point")
     assert shp.shape[0] == 2
     
 def test_shapefile_to_annotations(tmpdir):
@@ -70,7 +70,7 @@ def test_shapefile_to_annotations(tmpdir):
     
     gdf.to_file("{}/annotations.shp".format(tmpdir))
     image_path = get_data("OSBS_029.tif")
-    shp = utilities.shapefile_to_annotations(shapefile="{}/annotations.shp".format(tmpdir), rgb=image_path, savedir=tmpdir, convert_to_boxes=False)
+    shp = utilities.shapefile_to_annotations(shapefile="{}/annotations.shp".format(tmpdir), rgb=image_path, savedir=tmpdir, geometry_type="boundingbox")
     assert shp.shape[0] == 2
     
 def test_boxes_to_shapefile_projected(m):


### PR DESCRIPTION
This is just a simple swap with convert_to_boxes to with geometry_type to allow polygons to be used in the shape file further down the road. I also added some documentation regarding the handling of different geometries within the shape-file in the doc-strings body. 
