### PR TITLE
log training loss in pytorch trainer

### DIFF
--- a/deepforest/main.py
+++ b/deepforest/main.py
@@ -537,6 +537,9 @@ class deepforest(pl.LightningModule):
         for key, value in loss_dict.items():
             self.log("train_{}".format(key), value, on_epoch=True)
 
+        # Log sum of losses
+        self.log("train_loss", losses, on_epoch=True)
+        
         return losses
 
     def validation_step(self, batch, batch_idx):

--- a/deepforest/main.py
+++ b/deepforest/main.py
@@ -539,7 +539,7 @@ class deepforest(pl.LightningModule):
 
         # Log sum of losses
         self.log("train_loss", losses, on_epoch=True)
-        
+
         return losses
 
     def validation_step(self, batch, batch_idx):

--- a/deepforest/main.py
+++ b/deepforest/main.py
@@ -533,6 +533,10 @@ class deepforest(pl.LightningModule):
         # sum of regression and classification loss
         losses = sum([loss for loss in loss_dict.values()])
 
+        # Log loss
+        for key, value in loss_dict.items():
+            self.log("train_{}".format(key), value, on_epoch=True)
+
         return losses
 
     def validation_step(self, batch, batch_idx):


### PR DESCRIPTION
With the updates to pytorch lightning 2.0, we appear to no longer to auto log the training loss! This is kinda a big deal, and took me by surprise. 

We previously got the training loss every epoch automatically.

Simple fix is to add self.log within training_step.