### PR TITLE
Use primary API for huggingface_hub errors

### DIFF
--- a/deepforest/utilities.py
+++ b/deepforest/utilities.py
@@ -11,7 +11,6 @@ from tqdm import tqdm
 
 from PIL import Image
 from deepforest import _ROOT
-import json
 import warnings
 import geopandas as gpd
 import rasterio

--- a/deepforest/utilities.py
+++ b/deepforest/utilities.py
@@ -20,7 +20,7 @@ from deepforest import _ROOT
 import json
 import urllib.request
 from huggingface_hub import hf_hub_download
-from huggingface_hub.utils._errors import RevisionNotFoundError, HfHubHTTPError
+from huggingface_hub.errors import RevisionNotFoundError, HfHubHTTPError
 
 
 def read_config(config_path):


### PR DESCRIPTION
We had been using `huggingface_hub.utils._errors`, but this seems to have broken in 0.25 (see Azure builds). This switches to the public `errors` module which is likely to be more robust.