### PR TITLE
Fixed issue related to the bounding box coordinates

### DIFF
--- a/deepforest/preprocess.py
+++ b/deepforest/preprocess.py
@@ -91,6 +91,13 @@ def select_annotations(annotations, window):
 
     clipped_annotations.geometry = clipped_annotations.geometry.translate(
         xoff=-window_xmin, yoff=-window_ymin)
+    
+    # Update xmin, ymin, xmax, ymax based on the clipped annotations' geometry
+    if clipped_annotations.shape[0] > 0:
+      clipped_annotations['xmin'] = clipped_annotations.geometry.bounds.minx
+      clipped_annotations['ymin'] = clipped_annotations.geometry.bounds.miny
+      clipped_annotations['xmax'] = clipped_annotations.geometry.bounds.maxx
+      clipped_annotations['ymax'] = clipped_annotations.geometry.bounds.maxy
 
     return clipped_annotations
 


### PR DESCRIPTION
There is a problem with the `split_raster` function, it doesn't adjust the bounding boxes to the dimensions of the cropped image, and it creates a separate `geometry` column. And thus there are 7 columns instead of 6 columns and so the following assertion mentioned in the documentation fails:

![Screenshot from 2024-08-13 23-14-36](https://github.com/user-attachments/assets/2391f970-502b-4363-bbb4-fc0754251256)

So I have modified the `select_annotations` function in the `deepforest/preprocess.py` file and added the following lines:
```python
if clipped_annotations.shape[0] > 0:
      clipped_annotations['xmin'] = clipped_annotations.geometry.bounds.minx
      clipped_annotations['ymin'] = clipped_annotations.geometry.bounds.miny
      clipped_annotations['xmax'] = clipped_annotations.geometry.bounds.maxx
      clipped_annotations['ymax'] = clipped_annotations.geometry.bounds.maxy
```
which replaces the `xmin`, `ymin`, `xmax`, `ymax` with the correct coordinates.