### PR TITLE
warn and set projected to False if flip_y_axis is set to True, closes #440

### DIFF
--- a/deepforest/utilities.py
+++ b/deepforest/utilities.py
@@ -388,6 +388,14 @@ def boxes_to_shapefile(df, root_dir, projected=True, flip_y_axis=False):
     Returns:
        df: a geospatial dataframe with the boxes optionally transformed to the target crs
     """
+    # Check if the user has set flip_y_axis, but not projected. Warn and confirm.
+
+    if (flip_y_axis and projected):
+        warnings.warn(
+            "flip_y_axis is {}, and projected is {}. In most cases, projected should be False when inverting y axis. Setting projected=False"
+            .format(flip_y_axis, projected), UserWarning)
+        projected = False
+
     plot_names = df.image_path.unique()
     if len(plot_names) > 1:
         raise ValueError("This function projects a single plots worth of data. "

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -101,12 +101,26 @@ def test_boxes_to_shapefile_projected_from_predict_tile(m):
     gdf = utilities.boxes_to_shapefile(df.iloc[:1,], root_dir=os.path.dirname(img), projected=True)
     assert gdf.shape[0] == 1
     
+# Test unprojected data, including warning if flip_y_axis is set to True, but projected is False
 @pytest.mark.parametrize("flip_y_axis", [True, False])
-def test_boxes_to_shapefile_unprojected(m, flip_y_axis):
+@pytest.mark.parametrize("projected", [True, False])
+def test_boxes_to_shapefile_unprojected(m, flip_y_axis, projected):
     img = get_data("OSBS_029.png")
     r = rio.open(img)
     df = m.predict_image(path=img)
-    gdf = utilities.boxes_to_shapefile(df, root_dir=os.path.dirname(img), projected=False, flip_y_axis=flip_y_axis)
+    if projected and flip_y_axis:
+        with pytest.warns(UserWarning):
+            gdf = utilities.boxes_to_shapefile(
+                df,
+                root_dir=os.path.dirname(img),
+                projected=projected,
+                flip_y_axis=flip_y_axis)
+    else:
+        gdf = utilities.boxes_to_shapefile(
+        df,
+        root_dir=os.path.dirname(img),
+        projected=projected,
+        flip_y_axis=flip_y_axis)
     
     #Confirm that each boxes within image bounds
     geom = geometry.box(*r.bounds)


### PR DESCRIPTION
This is a small PR to add a warning and set projected=True in deepforest.utilities.boxes_to_shapefile when setting flip_y_axis=True.  