### PR TITLE
Add a point_recall evaluate

### DIFF
--- a/deepforest/evaluate.py
+++ b/deepforest/evaluate.py
@@ -170,17 +170,16 @@ def _point_recall_image_(predictions, ground_df, root_dir=None, savedir=None):
     """
     Compute intersection-over-union matching among prediction and ground truth boxes for one image
     Args:
-        df: a pandas dataframe with columns name, xmin, xmax, ymin, ymax, label. The 'name' column should be the path relative to the location of the file.
-        summarize: Whether to group statistics by plot and overall score
-        image_coordinates: Whether the current boxes are in coordinate system of the image, e.g. origin (0,0) upper left.
-        root_dir: Where to search for image names in df, only needed if savedir is supplied
+        predictions: a pandas dataframe. The labels in ground truth and predictions must match. For example, if one is numeric, the other must be numeric.
+        ground_df: a pandas dataframe
+        root_dir: location of files in the dataframe 'name' column, only needed if savedir is supplied
         savedir: optional directory to save image with overlaid predictions and annotations
     Returns:
         result: pandas dataframe with crown ids of prediciton and ground truth and the IoU score.
     """
     plot_names = predictions["image_path"].unique()
     if len(plot_names) > 1:
-        raise ValueError("More than one plot passed to image crown: {}".format(plot_name))
+        raise ValueError("More than one image passed to function: {}".format(plot_name))
     else:
         plot_name = plot_names[0]
 
@@ -221,13 +220,12 @@ def point_recall(predictions, ground_df, root_dir=None, savedir=None):
         predictions: a pandas dataframe, if supplied a root dir is needed to give the relative path of files in df.name. The labels in ground truth and predictions must match. If one is numeric, the other must be numeric.
         ground_df: a pandas dataframe, if supplied a root dir is needed to give the relative path of files in df.name
         root_dir: location of files in the dataframe 'name' column.
+        savedir: optional directory to save image with overlaid predictions and annotations
     Returns:
