### PR TITLE
check for unprojected data when converting points to boxes

### DIFF
--- a/deepforest/utilities.py
+++ b/deepforest/utilities.py
@@ -295,10 +295,11 @@ def shapefile_to_annotations(shapefile,
         resolution = src.res[0]
         raster_crs = src.crs
 
-    # Check matching the crs
-    if not gdf.crs.to_string() == raster_crs.to_string():
-        raise ValueError("The shapefile crs {} does not match the image crs {}".format(
-            gdf.crs, src.crs))
+    if gdf.crs:
+        # Check matching the crs
+        if not gdf.crs.to_string() == raster_crs.to_string():
+            raise ValueError("The shapefile crs {} does not match the image crs {}".format(
+                gdf.crs, src.crs))
 
     # Transform project coordinates to image coordinates
     df["tile_xmin"] = (df.minx - left) / resolution

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -60,7 +60,17 @@ def test_shapefile_to_annotations_convert_to_boxes(tmpdir):
     image_path = get_data("OSBS_029.tif")
     shp = utilities.shapefile_to_annotations(shapefile="{}/annotations.shp".format(tmpdir), rgb=image_path, savedir=tmpdir, geometry_type="point")
     assert shp.shape[0] == 2
-    
+
+def test_shapefile_to_annotations_convert_unprojected_to_boxes(tmpdir):
+    sample_geometry = [geometry.Point(10,20),geometry.Point(20,40)]
+    labels = ["Tree","Tree"]
+    df = pd.DataFrame({"geometry":sample_geometry,"label":labels})
+    gdf = gpd.GeoDataFrame(df, geometry="geometry")
+    gdf.to_file("{}/annotations.shp".format(tmpdir))
+    image_path = get_data("OSBS_029.png")
+    shp = utilities.shapefile_to_annotations(shapefile="{}/annotations.shp".format(tmpdir), rgb=image_path, savedir=tmpdir, geometry_type="point")
+    assert shp.shape[0] == 2
+
 def test_shapefile_to_annotations(tmpdir):
     sample_geometry = [geometry.Point(404211.9 + 10,3285102 + 20),geometry.Point(404211.9 + 20,3285102 + 20)]
     labels = ["Tree","Tree"]


### PR DESCRIPTION
This is a quick fix for users converting points to boxes with unprojected data. I added a test and a simple check for a coordinate reference system. In general this whole logic will be replaced when the large PR (DeepForest 2.0)

https://github.com/weecology/DeepForest/pull/590

closes #643 

 