### PR TITLE
Add test and fix to return None and avoid read_file error

### DIFF
--- a/deepforest/main.py
+++ b/deepforest/main.py
@@ -589,7 +589,7 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
         if results.empty:
             warnings.warn("No predictions made, returning None")
             return None
-        
+
         results = utilities.read_file(results)
 
         if raster_path is None:

--- a/deepforest/main.py
+++ b/deepforest/main.py
@@ -505,6 +505,7 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
         Returns:
             boxes (array): if return_plot, an image.
             Otherwise a numpy array of predicted bounding boxes, scores and labels
+            If no predictions are made, returns None
         """
         self.model.eval()
         self.model.nms_thresh = self.config["nms_thresh"]
@@ -585,7 +586,10 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
                                                    trainer=self.trainer,
                                                    transform=crop_transform,
                                                    augment=crop_augment)
-
+        if results.empty:
+            warnings.warn("No predictions made, returning None")
+            return None
+        
         results = utilities.read_file(results)
 
         if raster_path is None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -263,6 +263,12 @@ def test_predict_dataloader(m, batch_size, raster_path):
     batch.shape[0] == batch_size
 
 
+def test_predict_tile_empty(raster_path):
+    # Random weights
+    m = main.deepforest()
+    predictions = m.predict_tile(raster_path=raster_path, patch_size=300, patch_overlap=0)
+    assert predictions is None
+
 def test_predict_tile(m, raster_path):
     m.create_model()
     m.config["train"]["fast_dev_run"] = False


### PR DESCRIPTION
If you have a broken model and go to make a prediction, you get an error, which feels incorrect, you want to get None. Added a test and functionality. 

Closes https://github.com/weecology/DeepForest/issues/794