### PR TITLE
Issue #631: Remove the version dependency for setuptools 

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -28,7 +28,7 @@ dependencies:
   - recommonmark
   - rtree
   - slidingwindow
-  - setuptools <59.6.
+  - setuptools
   - sphinx
   - sphinx_rtd_theme
   - torchvision>=0.13


### PR DESCRIPTION
Fixed #631 Remove the version dependency for setuptools from environment.yml, Create a new conda environment using that file, and then check by run the tests in that environment.