### PR TITLE
troublesome crs matching, works on some versions of rasterio, but not others

### DIFF
--- a/deepforest/utilities.py
+++ b/deepforest/utilities.py
@@ -296,7 +296,7 @@ def shapefile_to_annotations(shapefile,
         raster_crs = src.crs
 
     # Check matching the crs
-    if not gdf.crs == raster_crs:
+    if not gdf.crs.to_string() == raster_crs.to_string():
         raise ValueError("The shapefile crs {} does not match the image crs {}".format(
             gdf.crs, src.crs))
 


### PR DESCRIPTION
This is becoming a bit of a saga. #591 is rasterio version dependent. Comparing on str is much safer. 

For example

```
gdf.crs
<Projected CRS: EPSG:32659>
Name: WGS 84 / UTM zone 59N
Axis Info [cartesian]:
- E[east]: Easting (metre)
- N[north]: Northing (metre)
Area of Use:
- name: Between 168°E and 174°E, northern hemisphere between equator and 84°N, onshore and offshore. Russian Federation; United States (USA) - Alaska.
- bounds: (168.0, 0.0, 174.0, 84.0)
Coordinate Operation:
- name: UTM zone 59N
- method: Transverse Mercator
Datum: World Geodetic System 1984 ensemble
- Ellipsoid: WGS 84
- Prime Meridian: Greenwich
```

has the same raster crs
```
raster_crs
CRS.from_epsg(32659)
```

Locally it works, but not on HPC

```
gdf.crs == raster_crs
False
```


```
gdf.crs.to_string() == raster_crs.to_string()
True
```

I'm rebasing upstream on my geo_type branch. 

Not my finest day of software dev.
