### PR TITLE
Move main.predict_file to predict.predict_file and uses trainer.predict() for predict_file(). Speeds up main.evaluate!

### DIFF
--- a/deepforest/callbacks.py
+++ b/deepforest/callbacks.py
@@ -63,7 +63,7 @@ class images_callback(Callback):
                   "skipping upload, images were saved to {}, "
                   "error was rasied {}".format(self.savedir, e))
 
-    def on_validation_epoch_end(self, trainer, pl_module):
+    def on_validation_end(self, trainer, pl_module):
         if trainer.sanity_checking:  # optional skip
             return
 

--- a/deepforest/main.py
+++ b/deepforest/main.py
@@ -382,15 +382,13 @@ class deepforest(pl.LightningModule):
         Returns:
             df: pandas dataframe with bounding boxes, label and scores for each image in the csv file
         """
-        results = predict.predict_file(
-                model=self,
-                csv_file=csv_file,
-                root_dir=root_dir,
-                nms_thresh=self.config["nms_thresh"],
-                savedir=savedir,
-                color=color,
-                thickness=thickness
-                )
+        results = predict.predict_file(model=self,
+                                       csv_file=csv_file,
+                                       root_dir=root_dir,
+                                       nms_thresh=self.config["nms_thresh"],
+                                       savedir=savedir,
+                                       color=color,
+                                       thickness=thickness)
         return results
 
     def predict_tile(self,

--- a/deepforest/predict.py
+++ b/deepforest/predict.py
@@ -13,6 +13,7 @@ from deepforest import preprocess
 from deepforest import visualize
 from deepforest import dataset
 
+
 def predict_image(model,
                   image,
                   return_plot,
@@ -138,7 +139,14 @@ def across_class_nms(predicted_boxes, iou_threshold=0.15):
 
     return new_df
 
-def predict_file(model, csv_file, root_dir, nms_thresh, savedir=None, color=None, thickness=1):
+
+def predict_file(model,
+                 csv_file,
+                 root_dir,
+                 nms_thresh,
+                 savedir=None,
+                 color=None,
+                 thickness=1):
     """Create a dataset and predict entire annotation file
 
     Csv file format is .csv file with the columns "image_path", "xmin","ymin","xmax","ymax" for the image name and bounding box position.
@@ -158,12 +166,12 @@ def predict_file(model, csv_file, root_dir, nms_thresh, savedir=None, color=None
     df = pd.read_csv(csv_file)
     paths = df.image_path.unique()
     ds = dataset.TreeDataset(csv_file=csv_file,
-                                root_dir=root_dir,
-                                transforms=None,
-                                train=False)
+                             root_dir=root_dir,
+                             transforms=None,
+                             train=False)
 
     dataloader = model.predict_dataloader(ds)
-    
+
     #Make sure the latest trainer is used.
     model.create_trainer()
     trainer = model.trainer
@@ -179,25 +187,23 @@ def predict_file(model, csv_file, root_dir, nms_thresh, savedir=None, color=None
     for index, prediction in enumerate(prediction_list):
         # If there is more than one class, apply NMS Loop through images and apply cross
         if len(prediction.label.unique()) > 1:
-            prediction = across_class_nms(
-                prediction, iou_threshold=nms_thresh)
+            prediction = across_class_nms(prediction, iou_threshold=nms_thresh)
 
         if savedir:
             # Just predict the images, even though we have the annotations
             image = np.array(Image.open("{}/{}".format(root_dir,
-                                                        paths[index])))[:, :, ::-1]
+                                                       paths[index])))[:, :, ::-1]
             image = visualize.plot_predictions(image, prediction)
 
             # Plot annotations if they exist
             annotations = df[df.image_path == paths[index]]
 
             image = visualize.plot_predictions(image,
-                                                annotations,
-                                                color=color,
-                                                thickness=thickness)
-            cv2.imwrite(
-                "{}/{}.png".format(savedir,
-                                    os.path.splitext(paths[index])[0]), image)
+                                               annotations,
+                                               color=color,
+                                               thickness=thickness)
+            cv2.imwrite("{}/{}.png".format(savedir,
+                                           os.path.splitext(paths[index])[0]), image)
 
         prediction["image_path"] = paths[index]
         results.append(prediction)

--- a/deepforest/predict.py
+++ b/deepforest/predict.py
@@ -2,6 +2,8 @@
 import cv2
 import pandas as pd
 import numpy as np
+import os
+from PIL import Image
 import warnings
 
 import torch
@@ -9,7 +11,7 @@ from torchvision.ops import nms
 
 from deepforest import preprocess
 from deepforest import visualize
-
+from deepforest import dataset
 
 def predict_image(model,
                   image,
@@ -135,3 +137,71 @@ def across_class_nms(predicted_boxes, iou_threshold=0.15):
                           columns=["xmin", "ymin", "xmax", "ymax", "label", "score"])
 
     return new_df
