### PR TITLE
Fix GH Actions tests

### DIFF
--- a/.github/workflows/Conda-app.yml
+++ b/.github/workflows/Conda-app.yml
@@ -47,12 +47,14 @@ jobs:
           cache-environment: true
           cache-downloads: true
 
-      - name: Run pytest, test style, and notebooks
-        run: |
-          pip install -e .
-          pytest -v
-          yapf -d --recursive deepforest/ --style=.style.yapf
-          pytest --nbmake docs/*.ipynb
+      - name: Run pytest
+        run: pytest -v
+
+      - name: Check style
+        run: yapf -d --recursive deepforest/ --style=.style.yapf
+          
+      - name: Check notebook build
+        run: pytest --nbmake docs/*.ipynb
 
       - name: Test Docs
         run: |

--- a/.github/workflows/Conda-app.yml
+++ b/.github/workflows/Conda-app.yml
@@ -33,6 +33,12 @@ jobs:
       - name: "Checkout code"
         uses: "actions/checkout@v4"
 
+      - name: Install opencv dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgl1-mesa-glx libegl1-mesa
+          sudo apt-get install -y python3-opencv
+
       - name: Install Conda environment with Micromamba
         uses: mamba-org/setup-micromamba@v1
         with:

--- a/.github/workflows/Conda-app.yml
+++ b/.github/workflows/Conda-app.yml
@@ -14,7 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.x"
           - "3.12"
           - "3.11"
           - "3.10"
@@ -44,8 +43,8 @@ jobs:
         with:
           environment-name: DeepForest
           environment-file: environment.yml
-          extra-specs: "python=${{ matrix.python-version }}"
-          cache-env: true
+          create-args: "python=${{ matrix.python-version }}"
+          cache-environment: true
           cache-downloads: true
 
       - name: Run pytest, test style, and notebooks

--- a/deepforest/models/FasterRCNN.py
+++ b/deepforest/models/FasterRCNN.py
@@ -13,7 +13,8 @@ class Model(Model):
 
     def load_backbone(self):
         """A torch vision retinanet model"""
-        backbone = torchvision.models.detection.fasterrcnn_resnet50_fpn(weights='FasterRCNN_ResNet50_FPN_Weights.COCO_V1')
+        backbone = torchvision.models.detection.fasterrcnn_resnet50_fpn(
+            weights='FasterRCNN_ResNet50_FPN_Weights.COCO_V1')
         return backbone
 
     def create_model(self, backbone=None):
@@ -24,7 +25,8 @@ class Model(Model):
             model: a pytorch nn module
         """
         # load Faster RCNN pre-trained model
-        model = torchvision.models.detection.fasterrcnn_resnet50_fpn(weights='FasterRCNN_ResNet50_FPN_Weights.COCO_V1')
+        model = torchvision.models.detection.fasterrcnn_resnet50_fpn(
+            weights='FasterRCNN_ResNet50_FPN_Weights.COCO_V1')
 
         # get the number of input features
         in_features = model.roi_heads.box_predictor.cls_score.in_features

--- a/deepforest/preprocess.py
+++ b/deepforest/preprocess.py
@@ -78,15 +78,13 @@ def select_annotations(annotations, windows, index, allow_empty=False):
     offset = 40
     selected_annotations = annotations[(annotations.xmin > (window_xmin - offset)) &
                                        (annotations.xmin < (window_xmax)) &
-                                       (annotations.xmax >
-                                        (window_xmin)) & (annotations.ymin >
-                                                          (window_ymin - offset)) &
+                                       (annotations.xmax > (window_xmin)) &
+                                       (annotations.ymin > (window_ymin - offset)) &
                                        (annotations.xmax < (window_xmax + offset)) &
-                                       (annotations.ymin <
-                                        (window_ymax)) & (annotations.ymax >
-                                                          (window_ymin)) &
-                                       (annotations.ymax <
-                                        (window_ymax + offset))].copy(deep=True)
+                                       (annotations.ymin < (window_ymax)) &
+                                       (annotations.ymax > (window_ymin)) &
+                                       (annotations.ymax < (window_ymax + offset))].copy(
+                                           deep=True)
     # change the image name
     image_basename = os.path.splitext("{}".format(annotations.image_path.unique()[0]))[0]
     selected_annotations.image_path = "{}_{}.png".format(image_basename, index)

--- a/deepforest/utilities.py
+++ b/deepforest/utilities.py
@@ -298,8 +298,9 @@ def shapefile_to_annotations(shapefile,
     if gdf.crs:
         # Check matching the crs
         if not gdf.crs.to_string() == raster_crs.to_string():
-            raise ValueError("The shapefile crs {} does not match the image crs {}".format(
-                gdf.crs, src.crs))
+            raise ValueError(
+                "The shapefile crs {} does not match the image crs {}".format(
+                    gdf.crs, src.crs))
 
     # Transform project coordinates to image coordinates
     df["tile_xmin"] = (df.minx - left) / resolution

--- a/environment.yml
+++ b/environment.yml
@@ -32,6 +32,7 @@ dependencies:
   - sphinx_rtd_theme
   - pytorch::torchvision
   - tqdm
+  - tensorboard
   - twine
   - xmltodict
   - yapf

--- a/environment.yml
+++ b/environment.yml
@@ -17,7 +17,6 @@ dependencies:
   - pandas
   - pillow>6.2.0
   - pip
-  - pycocotools
   - psutil
   - pytest
   - pytest-profiling
@@ -41,4 +40,4 @@ dependencies:
     - imagecodecs
     - albumentations>=1.0.0
     - comet_ml
-
+    - pycocotools

--- a/environment.yml
+++ b/environment.yml
@@ -27,7 +27,7 @@ dependencies:
   - recommonmark
   - rtree
   - slidingwindow
-  - setuptools<=59.2.0
+  - setuptools
   - sphinx
   - sphinx_rtd_theme
   - pytorch::torchvision


### PR DESCRIPTION
This fixes our failing GH Actions tests: 

1. Installs required system files (something in the default build environment must have changed) (Fixes #631) 
2. Updates setup-micromamba usage, which changed upstream
3. Install pycocotools from pip since conda install is failing on Python 3.12
4. Uses separate runs for tests, style, and notebook checks so that failing tests actually result in a failed build (Fixes #651)
5. Fixes some yapf style issues and a missing dependency to get the test passing