### PR TITLE
Fixed deprecation warning

### DIFF
--- a/deepforest/main.py
+++ b/deepforest/main.py
@@ -620,7 +620,6 @@ class deepforest(pl.LightningModule):
                                                                mode='min',
                                                                factor=0.1,
                                                                patience=10,
-                                                               verbose=True,
                                                                threshold=0.0001,
                                                                threshold_mode='rel',
                                                                cooldown=0,


### PR DESCRIPTION
Fixes the fifth issue of #625 

Initially, the following error used to occur:
![image](https://github.com/weecology/DeepForest/assets/83624310/bc7c9ed5-cd57-4d13-9ca7-86f65eafdf0f)

This was because of the `verbose` parameter used in the `ReduceLROnPlateau` function used on line 619 in the file `deepforest/main,py`. After removing the `verbose` parameter, the issue was solved. 

![image](https://github.com/weecology/DeepForest/assets/83624310/7e1ed44e-b38d-485e-a921-f50f7a5d5ac8)
