### PR TITLE
fixing the deprecation warning in the first two tasks of the issue #625

### DIFF
--- a/deepforest/models/FasterRCNN.py
+++ b/deepforest/models/FasterRCNN.py
@@ -13,8 +13,7 @@ class Model(Model):
 
     def load_backbone(self):
         """A torch vision retinanet model"""
-        backbone = torchvision.models.detection.fasterrcnn_resnet50_fpn(pretrained=True)
-
+        backbone = torchvision.models.detection.fasterrcnn_resnet50_fpn(weights='FasterRCNN_ResNet50_FPN_Weights.COCO_V1')
         return backbone
 
     def create_model(self, backbone=None):
@@ -25,7 +24,7 @@ class Model(Model):
             model: a pytorch nn module
         """
         # load Faster RCNN pre-trained model
-        model = torchvision.models.detection.fasterrcnn_resnet50_fpn(pretrained=True)
+        model = torchvision.models.detection.fasterrcnn_resnet50_fpn(weights='FasterRCNN_ResNet50_FPN_Weights.COCO_V1')
 
         # get the number of input features
         in_features = model.roi_heads.box_predictor.cls_score.in_features


### PR DESCRIPTION
Fixing the first warning 

 `The parameter 'pretrained' is deprecated since 0.13 and may be removed in the future, please use 'weights' instead.`

Fixed the second warning

 `Arguments other than a weight enum or None for 'weights' are deprecated since 0.13 and may be removed in the future. The current behavior is equivalent to passing weights=FasterRCNN_ResNet50_FPN_Weights.COCO_V1. You can also use weights=FasterRCNN_ResNet50_FPN_Weights.DEFAULT to get the most up-to-date weights.`