### PR TITLE
Make the Getting Started example executable

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -2,15 +2,16 @@
 
 ## How do I use a pretrained model to predict an image?
 
-```
+```python
 from deepforest import main
 from deepforest import get_data
-import os
 import matplotlib.pyplot as plt
+
 model = main.deepforest()
 model.use_release()
 
-img = model.predict_image(path="/Users/benweinstein/Documents/NeonTreeEvaluation/evaluation/RGB/TEAK_049_2019.tif",return_plot=True)
+sample_image_path = get_data("OSBS_029.png")
+img = model.predict_image(path=sample_image_path, return_plot=True)
 
 #predict_image returns plot in BlueGreenRed (opencv style), but matplotlib likes RedGreenBlue, switch the channel order.
 plt.imshow(img[:,:,::-1])
@@ -84,6 +85,8 @@ with each bounding box on a separate row. The image path is relative to the root
 We can view predictions by supplying a save dir ("." = current directory). Predictions in green, annotations in black.
 
 ```python
+import os
+
 csv_file = get_data("testfile_deepforest.csv")
 boxes = model.predict_file(csv_file=csv_file, root_dir = os.path.dirname(csv_file),savedir=".")
 ```


### PR DESCRIPTION
The first thing most folks want to do on a Getting Started page is to run the example so this swaps out the local path for one present on all installs.

Also moves the `os` import down to where it is used to keep things simpler.