### PR TITLE
when the CRS of the shapefile and RGB data don't match, don't proceed…

### DIFF
--- a/deepforest/main.py
+++ b/deepforest/main.py
@@ -83,7 +83,6 @@ class deepforest(pl.LightningModule):
 
         self.create_model()
 
-
         # Metrics
         self.iou_metric = IntersectionOverUnion(
             class_metrics=True, iou_threshold=self.config["validation"]["iou_threshold"])

--- a/deepforest/utilities.py
+++ b/deepforest/utilities.py
@@ -296,10 +296,9 @@ def shapefile_to_annotations(shapefile,
 
     # Check matching the crs
     if not gdf.crs == src.crs:
-        raise ValueError(
-            "The shapefile crs {} does not match the image crs {}".format(
-                gdf.crs, src.crs))
-    
+        raise ValueError("The shapefile crs {} does not match the image crs {}".format(
+            gdf.crs, src.crs))
+
     # Transform project coordinates to image coordinates
     df["tile_xmin"] = (df.minx - left) / resolution
     df["tile_xmin"] = df["tile_xmin"].astype(int)
@@ -478,10 +477,11 @@ def annotations_to_shapefile(df, transform, crs):
     Returns:
         results: a geopandas dataframe where every entry is the bounding box for a detected tree.
     """
-    warnings.warn("This method is deprecated and will be "
-                  "removed in version DeepForest 2.0.0, "
-                  "please use boxes_to_shapefile which unifies project_boxes and "
-                  "annotations_to_shapefile functionalities", DeprecationWarning)
+    warnings.warn(
+        "This method is deprecated and will be "
+        "removed in version DeepForest 2.0.0, "
+        "please use boxes_to_shapefile which unifies project_boxes and "
+        "annotations_to_shapefile functionalities", DeprecationWarning)
 
     # Convert image pixel locations to geographic coordinates
     xmin_coords, ymin_coords = rasterio.transform.xy(transform=transform,
@@ -500,7 +500,7 @@ def annotations_to_shapefile(df, transform, crs):
         ymin_coords = [ymin_coords]
         xmax_coords = [xmax_coords]
         ymax_coords = [ymax_coords]
-    
+
     # One box polygon for each tree bounding box
     box_coords = zip(xmin_coords, ymin_coords, xmax_coords, ymax_coords)
     box_geoms = [
@@ -523,9 +523,11 @@ def project_boxes(df, root_dir, transform=True):
     root_dir: directory of images to lookup image_path column
     transform: If true, convert from image to geographic coordinates
     """
-    warnings.warn("This method is deprecated and will be removed in version "
-                  "DeepForest 2.0.0, please use boxes_to_shapefile which "
-                  "unifies project_boxes and annotations_to_shapefile functionalities", DeprecationWarning)
+    warnings.warn(
+        "This method is deprecated and will be removed in version "
+        "DeepForest 2.0.0, please use boxes_to_shapefile which "
+        "unifies project_boxes and annotations_to_shapefile functionalities",
+        DeprecationWarning)
     plot_names = df.image_path.unique()
     if len(plot_names) > 1:
         raise ValueError("This function projects a single plots worth of data. "

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -55,7 +55,7 @@ def test_shapefile_to_annotations_convert_to_boxes(tmpdir):
     sample_geometry = [geometry.Point(404211.9 + 10,3285102 + 20),geometry.Point(404211.9 + 20,3285102 + 20)]
     labels = ["Tree","Tree"]
     df = pd.DataFrame({"geometry":sample_geometry,"label":labels})
-    gdf = gpd.GeoDataFrame(df, geometry="geometry")
+    gdf = gpd.GeoDataFrame(df, geometry="geometry", crs="EPSG:32617")
     gdf.to_file("{}/annotations.shp".format(tmpdir))
     image_path = get_data("OSBS_029.tif")
     shp = utilities.shapefile_to_annotations(shapefile="{}/annotations.shp".format(tmpdir), rgb=image_path, savedir=tmpdir, geometry_type="point")
@@ -65,7 +65,7 @@ def test_shapefile_to_annotations(tmpdir):
     sample_geometry = [geometry.Point(404211.9 + 10,3285102 + 20),geometry.Point(404211.9 + 20,3285102 + 20)]
     labels = ["Tree","Tree"]
     df = pd.DataFrame({"geometry":sample_geometry,"label":labels})
-    gdf = gpd.GeoDataFrame(df, geometry="geometry")
+    gdf = gpd.GeoDataFrame(df, geometry="geometry", crs="EPSG:32617")
     gdf["geometry"] = [geometry.box(left, bottom, right, top) for left, bottom, right, top in gdf.geometry.buffer(0.5).bounds.values]
     
     gdf.to_file("{}/annotations.shp".format(tmpdir))


### PR DESCRIPTION
I found that we just proceed with converting data even if it obviously doesn't overlap. We should expect the user to have proper georeferenced data. I also cleaned up the annotations_to_shapefile function even though its going to be deprecated, it had an obvious edge that users could run into. 