-        results: a dataframe of match bounding boxes
-        box_recall: proportion of true positives of box position, regardless of class
-        box_precision: proportion of predictions that are true positive, regardless of class
+        results: a dataframe of matched bounding boxes and ground truth labels
+        box_recall: proportion of true positives between predicted boxes and ground truth points, regardless of class
         class_recall: a pandas dataframe of class level recall and precision with class sizes
     """
-
     check_file(predictions)
     if savedir:
         if root_dir is None:

--- a/deepforest/evaluate.py
+++ b/deepforest/evaluate.py
@@ -164,3 +164,112 @@ def evaluate(predictions, ground_df, root_dir, iou_threshold=0.4, savedir=None):
         "box_recall": box_recall,
         "class_recall": class_recall
     }
+
+def _point_recall_image_(predictions, ground_df, root_dir=None, savedir=None):
+    """
+    Compute intersection-over-union matching among prediction and ground truth boxes for one image
+    Args:
+        df: a pandas dataframe with columns name, xmin, xmax, ymin, ymax, label. The 'name' column should be the path relative to the location of the file.
+        summarize: Whether to group statistics by plot and overall score
+        image_coordinates: Whether the current boxes are in coordinate system of the image, e.g. origin (0,0) upper left.
+        root_dir: Where to search for image names in df, only needed if savedir is supplied
+        savedir: optional directory to save image with overlaid predictions and annotations
+    Returns:
+        result: pandas dataframe with crown ids of prediciton and ground truth and the IoU score.
+    """
+    plot_names = predictions["image_path"].unique()
+    if len(plot_names) > 1:
+        raise ValueError("More than one plot passed to image crown: {}".format(plot_name))
+    else:
+        plot_name = plot_names[0]
+
+    predictions['geometry'] = predictions.apply(
+        lambda x: shapely.geometry.box(x.xmin, x.ymin, x.xmax, x.ymax), axis=1)
+    predictions = gpd.GeoDataFrame(predictions, geometry='geometry')
+
+    ground_df['geometry'] = ground_df.apply(
+        lambda x: shapely.geometry.Point(x.x, x.y), axis=1)
+    ground_df = gpd.GeoDataFrame(ground_df, geometry='geometry')
+
+    # Which points in boxes
+    result = gpd.sjoin(ground_df,predictions, op='within', how="left")
+    result = result.rename(columns={"label_left":"true_label","label_right":"predicted_label","image_path_left":"image_path"})
+    result = result.drop(columns=["index_right"])
+
+    if savedir:
+        if root_dir is None:
+            raise AttributeError("savedir is {}, but root dir is None".format(savedir))
+        image = np.array(Image.open("{}/{}".format(root_dir, plot_name)))[:, :, ::-1]
+        image = visualize.plot_predictions(image, df=predictions)
+        image = visualize.plot_points(image, df=ground_df, color=(0, 165, 255))
+        cv2.imwrite("{}/{}".format(savedir, plot_name), image)
+
+    return result
+
+def point_recall(predictions, ground_df, root_dir=None, savedir=None):
+    """Evaluate the proportion on ground truth points overlap with predictions
+    submission can be submitted as a .shp, existing pandas dataframe or .csv path
+    For bounding box recall, see evaluate(). 
+    Args:
+        predictions: a pandas dataframe, if supplied a root dir is needed to give the relative path of files in df.name. The labels in ground truth and predictions must match. If one is numeric, the other must be numeric.
+        ground_df: a pandas dataframe, if supplied a root dir is needed to give the relative path of files in df.name
+        root_dir: location of files in the dataframe 'name' column.
+    Returns:
+        results: a dataframe of match bounding boxes
+        box_recall: proportion of true positives of box position, regardless of class
+        box_precision: proportion of predictions that are true positive, regardless of class
+        class_recall: a pandas dataframe of class level recall and precision with class sizes
+    """
+
+    check_file(predictions)
+    if savedir:
+        if root_dir is None:
+            raise AttributeError("savedir is {}, but root dir is None".format(savedir))
+    
+    # Run evaluation on all images
+    results = []
+    box_recalls = []
+    for image_path, group in ground_df.groupby("image_path"):
+        image_predictions = predictions[predictions["image_path"] ==
+                                        image_path].reset_index(drop=True)
+
+        # If empty, add to list without computing recall
+        if image_predictions.empty:
+            result = pd.DataFrame({
+                "recall": 0,
+                "predicted_label": None,
+                "score": None,
+                "true_label": group.label
+            })
+            # An empty prediction set has recall of 0, precision of NA.
+            box_recalls.append(0)
+            results.append(result)
+            continue
+        else:
+            group = group.reset_index(drop=True)
+            result = _point_recall_image_(predictions=image_predictions,
+                                    ground_df=group,
+                                    root_dir=root_dir,
+                                    savedir=savedir)
+
+        result["image_path"] = image_path
+       
+        # What proportion of boxes match? Regardless of label
+        true_positive = sum(result.predicted_label.notnull())
+        recall = true_positive / result.shape[0]
+
+        box_recalls.append(recall)
+        results.append(result)
+
+    results = pd.concat(results)
+    box_recall = np.mean(box_recalls)
+
+    # Only matching boxes are considered in class recall
+    matched_results = results[results.predicted_label.notnull()]
+    class_recall = compute_class_recall(matched_results)
+
+    return {
+        "results": results,
+        "box_recall": box_recall,
+        "class_recall": class_recall
+    }

--- a/deepforest/visualize.py
+++ b/deepforest/visualize.py
@@ -133,6 +133,42 @@ def plot_predictions(image, df, color=None, thickness=1):
 
     return image
 
+def plot_points(image, df, color=None, thickness=1):
+    """Plot a set of boxes on an image
+    By default this function does not show, but only plots an axis
+    Label column must be numeric!
+    Image must be BGR color order!
+    Args:
+        image: a numpy array in *BGR* color order! Channel order is channels first 
+        df: a pandas dataframe with x,y and label column
+        color: color of the bounding box as a tuple of BGR color, e.g. orange annotations is (0, 165, 255)
+        thickness: thickness of the rectangle border line in px
+    Returns:
+        image: a numpy array with drawn annotations
+    """
+    if image.shape[0] == 3:
+        warnings.warn("Input images must be channels last format [h, w, 3] not channels "
+                      "first [3, h, w], using np.rollaxis(image, 0, 3) to invert!")
+        image = np.rollaxis(image, 0, 3)
+    if image.dtype == "float32":
+        image = image.astype("uint8")
+    image = image.copy()
+    if not color:
+        if not ptypes.is_numeric_dtype(df.label):
+            warnings.warn("No color was provided and the label column is not numeric. "
+                          "Using a single default color.")
+            color = (255, 255, 255)
+
+    for index, row in df.iterrows():
+        if not color:
+            color = label_to_color(row["label"])
+        cv2.circle(image,
+                    (row["x"],row["y"]),
+                    color=color,
+                    radius=5,
+                    thickness=thickness)
+
+    return image
 
 def label_to_color(label):
     color_dict = {}

--- a/deepforest/visualize.py
+++ b/deepforest/visualize.py
@@ -135,7 +135,7 @@ def plot_predictions(image, df, color=None, thickness=1):
 
 
 def plot_points(image, df, color=None, thickness=1):
-    """Plot a set of boxes on an image
+    """Plot a set of points on an image
     By default this function does not show, but only plots an axis
     Label column must be numeric!
     Image must be BGR color order!

--- a/deepforest/visualize.py
+++ b/deepforest/visualize.py
@@ -133,6 +133,7 @@ def plot_predictions(image, df, color=None, thickness=1):
 
     return image
 
+
 def plot_points(image, df, color=None, thickness=1):
     """Plot a set of boxes on an image
     By default this function does not show, but only plots an axis
