### PR TITLE
load_model should not return anything

### DIFF
--- a/deepforest/main.py
+++ b/deepforest/main.py
@@ -149,8 +149,6 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
             self.label_dict = {"Bird": 0}
             self.numeric_to_label_dict = {v: k for k, v in self.label_dict.items()}
 
-        return self
-
     def use_release(self, check_release=True):
         """Use the latest DeepForest model release from github and load model.
         Optionally download if release doesn't exist.

--- a/deepforest/main.py
+++ b/deepforest/main.py
@@ -135,7 +135,7 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
             revision (str): The model version ('main', 'v1.0.0', etc.).
 
         Returns:
-            self (object):A trained PyTorch model with its config and weights.
+            None
         """
         # Load the model using from_pretrained
         self.create_model()


### PR DESCRIPTION
Keeping the behavior with load_model and use_release, there isn't a use case where a user would capture the output of load_model

```
from deepforest import main
m = main.deepforest()
m.load_model("weecology/deepforest-tree")
```
it should not return self.