### PR TITLE
Refactor evaluation loop for empty frames

### DIFF
--- a/docs/user_guide/12_evaluation.md
+++ b/docs/user_guide/12_evaluation.md
@@ -28,6 +28,10 @@ There is an additional difference between ecological object detection methods li
 
 DeepForest uses the [hungarian matching algorithm](https://thinkautonomous.medium.com/computer-vision-for-tracking-8220759eee85) to assign predictions to ground truth based on maximum IoU overlap. This is slow compared to the methods above, and so isn't a good choice for running hundreds of times during model training see config["validation"]["val_accuracy_interval"] for setting the frequency of the evaluate callback for this metric.
 
+### Empty Frame Accuracy
+
+DeepForest allows the user to pass empty frames to evaluation by setting xmin, ymin, xmax, ymax to 0. This is useful for evaluating models on data that has empty frames. The empty frame accuracy is the proportion of empty frames that are contain no predictions. The 'label' column in this case is ignored, but must be one of the labels in the model to be included in the evaluation.
+
 # Calculating Evaluation Metrics 
 
 ## Torchmetrics and loss scores

--- a/src/deepforest/main.py
+++ b/src/deepforest/main.py
@@ -36,7 +36,6 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
 
     Returns:
         self: a deepforest pytorch lightning module
-
     """
 
     def __init__(self,
@@ -143,7 +142,6 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
 
         Returns:
             None
-
         """
         # Load the model using from_pretrained
         self.create_model()
@@ -196,7 +194,6 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
 
         Returns:
             None
-
         """
         if self.model is None:
             model_name = importlib.import_module("deepforest.models.{}".format(
@@ -213,7 +210,6 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
 
         Returns:
             None
-
         """
         # If val data is passed, monitor learning rate and setup classification metrics
         if not self.config["validation"]["csv_file"] is None:
@@ -362,7 +358,7 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
                       thickness: int = 1):
         """Predict a single image with a deepforest model.
 
-        Deprecation warning: The 'return_plot', and related 'color' and 'thickness' arguments 
+        Deprecation warning: The 'return_plot', and related 'color' and 'thickness' arguments
         are deprecated and will be removed in 2.0. Use visualize.plot_results on the result instead.
 
         Args:
@@ -375,7 +371,6 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
         Returns:
             result: A pandas dataframe of predictions (Default)
             img: The input with predictions overlaid (Optional)
-
         """
 
         # Ensure we are in eval mode
@@ -514,7 +509,6 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
 
         Returns:
             pd.DataFrame or tuple: Predictions dataframe or (predictions, crops) tuple
