### PR TITLE
raise error on wgs84 boxes for shapefile to annotation see issue #694

### DIFF
--- a/deepforest/utilities.py
+++ b/deepforest/utilities.py
@@ -298,6 +298,11 @@ def shapefile_to_annotations(shapefile,
         raster_crs = src.crs
 
     if gdf.crs:
+        # If epsg is 4326, then the buffer size is in degrees, not meters, see https://github.com/weecology/DeepForest/issues/694
+        if gdf.crs.to_string() == "EPSG:4326":
+            raise ValueError(
+                "The shapefile crs is in degrees. This function works for UTM and meter based crs only. see https://github.com/weecology/DeepForest/issues/694")
+
         # Check matching the crs
         if not gdf.crs.to_string() == raster_crs.to_string():
             raise ValueError(

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -75,6 +75,17 @@ def test_shapefile_to_annotations_convert_unprojected_to_boxes(tmpdir):
     shp = utilities.shapefile_to_annotations(shapefile="{}/annotations.shp".format(tmpdir), rgb=image_path, savedir=tmpdir, geometry_type="point")
     assert shp.shape[0] == 2
 
+def test_shapefile_to_annotations_invalid_epsg(tmpdir):
+    sample_geometry = [geometry.Point(404211.9 + 10, 3285102 + 20), geometry.Point(404211.9 + 20, 3285102 + 20)]
+    labels = ["Tree", "Tree"]
+    df = pd.DataFrame({"geometry": sample_geometry, "label": labels})
+    gdf = gpd.GeoDataFrame(df, geometry="geometry", crs="EPSG:4326")
+    gdf.to_file("{}/annotations.shp".format(tmpdir))
+    assert gdf.crs.to_string() == "EPSG:4326"
+    image_path = get_data("OSBS_029.tif")
+    with pytest.raises(ValueError):
+        shp = utilities.shapefile_to_annotations(shapefile="{}/annotations.shp".format(tmpdir), rgb=image_path, savedir=tmpdir, geometry_type="bbox")
+        
 def test_shapefile_to_annotations(tmpdir):
     sample_geometry = [geometry.Point(404211.9 + 10,3285102 + 20),geometry.Point(404211.9 + 20,3285102 + 20)]
     labels = ["Tree","Tree"]


### PR DESCRIPTION
This is a short term fix given the importance of silently misprojecting boxes that are WGS84, see #694. This raises an error and provides a workaround.