### PR TITLE
Remove 'no validation file' warning

### DIFF
--- a/deepforest/main.py
+++ b/deepforest/main.py
@@ -197,7 +197,6 @@ class deepforest(pl.LightningModule):
             num_sanity_val_steps = 2
         else:
             # Disable validation, don't use trainer defaults
-            print("No validation file provided. Turning off validation loop")
             limit_val_batches = 0
             num_sanity_val_steps = 0
         # Check for model checkpoint object


### PR DESCRIPTION
This warning is triggered anytime a model is created and causes confusion for zero-shot users #664.

Closes #664