### PR TITLE
Cleanup deprecation and other warnings

### DIFF
--- a/deepforest/main.py
+++ b/deepforest/main.py
@@ -135,7 +135,7 @@ class deepforest(pl.LightningModule):
                 .format(self.config["architecture"]))
             self.config["architecture"] = "retinanet"
             self.create_model()
-        self.model.load_state_dict(torch.load(self.release_state_dict))
+        self.model.load_state_dict(torch.load(self.release_state_dict, weights_only=True))
 
         # load saved model and tag release
         self.__release_version__ = release_tag
@@ -153,7 +153,7 @@ class deepforest(pl.LightningModule):
         # Download latest model from github release
         release_tag, self.release_state_dict = utilities.use_bird_release(
             check_release=check_release)
-        self.model.load_state_dict(torch.load(self.release_state_dict))
+        self.model.load_state_dict(torch.load(self.release_state_dict, weights_only=True))
 
         # load saved model and tag release
         self.__release_version__ = release_tag

--- a/deepforest/model.py
+++ b/deepforest/model.py
@@ -71,7 +71,7 @@ class Model():
 
 
 def simple_resnet_50(num_classes=2):
-    m = models.resnet50(pretrained=True)
+    m = models.resnet50(weights=models.ResNet50_Weights.DEFAULT)
     num_ftrs = m.fc.in_features
     m.fc = torch.nn.Linear(num_ftrs, num_classes)
 

--- a/deepforest/model.py
+++ b/deepforest/model.py
@@ -240,7 +240,6 @@ class CropModel(LightningModule):
                                                                mode='min',
                                                                factor=0.5,
                                                                patience=10,
-                                                               verbose=True,
                                                                threshold=0.0001,
                                                                threshold_mode='rel',
                                                                cooldown=0,

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,4 @@
 [pytest]
 filterwarnings =
-    ignore:The number of training batches \(1\) is smaller than the logging interval
-    ignore:The dataloader, train_dataloader, does not have many workers which may be a bottleneck
-    ignore:The dataloader, val_dataloader, does not have many workers which may be a bottleneck
-    ignore:The dataloader, predict_dataloader, does not have many workers which may be a bottleneck
+    ignore::pytorch_lightning.utilities.warnings.PossibleUserWarning
+

--- a/tests/test_FasterRCNN.py
+++ b/tests/test_FasterRCNN.py
@@ -25,14 +25,14 @@ def _make_empty_sample():
 def test_retinanet(config):
     r = FasterRCNN.Model(config)
 
-    return r
+    assert r
 
 def test_load_backbone(config):
     r = FasterRCNN.Model(config)
     resnet_backbone = r.load_backbone()
     resnet_backbone.eval()
     x = [torch.rand(3, 300, 400), torch.rand(3, 500, 400)]
-    prediction = resnet_backbone(x)    
+    prediction = resnet_backbone(x)
 
 # This test still fails, do we want a way to pass kwargs directly to method, instead of being limited by config structure?
 # Need to create issue when I get online.
@@ -42,7 +42,7 @@ def test_create_model(config, num_classes):
     retinanet_model = FasterRCNN.Model(config).create_model()
     retinanet_model.eval()
     x = [torch.rand(3, 300, 400), torch.rand(3, 500, 400)]
-    predictions = retinanet_model(x)    
+    predictions = retinanet_model(x)
 
 def test_forward_empty(config):
     r = FasterRCNN.Model(config)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -28,7 +28,7 @@ from .conftest import download_release
 
 @pytest.fixture()
 def two_class_m():
-    m = main.deepforest(num_classes=2,label_dict={"Alive":0,"Dead":1})
+    m = main.deepforest(config_args={"num_classes":2}, label_dict={"Alive":0,"Dead":1})
     m.config["train"]["csv_file"] = get_data("testfile_multi.csv") 
     m.config["train"]["root_dir"] = os.path.dirname(get_data("testfile_multi.csv"))
     m.config["train"]["fast_dev_run"] = True

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -208,7 +208,9 @@ def test_predict_image_fromarray(m):
         prediction = m.predict_image(image = image)
             
     image = np.array(Image.open(image_path).convert("RGB"))
-    prediction = m.predict_image(image = image)    
+    with pytest.warns(UserWarning, match="Image type is uint8, transforming to float32"):
+        prediction = m.predict_image(image = image)    
+    
     assert isinstance(prediction, pd.DataFrame)
     assert set(prediction.columns) == {"xmin","ymin","xmax","ymax","label","score"}
 
@@ -393,10 +395,10 @@ def test_reload_multi_class(two_class_m, tmpdir):
     before = two_class_m.trainer.validate(two_class_m)
     
     # reload
