### PR TITLE
Disable advice warnings from PyTorch

### DIFF
--- a/deepforest/__init__.py
+++ b/deepforest/__init__.py
@@ -5,8 +5,12 @@ __email__ = 'ben.weinstein@weecology.org'
 __version__ = '1.3.3'
 
 import os
+from pytorch_lightning.utilities import disable_possible_user_warnings
 
 _ROOT = os.path.abspath(os.path.dirname(__file__))
+
+# Disable PyTorch warnings that confuse users
+disable_possible_user_warnings()
 
 
 def get_data(path):


### PR DESCRIPTION
There are a number of warnings in PyTorch that represent advice for
improving model, data loader, and training decisions. However these
warnings are confusing to end users and often aren't clearly relevant
even for advanced users. As a result, PyTorch supports disabling these
class of warnings, PossibleUserWarnings.

See:
https://lightning.ai/docs/pytorch/2.4.0/advanced/warnings.html
https://github.com/Lightning-AI/pytorch-lightning/issues/10644

This change follows the recommended approach to hide these warnings
from users.