@@ -162,13 +163,13 @@ def plot_points(image, df, color=None, thickness=1):
     for index, row in df.iterrows():
         if not color:
             color = label_to_color(row["label"])
-        cv2.circle(image,
-                    (row["x"],row["y"]),
-                    color=color,
-                    radius=5,
-                    thickness=thickness)
+        cv2.circle(image, (row["x"], row["y"]),
+                   color=color,
+                   radius=5,
+                   thickness=thickness)
 
     return image
+
 
 def label_to_color(label):
     color_dict = {}

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -8,6 +8,7 @@ import os
 import pytest
 import pandas as pd
 import numpy as np
+import geopandas as gpd
 
 def test_evaluate_image(m):
     csv_file = get_data("OSBS_029.csv")
@@ -94,3 +95,59 @@ def test_compute_class_recall(sample_results):
     }).reset_index(drop=True)
 
     assert evaluate.compute_class_recall(sample_results).equals(expected_recall)
+
+@pytest.mark.parametrize("root_dir",[None,"tmpdir"])
+def test_point_recall_image(root_dir, tmpdir):
+    img_path = get_data("OSBS_029.png")
+    if root_dir == "tmpdir":
+        root_dir = os.path.dirname(img_path)
+        savedir = tmpdir
+    else:
+        savedir = None
+
+    # create sample dataframes
+    predictions = pd.DataFrame({
+        "image_path": ["OSBS_029.png", "OSBS_029.png"],
+        "xmin": [1, 150],
+        "xmax": [100, 200],
+        "ymin": [1, 75],
+        "ymax": [50, 100],
+        "label": ["A", "B"],
+    })
+    ground_df = pd.DataFrame({
+        "image_path": ["OSBS_029.png", "OSBS_029.png"],
+        "x": [5, 20],
+        "y": [30, 300],
+        "label": ["A", "B"],
+    })
+
+    # run the function
+    result = evaluate._point_recall_image_(predictions, ground_df, root_dir=root_dir, savedir=savedir)
+
+    # check the output, 1 match of 2 ground truth
+    assert all(result.predicted_label.isnull().values == [False,True])
+    assert isinstance(result, gpd.GeoDataFrame)
+    assert "predicted_label" in result.columns
+    assert "true_label" in result.columns
+    assert "geometry" in result.columns
+
+def test_point_recall():
+    # create sample dataframes
+    predictions = pd.DataFrame({
+        "image_path": ["OSBS_029.png", "OSBS_029.png"],
+        "xmin": [1, 150],
+        "xmax": [100, 200],
+        "ymin": [1, 75],
+        "ymax": [50, 100],
+        "label": ["A", "B"],
+    })
+    ground_df = pd.DataFrame({
+        "image_path": ["OSBS_029.png", "OSBS_029.png"],
+        "x": [5, 20],
+        "y": [30, 300],
+        "label": ["A", "B"],
+    })
+
+    results = evaluate.point_recall(ground_df=ground_df, predictions=predictions)
+    assert results["box_recall"] == 0.5
+    assert results["class_recall"].recall[0] == 1


### PR DESCRIPTION
As part of the larger goal of expanding DeepForest to more data types, I wrote a point recall function that calculates what proportion of ground truth points overlap with predicted boxes. I added a visualization function as well. I need this for the training the new backbone, as many datasets only have points. We may create psuedo boxes during training, but for evaluation, we need to deal with the original data type.