### PR TITLE
Add dummy scores if just plotting annotations

### DIFF
--- a/deepforest/visualize.py
+++ b/deepforest/visualize.py
@@ -314,7 +314,7 @@ def convert_to_sv_format(df, width=None, height=None):
             scores = np.array(df['score'].tolist())
         except KeyError:
             scores = np.ones(len(labels))
-            
+
         # Create a reverse mapping from integer to string labels
         class_name = {v: k for k, v in label_mapping.items()}
 

--- a/deepforest/visualize.py
+++ b/deepforest/visualize.py
@@ -310,7 +310,11 @@ def convert_to_sv_format(df, width=None, height=None):
         labels = df['label'].map(label_mapping).values.astype(int)
 
         # Extract scores as a numpy array
-        scores = np.array(df['score'].tolist())
+        try:
+            scores = np.array(df['score'].tolist())
+        except KeyError:
+            scores = np.ones(len(labels))
+            
         # Create a reverse mapping from integer to string labels
         class_name = {v: k for k, v in label_mapping.items()}
 


### PR DESCRIPTION
plot_results is also useful for plotting annotations. Sometimes I worry that we should have named it something more general. When you use it to plot annotations, you don't yet have scores, and there isn't any reason you need them. Just add a except for this case and add a dummy score.

```
split_files = split_raster(df, path_to_raster="/orange/ewhite/DeepForest/Araujo_2020/Orthomosaic_WGS84_UTM20S.tif", root_dir="/orange/ewhite/DeepForest/Araujo_2020/",
                           base_dir="/orange/ewhite/DeepForest/Araujo_2020/crops/", patch_size=2000, patch_overlap=0)

for image in split_files.image_path.unique():
    image_df = split_files[split_files.image_path==image]
    image_df.root_dir = "/orange/ewhite/DeepForest/Araujo_2020/crops/"
    plot_results(image_df)
```
