### PR TITLE
issue #404, can we assert that pytorch workers are correctly connected?

### DIFF
--- a/tests/test_multiprocessing.py
+++ b/tests/test_multiprocessing.py
@@ -1,10 +1,14 @@
-# Ensure that multiprocessing is behaving as expected. 
+# Ensure that multiprocessing is behaving as expected.
 from deepforest import main, get_data
 from deepforest import dataset
+from deepforest.utilities import read_config
+
 import pytest
 import os
+import shutil
+import yaml
 
-@pytest.mark.parametrize("num_workers",[0, 1 ,2])
+@pytest.mark.parametrize("num_workers",[0 ,2])
 def test_predict_tile_workers(m, num_workers):
     # Default workers is 0
     original_workers = m.config["workers"]
@@ -14,12 +18,31 @@ def test_predict_tile_workers(m, num_workers):
     csv_file = get_data("OSBS_029.csv")
     # make a dataset
     ds = dataset.TreeDataset(csv_file=csv_file,
+                             root_dir=os.path.dirname(csv_file),
+                             transforms=None,
+                             train=False)
+    dataloader = m.predict_dataloader(ds)
+    assert dataloader.num_workers == num_workers
+
+def test_predict_tile_workers_config(tmpdir):
+    # Open config file and change workers to 1, save to tmpdir
+    config_file = get_data("deepforest_config.yml")
+    tmp_config_file = os.path.join(tmpdir, "deepforest_config.yml")
+
+    shutil.copyfile(config_file, tmp_config_file)
+    x = read_config(tmp_config_file)
+    x["workers"] = 1
+    with open(tmp_config_file, "w+") as f:
+        f.write(yaml.dump(x))
+        
+    m = main.deepforest(config_file=tmp_config_file)
+    csv_file = get_data("OSBS_029.csv")
+    # make a dataset
+    ds = dataset.TreeDataset(csv_file=csv_file,
                                  root_dir=os.path.dirname(csv_file),
                                  transforms=None,
                                  train=False)
     dataloader = m.predict_dataloader(ds)
-    assert dataloader.num_workers == num_workers
-    
-
+    assert dataloader.num_workers == 1
     
 

--- a/tests/test_multiprocessing.py
+++ b/tests/test_multiprocessing.py
@@ -1,0 +1,21 @@
+# Ensure that multiprocessing is behaving as expected. 
+from deepforest import main, get_data
+from deepforest import dataset
+import pytest
+import os
+
+@pytest.mark.parametrize("num_workers",[0, 1 ,2])
+def test_predict_tile_workers(m, num_workers):
+    m.config["workers"] == num_workers
+    csv_file = get_data("OSBS_029.csv")
+    # make a dataset
+    ds = dataset.TreeDataset(csv_file=csv_file,
+                                 root_dir=os.path.dirname(csv_file),
+                                 transforms=None,
+                                 train=False)
+    dataloader = m.predict_dataloader(ds)
+    assert dataloader.num_workers == num_workers
+    
+
+    
+

--- a/tests/test_multiprocessing.py
+++ b/tests/test_multiprocessing.py
@@ -6,7 +6,11 @@ import os
 
 @pytest.mark.parametrize("num_workers",[0, 1 ,2])
 def test_predict_tile_workers(m, num_workers):
-    m.config["workers"] == num_workers
+    # Default workers is 0
+    original_workers = m.config["workers"]
+    assert original_workers == 0
+
+    m.config["workers"] = num_workers
     csv_file = get_data("OSBS_029.csv")
     # make a dataset
     ds = dataset.TreeDataset(csv_file=csv_file,


### PR DESCRIPTION
This is in response to #404 where user reports that the workers argument doesn't effect behavior. The original report is focused on the time elapsed. This doesn't necessarily mean something is wrong, there are many times when num_workers doesn't lead to a speedup. However, user reported that they can see the same number of workers being generated in task manager. I'm not yet sure how to assert this, since it happens fast and we don't want to resort to staring at task manager. 

I'm reading here

https://discuss.pytorch.org/t/communicating-with-dataloader-workers/11473/8
https://stackoverflow.com/questions/20353956/get-number-of-workers-from-process-pool-in-python-multiprocessing-module

I propose we start with a reasonably set of tests that assert config arguments and make sure it gets to the worker. Its going to hard to take it further, since at that point its up to torch and way upstream of DeepForest.