-    old_model = main.deepforest.load_from_checkpoint("{}/checkpoint.pl".format(tmpdir))
+    old_model = main.deepforest.load_from_checkpoint("{}/checkpoint.pl".format(tmpdir), weights_only=True)
     old_model.config = two_class_m.config
     assert old_model.config["num_classes"] == 2
-    old_model.create_trainer()    
+    old_model.create_trainer()
     after = old_model.trainer.validate(old_model)
 
     assert after[0]["val_classification"] == before[0]["val_classification"]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -377,7 +377,7 @@ def test_save_and_reload_weights(m, tmpdir):
 
     # reload the checkpoint to model object
     after = main.deepforest()
-    after.model.load_state_dict(torch.load("{}/checkpoint.pt".format(tmpdir)))
+    after.model.load_state_dict(torch.load("{}/checkpoint.pt".format(tmpdir), weights_only=True))
     pred_after_reload = after.predict_image(path=img_path)
 
     assert not pred_after_train.empty

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -79,7 +79,7 @@ def test_split_raster(config, tmpdir, input_type, geodataframe):
 
     output_annotations = preprocess.split_raster(path_to_raster=get_data("OSBS_029.tif"),
                                                  annotations_file=annotations_file,
-                                                 base_dir=tmpdir,
+                                                 save_dir=tmpdir,
                                                  patch_size=300,
                                                  patch_overlap=0)
 
@@ -93,7 +93,7 @@ def test_split_raster_no_annotations(config, tmpdir):
 
     output_crops = preprocess.split_raster(path_to_raster=raster,
                                            annotations_file=None,
-                                           base_dir=tmpdir,
+                                           save_dir=tmpdir,
                                            patch_size=500,
                                            patch_overlap=0)
 
@@ -138,7 +138,7 @@ def test_split_raster_empty(tmpdir, config, allow_empty):
             annotations_file = preprocess.split_raster(
                 path_to_raster=config["path_to_raster"],
                 annotations_file=tmpdir.join("blank_annotations.csv").strpath,
-                base_dir=tmpdir,
+                save_dir=tmpdir,
                 patch_size=config["patch_size"],
                 patch_overlap=config["patch_overlap"],
                 allow_empty=allow_empty)
@@ -146,7 +146,7 @@ def test_split_raster_empty(tmpdir, config, allow_empty):
             annotations_file = preprocess.split_raster(
                 path_to_raster=config["path_to_raster"],
                 annotations_file=tmpdir.join("blank_annotations.csv").strpath,
-                base_dir=tmpdir,
+                save_dir=tmpdir,
                 patch_size=config["patch_size"],
                 patch_overlap=config["patch_overlap"],
                 allow_empty=allow_empty)
@@ -158,7 +158,7 @@ def test_split_size_error(config, tmpdir, geodataframe):
         annotations_file = preprocess.split_raster(
             path_to_raster=config["path_to_raster"],
             annotations_file=geodataframe,
-            base_dir=tmpdir,
+            save_dir=tmpdir,
             patch_size=2000,
             patch_overlap=config["patch_overlap"])
 

--- a/tests/test_retinanet.py
+++ b/tests/test_retinanet.py
@@ -27,8 +27,7 @@ def _make_empty_sample():
 
 def test_retinanet(config):
     r = retinanet.Model(config)
-
-    return r
+    assert r
 
 def test_load_backbone(config):
     r = retinanet.Model(config)

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -43,7 +43,8 @@ def test_use_bird_release(download_release):
 def test_float_warning(config):
     """Users should get a rounding warning when adding annotations with floats"""
     float_annotations = "tests/data/float_annotations.txt"
-    annotations = utilities.read_pascal_voc(float_annotations)
+    with pytest.warns(UserWarning, match="Annotations file contained non-integer coordinates"):
+        annotations = utilities.read_pascal_voc(float_annotations)
     assert annotations.xmin.dtype is np.dtype('int64')
 
     


### PR DESCRIPTION
Our current test suite produces a lot of warnings. This is a combination of test
specific warnings (e.g., tests not keeping up with our API changes), deprecation
type warnings from packages we use, upstream warnings, and usage warnings
from PyTorch. These warnings clutter the test logs and indicated upcoming
changes that we need to adjust to.

This PR pays down some of our warnings dept, reducing the total number of
warnings from 339 to 195 by:

* Using `weights_only=True` when loading models (the future default behavior)
* Improving how we suppress PyTorch usage recommendations
* Updating use of our own API in the tests
* Properly handing tests of warnings so that correct warnings just pass
* Handling some minor upstream API changes