-
         """
         self.model.eval()
         self.model.nms_thresh = self.config["nms_thresh"]
@@ -719,7 +713,6 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
             float or None: Accuracy score for empty frame detection. A score of 1.0 means the model correctly
                 identified all empty frames (no false positives), while 0.0 means it predicted objects
                 in all empty frames (all false positives). Returns None if there are no empty frames.
-
         """
         # Find images that are marked as empty in ground truth (all coordinates are 0)
         empty_images = ground_df.loc[(ground_df.xmin == 0) & (ground_df.ymin == 0) &
@@ -949,7 +942,8 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
             return optimizer
 
     def evaluate(self, csv_file, root_dir, iou_threshold=None, savedir=None):
-        """Compute intersection-over-union and precision/recall for a given iou_threshold.
+        """Compute intersection-over-union and precision/recall for a given
+        iou_threshold.
 
         Args:
             csv_file: location of a csv file with columns "name","xmin","ymin","xmax","ymax","label"
@@ -959,7 +953,6 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
 
         Returns:
             dict: Results dictionary containing precision, recall and other metrics
-
         """
         ground_df = utilities.read_file(csv_file)
         ground_df["label"] = ground_df.label.apply(lambda x: self.label_dict[x])

--- a/src/deepforest/main.py
+++ b/src/deepforest/main.py
@@ -803,9 +803,9 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
                 self.log("empty_frame_accuracy", empty_accuracy)
             except:
                 pass
-        else:      
-            empty_accuracy = None
-
+            
+            # Remove empty predictions from the rest of the evaluation
+            self.predictions_df = self.predictions_df.loc[self.predictions_df.xmin.notnull()]
             if self.predictions_df.empty:
                 warnings.warn("No predictions made, skipping detection evaluation")
                 geom_type = utilities.determine_geometry_type(ground_df)

--- a/src/deepforest/main.py
+++ b/src/deepforest/main.py
@@ -799,10 +799,11 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
             # If there are empty frames, evaluate empty frame accuracy separately
             empty_accuracy = self.calculate_empty_frame_accuracy(ground_df, self.predictions_df)
             
-            try:
-                self.log("empty_frame_accuracy", empty_accuracy)
-            except:
-                pass
+            if empty_accuracy is not None:
+                try:
+                    self.log("empty_frame_accuracy", empty_accuracy)
+                except:
+                        pass
             
             # Remove empty predictions from the rest of the evaluation
             self.predictions_df = self.predictions_df.loc[self.predictions_df.xmin.notnull()]

--- a/src/deepforest/main.py
+++ b/src/deepforest/main.py
@@ -702,7 +702,7 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
         self.predictions = []
 
     def on_validation_epoch_end(self):
-        """Compute metrics"""
+        """Compute metrics."""
 
         output = self.iou_metric.compute()
         try:

--- a/src/deepforest/main.py
+++ b/src/deepforest/main.py
@@ -28,12 +28,12 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
     Args:
         num_classes (int): number of classes in the model
         config_file (str): path to deepforest config file
-        model (model.Model()): a deepforest model object, see model.Model().
-        config_args (dict): a dictionary of key->value to update
-        config file at run time. e.g. {"batch_size":10}
-        This is useful for iterating over arguments during model testing.
-            existing_train_dataloader: a Pytorch dataloader that yields a tuple path, images, targets
-            existing_val_dataloader: a Pytorch dataloader that yields a tuple path, images, targets
+        model (model.Model()): a deepforest model object, see model.Model()
+        config_args (dict): a dictionary of key->value to update config file at run time. 
+            e.g. {"batch_size":10}. This is useful for iterating over arguments during model testing.
+        existing_train_dataloader: a Pytorch dataloader that yields a tuple path, images, targets
+        existing_val_dataloader: a Pytorch dataloader that yields a tuple path, images, targets
+
     Returns:
         self: a deepforest pytorch lightning module
     """

--- a/src/deepforest/main.py
+++ b/src/deepforest/main.py
@@ -23,7 +23,20 @@ from huggingface_hub import PyTorchModelHubMixin
 
 
 class deepforest(pl.LightningModule, PyTorchModelHubMixin):
-    """Class for training and predicting tree crowns in RGB images."""
+    """Class for training and predicting tree crowns in RGB images.
+    
+    Args:
+        num_classes (int): number of classes in the model
+        config_file (str): path to deepforest config file
+        model (model.Model()): a deepforest model object, see model.Model().
+        config_args (dict): a dictionary of key->value to update
+        config file at run time. e.g. {"batch_size":10}
+        This is useful for iterating over arguments during model testing.
+            existing_train_dataloader: a Pytorch dataloader that yields a tuple path, images, targets
+            existing_val_dataloader: a Pytorch dataloader that yields a tuple path, images, targets
+    Returns:
+        self: a deepforest pytorch lightning module
+    """
 
     def __init__(self,
                  num_classes: int = 1,
@@ -34,18 +47,7 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
                  model=None,
                  existing_train_dataloader=None,
                  existing_val_dataloader=None):
-        """Args:
-            num_classes (int): number of classes in the model
-            config_file (str): path to deepforest config file
-            model (model.Model()): a deepforest model object, see model.Model().
-            config_args (dict): a dictionary of key->value to update
-            config file at run time. e.g. {"batch_size":10}
-            This is useful for iterating over arguments during model testing.
-            existing_train_dataloader: a Pytorch dataloader that yields a tuple path, images, targets
-            existing_val_dataloader: a Pytorch dataloader that yields a tuple path, images, targets
-        Returns:
-            self: a deepforest pytorch lightning module
-        """
+
         super().__init__()
 
         # Read config file. Defaults to deepforest_config.yml in working directory.

--- a/src/deepforest/main.py
+++ b/src/deepforest/main.py
@@ -24,7 +24,7 @@ from huggingface_hub import PyTorchModelHubMixin
 
 class deepforest(pl.LightningModule, PyTorchModelHubMixin):
     """Class for training and predicting tree crowns in RGB images.
-    
+
     Args:
         num_classes (int): number of classes in the model
         config_file (str): path to deepforest config file

--- a/src/deepforest/main.py
+++ b/src/deepforest/main.py
@@ -834,6 +834,9 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
                                         row["precision"])
                                 except MisconfigurationException:
                                     pass
+                        elif key in ["predictions", "results"]:
+                            # Don't log dataframes of predictions or IoU results per epoch
+                            pass
                         else:
                             try:
                                 self.log(key, value)

--- a/src/deepforest/main.py
+++ b/src/deepforest/main.py
@@ -29,7 +29,7 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
         num_classes (int): number of classes in the model
         config_file (str): path to deepforest config file
         model (model.Model()): a deepforest model object, see model.Model()
-        config_args (dict): a dictionary of key->value to update config file at run time. 
+        config_args (dict): a dictionary of key->value to update config file at run time.
             e.g. {"batch_size":10}. This is useful for iterating over arguments during model testing.
         existing_train_dataloader: a Pytorch dataloader that yields a tuple path, images, targets
         existing_val_dataloader: a Pytorch dataloader that yields a tuple path, images, targets

--- a/src/deepforest/main.py
+++ b/src/deepforest/main.py
@@ -20,6 +20,7 @@ from deepforest import dataset, visualize, get_data, utilities, predict
 from deepforest import evaluate as evaluate_iou
 
 from huggingface_hub import PyTorchModelHubMixin
+from lightning_fabric.utilities.exceptions import MisconfigurationException
 
 
 class deepforest(pl.LightningModule, PyTorchModelHubMixin):
@@ -674,7 +675,7 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
         for key, value in loss_dict.items():
             try:
                 self.log("val_{}".format(key), value, on_epoch=True)
-            except:
+            except MisconfigurationException:
                 pass
 
         for index, result in enumerate(preds):
@@ -761,7 +762,7 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
         output = {key: value for key, value in output.items() if not key == "classes"}
         try:
             self.log_dict(output)
-        except:
+        except MisconfigurationException:
             pass
         self.mAP_metric.reset()
 
@@ -831,12 +832,12 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
                                         "{}_Precision".format(
                                             self.numeric_to_label_dict[row["label"]]),
                                         row["precision"])
-                                except:
+                                except MisconfigurationException:
                                     pass
                         else:
                             try:
                                 self.log(key, value)
-                            except:
+                            except MisconfigurationException:
                                 pass
 
     def predict_step(self, batch, batch_idx):

--- a/src/deepforest/main.py
+++ b/src/deepforest/main.py
@@ -816,6 +816,13 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
                         "class_recall": pd.DataFrame()
                     }
             else:
+                # Remove empty ground truth
+                ground_df = ground_df.loc[~ground_df.xmin==0]
+                if ground_df.empty:
+                    results = {}
+                    results["empty_frame_accuracy"] = empty_accuracy
+                    return results
+                
                 results = evaluate_iou.__evaluate_wrapper__(
                     predictions=self.predictions_df,
                     ground_df=ground_df,

--- a/src/deepforest/main.py
+++ b/src/deepforest/main.py
@@ -818,7 +818,7 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
                     }
             else:
                 # Remove empty ground truth
-                ground_df = ground_df.loc[~ground_df.xmin==0]
+                ground_df = ground_df.loc[~(ground_df.xmin==0)]
                 if ground_df.empty:
                     results = {}
                     results["empty_frame_accuracy"] = empty_accuracy

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -701,12 +701,107 @@ def test_predict_tile_with_crop_model_empty():
     # Assert the result
     assert result is None
 
-def test_evaluate_on_epoch_interval(m):
-    m.config["val_accuracy_interval"] = 1
-    m.config["train"]["epochs"] = 1
-    m.trainer.fit(m)
-    assert m.trainer.logged_metrics["box_precision"]
-    assert m.trainer.logged_metrics["box_recall"]
+# @pytest.mark.parametrize("batch_size", [1, 4, 8])
+# def test_batch_prediction(m, batch_size, raster_path):
+#    
+#     # Prepare input data
+#     tile = np.array(Image.open(raster_path))
+#     ds = dataset.TileDataset(tile=tile, patch_overlap=0.1, patch_size=100)
+#     dl = DataLoader(ds, batch_size=batch_size)
+    
+#     # Perform prediction
+#     predictions = []
+#     for batch in dl:
+#         prediction = m.predict_batch(batch)
+#         predictions.append(prediction)
+    
+#     # Check results
+#     assert len(predictions) == len(dl)
+#     for batch_pred in predictions:
+#         assert isinstance(batch_pred, pd.DataFrame)
+#         assert set(batch_pred.columns) == {
+#             "xmin", "ymin", "xmax", "ymax", "label", "score", "geometry"
+#         }
+
+# @pytest.mark.parametrize("batch_size", [1, 4])
+# def test_batch_training(m, batch_size, tmpdir):
+#     
+#     # Generate synthetic training data
+#     csv_file = get_data("example.csv")
+#     root_dir = os.path.dirname(csv_file)
+#     train_ds = m.load_dataset(csv_file, root_dir=root_dir)
+#     train_dl = DataLoader(train_ds, batch_size=batch_size, shuffle=True)
+    
+#     # Configure the model and trainer
+#     m.config["batch_size"] = batch_size
+#     m.create_trainer()
+#     trainer = m.trainer
+    
+#     # Train the model
+#     trainer.fit(m, train_dl)
+    
+#     # Assertions
+#     assert trainer.current_epoch == 1
+#     assert trainer.batch_size == batch_size
+
+# @pytest.mark.parametrize("batch_size", [2, 4])
+# def test_batch_data_augmentation(m, batch_size, raster_path):
+#     
+#     tile = np.array(Image.open(raster_path))
+#     ds = dataset.TileDataset(tile=tile, patch_overlap=0.1, patch_size=100, augment=True)
+#     dl = DataLoader(ds, batch_size=batch_size)
+    
+#     predictions = []
+#     for batch in dl:
+#         prediction = m.predict_batch(batch)
+#         predictions.append(prediction)
+    
+#     assert len(predictions) == len(dl)
+#     for batch_pred in predictions:
+#         assert isinstance(batch_pred, pd.DataFrame)
+#         assert set(batch_pred.columns) == {
+#             "xmin", "ymin", "xmax", "ymax", "label", "score", "geometry"
+#         }
+
+# def test_batch_inference_consistency(m, raster_path):
+#     
+#     tile = np.array(Image.open(raster_path))
+#     ds = dataset.TileDataset(tile=tile, patch_overlap=0.1, patch_size=100)
+#     dl = DataLoader(ds, batch_size=4)
+    
+#     batch_predictions = []
+#     for batch in dl:
+#         prediction = m.predict_batch(batch)
+#         batch_predictions.append(prediction)
+    
+#     single_predictions = []
+#     for image in ds:
+#         prediction = m.predict_image(image=image)
+#         single_predictions.append(prediction)
+    
+#     batch_df = pd.concat(batch_predictions, ignore_index=True)
+#     single_df = pd.concat(single_predictions, ignore_index=True)
+    
+#     pd.testing.assert_frame_equal(batch_df, single_df)
+
+# def test_large_batch_handling(m, raster_path):
+#    
+#     tile = np.array(Image.open(raster_path))
+#     ds = dataset.TileDataset(tile=tile, patch_overlap=0.1, patch_size=100)
+#     dl = DataLoader(ds, batch_size=16)
+    
+#     predictions = []
+#     for batch in dl:
+#         prediction = m.predict_batch(batch)
+#         predictions.append(prediction)
+    
+#     assert len(predictions) > 0
+#     for batch_pred in predictions:
+#         assert isinstance(batch_pred, pd.DataFrame)
+#         assert set(batch_pred.columns) == {
+#             "xmin", "ymin", "xmax", "ymax", "label", "score", "geometry"
+#         }
+#         assert not batch_pred.empty
 
 def test_epoch_evaluation_end(m):
     preds = [{
@@ -804,3 +899,11 @@ def test_mulit_class_with_empty_frame_accuracy_without_predictions(two_class_m, 
     two_class_m.create_trainer()
     results = two_class_m.trainer.validate(two_class_m)
     assert results[0]["empty_frame_accuracy"] == 1
+
+def test_evaluate_on_epoch_interval(m):
+    m.config["validation"]["val_accuracy_interval"] = 1
+    m.config["train"]["epochs"] = 1
+    m.create_trainer()
+    m.trainer.fit(m)
+    assert m.trainer.logged_metrics["box_precision"]
+    assert m.trainer.logged_metrics["box_recall"]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -173,6 +173,7 @@ def test_validation_step(m):
     val_loss = m.validation_step(batch, 0)
     assert val_loss != 0
 
+"
 def test_validation_step_empty():
     """If the model returns an empty prediction, the metrics should not fail"""
     m = main.deepforest()
@@ -185,6 +186,8 @@ def test_validation_step_empty():
     m.predictions = []
     val_loss = m.validation_step(batch, 0)
     assert len(m.predictions) == 0
+
+    assert m.iou_metric.compute()["iou"] is None
 
 def test_validate(m):
     m.trainer = None

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -185,7 +185,7 @@ def test_validation_step_empty():
     m.predictions = []
     val_loss = m.validation_step(batch, 0)
     assert len(m.predictions) == 0
-    assert torch.isnan(m.iou_metric.compute()["iou"])
+    assert m.iou_metric.compute()["iou"] == 0
 
 def test_validate(m):
     m.trainer = None

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -701,107 +701,12 @@ def test_predict_tile_with_crop_model_empty():
     # Assert the result
     assert result is None
 
-# @pytest.mark.parametrize("batch_size", [1, 4, 8])
-# def test_batch_prediction(m, batch_size, raster_path):
-#    
-#     # Prepare input data
-#     tile = np.array(Image.open(raster_path))
-#     ds = dataset.TileDataset(tile=tile, patch_overlap=0.1, patch_size=100)
-#     dl = DataLoader(ds, batch_size=batch_size)
-    
-#     # Perform prediction
-#     predictions = []
-#     for batch in dl:
-#         prediction = m.predict_batch(batch)
-#         predictions.append(prediction)
-    
-#     # Check results
-#     assert len(predictions) == len(dl)
-#     for batch_pred in predictions:
-#         assert isinstance(batch_pred, pd.DataFrame)
-#         assert set(batch_pred.columns) == {
-#             "xmin", "ymin", "xmax", "ymax", "label", "score", "geometry"
-#         }
-
-# @pytest.mark.parametrize("batch_size", [1, 4])
-# def test_batch_training(m, batch_size, tmpdir):
-#     
-#     # Generate synthetic training data
-#     csv_file = get_data("example.csv")
-#     root_dir = os.path.dirname(csv_file)
-#     train_ds = m.load_dataset(csv_file, root_dir=root_dir)
-#     train_dl = DataLoader(train_ds, batch_size=batch_size, shuffle=True)
-    
-#     # Configure the model and trainer
-#     m.config["batch_size"] = batch_size
-#     m.create_trainer()
-#     trainer = m.trainer
-    
-#     # Train the model
-#     trainer.fit(m, train_dl)
-    
-#     # Assertions
-#     assert trainer.current_epoch == 1
-#     assert trainer.batch_size == batch_size
-
-# @pytest.mark.parametrize("batch_size", [2, 4])
-# def test_batch_data_augmentation(m, batch_size, raster_path):
-#     
-#     tile = np.array(Image.open(raster_path))
-#     ds = dataset.TileDataset(tile=tile, patch_overlap=0.1, patch_size=100, augment=True)
-#     dl = DataLoader(ds, batch_size=batch_size)
-    
-#     predictions = []
-#     for batch in dl:
-#         prediction = m.predict_batch(batch)
-#         predictions.append(prediction)
-    
-#     assert len(predictions) == len(dl)
-#     for batch_pred in predictions:
-#         assert isinstance(batch_pred, pd.DataFrame)
-#         assert set(batch_pred.columns) == {
-#             "xmin", "ymin", "xmax", "ymax", "label", "score", "geometry"
-#         }
-
-# def test_batch_inference_consistency(m, raster_path):
-#     
-#     tile = np.array(Image.open(raster_path))
-#     ds = dataset.TileDataset(tile=tile, patch_overlap=0.1, patch_size=100)
-#     dl = DataLoader(ds, batch_size=4)
-    
-#     batch_predictions = []
-#     for batch in dl:
-#         prediction = m.predict_batch(batch)
-#         batch_predictions.append(prediction)
-    
-#     single_predictions = []
-#     for image in ds:
-#         prediction = m.predict_image(image=image)
-#         single_predictions.append(prediction)
-    
-#     batch_df = pd.concat(batch_predictions, ignore_index=True)
-#     single_df = pd.concat(single_predictions, ignore_index=True)
-    
-#     pd.testing.assert_frame_equal(batch_df, single_df)
-
-# def test_large_batch_handling(m, raster_path):
-#    
-#     tile = np.array(Image.open(raster_path))
-#     ds = dataset.TileDataset(tile=tile, patch_overlap=0.1, patch_size=100)
-#     dl = DataLoader(ds, batch_size=16)
-    
-#     predictions = []
-#     for batch in dl:
-#         prediction = m.predict_batch(batch)
-#         predictions.append(prediction)
-    
-#     assert len(predictions) > 0
-#     for batch_pred in predictions:
-#         assert isinstance(batch_pred, pd.DataFrame)
-#         assert set(batch_pred.columns) == {
-#             "xmin", "ymin", "xmax", "ymax", "label", "score", "geometry"
-#         }
-#         assert not batch_pred.empty
+def test_evaluate_on_epoch_interval(m):
+    m.config["val_accuracy_interval"] = 1
+    m.config["train"]["epochs"] = 1
+    m.trainer.fit(m)
+    assert m.trainer.logged_metrics["box_precision"]
+    assert m.trainer.logged_metrics["box_recall"]
 
 def test_epoch_evaluation_end(m):
     preds = [{
@@ -850,7 +755,7 @@ def test_empty_frame_accuracy_with_predictions(m, tmpdir):
     # Set all xmin, ymin, xmax, ymax to 0
     ground_df.loc[:, ["xmin", "ymin", "xmax", "ymax"]] = 0
     ground_df.drop_duplicates(subset=["image_path"], keep="first", inplace=True)
-    
+
     # Save the ground truth to a temporary file
     ground_df.to_csv(tmpdir.strpath + "/ground_truth.csv", index=False)
     m.config["validation"]["csv_file"] = tmpdir.strpath + "/ground_truth.csv"
@@ -868,7 +773,7 @@ def test_empty_frame_accuracy_without_predictions(tmpdir):
     # Set all xmin, ymin, xmax, ymax to 0
     ground_df.loc[:, ["xmin", "ymin", "xmax", "ymax"]] = 0
     ground_df.drop_duplicates(subset=["image_path"], keep="first", inplace=True)
-    
+
     # Save the ground truth to a temporary file
     ground_df.to_csv(tmpdir.strpath + "/ground_truth.csv", index=False)
     m.config["validation"]["csv_file"] = tmpdir.strpath + "/ground_truth.csv"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -185,7 +185,7 @@ def test_validation_step_empty():
     m.predictions = []
     val_loss = m.validation_step(batch, 0)
     assert len(m.predictions) == 0
-    assert m.iou_metric.compute()["iou"] is None
+    assert torch.isnan(m.iou_metric.compute()["iou"])
 
 def test_validate(m):
     m.trainer = None

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -184,7 +184,8 @@ def test_validation_step_empty():
     batch = next(iter(val_dataloader))
     m.predictions = []
     val_loss = m.validation_step(batch, 0)
-    assert len(m.predictions) == 0
+    assert len(m.predictions) == 1
+    assert m.predictions[0].xmin.isna().all()
     assert m.iou_metric.compute()["iou"] == 0
 
 def test_validate(m):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -173,7 +173,6 @@ def test_validation_step(m):
     val_loss = m.validation_step(batch, 0)
     assert val_loss != 0
 
-"
 def test_validation_step_empty():
     """If the model returns an empty prediction, the metrics should not fail"""
     m = main.deepforest()
@@ -186,7 +185,6 @@ def test_validation_step_empty():
     m.predictions = []
     val_loss = m.validation_step(batch, 0)
     assert len(m.predictions) == 0
-
     assert m.iou_metric.compute()["iou"] is None
 
 def test_validate(m):


### PR DESCRIPTION
This PR aims to standardize, document and better test those situations in which 1) the model doesn't make predictions, but there are ground truth to evaluate and 2) where there are no ground truth in validation, but the model makes predictions. I introduce a new evaluation metric 'empty frame accuracy' that will be useful for many users, I added tests and docs. During this, I found that the test that was called validation_step wasn't fully testing validation_step, but rather trainer.validate, which is related, but not the same. I added a proper validation step test, which required silencing the loggers, due to pytorch lightning being overeager in throwing errors if self.validation_step is run outside of trainer.validate, which is only needed for testing situations. 