### PR TITLE
Dev requirements should not pin pytorch lightning or have a pinned version of docutils

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.7"
+    python: "3.10"
 
 python:
   install:

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -4,7 +4,6 @@ aiohttp
 bumpversion
 comet_ml
 docformatter
-docutils<0.18
 furo
 geopandas
 huggingface_hub
@@ -25,7 +24,7 @@ pycocotools
 Pygments
 pytest
 pytest-profiling
-pytorch-lightning>2.0.0
+pytorch-lightning
 pyyaml>=5.1.0
 rasterio
 recommonmark

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -25,7 +25,7 @@ pycocotools
 Pygments
 pytest
 pytest-profiling
-pytorch-lightning>=1.5.8
+pytorch-lightning>2.0.0
 pyyaml>=5.1.0
 rasterio
 recommonmark


### PR DESCRIPTION
I believe this issue will solve #751, we need to allow it to build to be sure. readthedocs was using some old cached version because the pinned allowed it.