### PR TITLE
Modified create_trainer function to allow the arguments take precedence

### DIFF
--- a/deepforest/main.py
+++ b/deepforest/main.py
@@ -206,17 +206,22 @@ class deepforest(pl.LightningModule):
             enable_checkpointing = True
         else:
             enable_checkpointing = False
+        
+        trainer_args = {
+            "logger":logger,
+            "max_epochs":self.config["train"]["epochs"],
+            "enable_checkpointing":enable_checkpointing,
+            "devices":self.config["devices"],
+            "accelerator":self.config["accelerator"],
+            "fast_dev_run":self.config["train"]["fast_dev_run"],
+            "callbacks":callbacks,
+            "limit_val_batches":limit_val_batches,
+            "num_sanity_val_steps":num_sanity_val_steps
+        }
+        # Update with kwargs to allow them to override config
+        trainer_args.update(kwargs)
 
-        self.trainer = pl.Trainer(logger=logger,
-                                  max_epochs=self.config["train"]["epochs"],
-                                  enable_checkpointing=enable_checkpointing,
-                                  devices=self.config["devices"],
-                                  accelerator=self.config["accelerator"],
-                                  fast_dev_run=self.config["train"]["fast_dev_run"],
-                                  callbacks=callbacks,
-                                  limit_val_batches=limit_val_batches,
-                                  num_sanity_val_steps=num_sanity_val_steps,
-                                  **kwargs)
+        self.trainer = pl.Trainer(**trainer_args)
 
     def on_fit_start(self):
         if self.config["train"]["csv_file"] is None:


### PR DESCRIPTION
Fixes issue #676 

I have modified the `create_trainer()` function in the main.py file to allow the arguments specified by the user to take precedence over the config values. I have created a dictionary `trainer_args` which contains all the parameters required for the `pl.Trainer` initialization and then updated it with the values from the kwargs. 

![image](https://github.com/weecology/DeepForest/assets/83624310/088b9582-03cf-44dd-9b1c-25a6dfd872c3)