+
+def predict_file(model, csv_file, root_dir, nms_thresh, savedir=None, color=None, thickness=1):
+    """Create a dataset and predict entire annotation file
+
+    Csv file format is .csv file with the columns "image_path", "xmin","ymin","xmax","ymax" for the image name and bounding box position.
+    Image_path is the relative filename, not absolute path, which is in the root_dir directory. One bounding box per line.
+
+    Args:
+        model: deepforest.main object
+        csv_file: path to csv file
+        root_dir: directory of images. If none, uses "image_dir" in config
+        nms_thresh: Non-max supression threshold, see config["nms_thresh"]
+        savedir: Optional. Directory to save image plots.
+        color: color of the bounding box as a tuple of BGR color, e.g. orange annotations is (0, 165, 255)
+        thickness: thickness of the rectangle border line in px
+    Returns:
+        df: pandas dataframe with bounding boxes, label and scores for each image in the csv file
+    """
+    df = pd.read_csv(csv_file)
+    paths = df.image_path.unique()
+    ds = dataset.TreeDataset(csv_file=csv_file,
+                                root_dir=root_dir,
+                                transforms=None,
+                                train=False)
+
+    dataloader = model.predict_dataloader(ds)
+    
+    #Make sure the latest trainer is used.
+    model.create_trainer()
+    trainer = model.trainer
+    batched_results = trainer.predict(model, dataloader)
+
+    # Flatten list from batched prediction
+    prediction_list = []
+    for batch in batched_results:
+        for images in batch:
+            prediction_list.append(images)
+
+    results = []
+    for index, prediction in enumerate(prediction_list):
+        # If there is more than one class, apply NMS Loop through images and apply cross
+        if len(prediction.label.unique()) > 1:
+            prediction = across_class_nms(
+                prediction, iou_threshold=nms_thresh)
+
+        if savedir:
+            # Just predict the images, even though we have the annotations
+            image = np.array(Image.open("{}/{}".format(root_dir,
+                                                        paths[index])))[:, :, ::-1]
+            image = visualize.plot_predictions(image, prediction)
+
+            # Plot annotations if they exist
+            annotations = df[df.image_path == paths[index]]
+
+            image = visualize.plot_predictions(image,
+                                                annotations,
+                                                color=color,
+                                                thickness=thickness)
+            cv2.imwrite(
+                "{}/{}.png".format(savedir,
+                                    os.path.splitext(paths[index])[0]), image)
+
+        prediction["image_path"] = paths[index]
+        results.append(prediction)
+
+    results = pd.concat(results, ignore_index=True)
+
+    return results

--- a/tests/profile_predict_file.py
+++ b/tests/profile_predict_file.py
@@ -15,6 +15,8 @@ def run(m, csv_file, root_dir):
 if __name__ == "__main__":
     m = main.deepforest()
     m.use_release()
+    m.config["workers"] = 0
+    m.config["batch_size"] = 5
     
     csv_file = get_data("OSBS_029.csv")
     image_path = get_data("OSBS_029.png")
@@ -22,7 +24,7 @@ if __name__ == "__main__":
     df = pd.read_csv(csv_file)    
     
     big_frame = []
-    for x in range(10):
+    for x in range(100):
         img = Image.open("{}/{}".format(os.path.dirname(csv_file), df.image_path.unique()[0]))
         cv2.imwrite("{}/{}.png".format(tmpdir, x), np.array(img))
         new_df = df.copy()


### PR DESCRIPTION
1. Migrate the code in main.predict_file to predict.predict_file with just a wrapper in main. main.py is too long and shouldn't have any complex logic in it.
2. Used the trainer logic instead of manually moving batches to GPU, this causes significant speed up in evaluate, which should close #538. 

Before was around 37 seconds.

After
<img width="1678" alt="Screenshot 2023-11-09 at 11 30 16 AM" src="https://github.com/weecology/DeepForest/assets/1208492/4f0065b2-3006-46c6-ae7c-df9c4a3f161d">

Tested on hpc with 1 gpu

```
(base) [b.weinstein@login12 ~]$ cat tunnel.sh
#!/bin/bash
#SBATCH --job-name=tunnel   # Job name
#SBATCH --mail-type=END               # Mail events
#SBATCH --mail-user=benweinstein2010@gmail.com  # Where to send mail
#SBATCH --account=ewhite
#SBATCH --nodes=1                 # Number of MPI ran
#SBATCH --cpus-per-task=1
#SBATCH --mem=70GB
#SBATCH --time=12:00:00       #Time limit hrs:min:sec
#SBATCH --output=/home/b.weinstein/logs/tunnel.out   # Standard output and error log
#SBATCH --error=/home/b.weinstein/logs/tunnel.err
#SBATCH --partition=gpu
#SBATCH --gpus=1
```
```
(base) [b.weinstein@login12 tests]$ cat profile_predict_file.py
#Profile the dataset class on gpu
from deepforest import main
from deepforest import get_data
import os
import pandas as pd
import numpy as np
import cProfile, pstats
import tempfile
from PIL import Image
import cv2

def run(m, csv_file, root_dir):
    predictions = m.predict_file(csv_file=csv_file, root_dir=root_dir)

if __name__ == "__main__":
    profiler = cProfile.Profile()
    profiler.enable()
    m = main.deepforest()
    m.use_release()
    m.config["workers"] = 0
    m.config["batch_size"] = 24

    csv_file = get_data("OSBS_029.csv")
    image_path = get_data("OSBS_029.png")
    tmpdir = tempfile.gettempdir()
    df = pd.read_csv(csv_file)

    big_frame = []
    for x in range(100):
        img = Image.open("{}/{}".format(os.path.dirname(csv_file), df.image_path.unique()[0]))
        cv2.imwrite("{}/{}.png".format(tmpdir, x), np.array(img))
        new_df = df.copy()
        new_df.image_path = "{}.png".format(x)
        big_frame.append(new_df)

    big_frame = pd.concat(big_frame)
    big_frame.to_csv("{}/annotations.csv".format(tmpdir))


    run(m, csv_file = "{}/annotations.csv".format(tmpdir), root_dir = tmpdir)
    profiler.disable()
    stats = pstats.Stats(profiler).sort_stats('cumtime')
    stats.print_stats()
    stats.dump_stats('predict_file.prof')
```
