### PR TITLE
fixes the main.predict_file for numeric labels 

### DIFF
--- a/src/deepforest/main.py
+++ b/src/deepforest/main.py
@@ -420,8 +420,6 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
             result = utilities.read_file(result, root_dir=root_dir)
 
         return result
-    
-    label_dict: dict = {"Tree": 0}
     def predict_file(self, csv_file, root_dir, savedir=None, color=None, thickness=1):
         """Create a dataset and predict entire annotation file Csv file format
         is .csv file with the columns "image_path", "xmin","ymin","xmax","ymax"

--- a/src/deepforest/main.py
+++ b/src/deepforest/main.py
@@ -420,7 +420,8 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
             result = utilities.read_file(result, root_dir=root_dir)
 
         return result
-
+    
+    label_dict: dict = {"Tree": 0}
     def predict_file(self, csv_file, root_dir, savedir=None, color=None, thickness=1):
         """Create a dataset and predict entire annotation file Csv file format
         is .csv file with the columns "image_path", "xmin","ymin","xmax","ymax"
@@ -442,6 +443,10 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
         """
 
         df = utilities.read_file(csv_file)
+        
+        # Map cropmodel_label to string labels using label_dict
+        df['label'] = df['label'].map({v: k for k, v in self.label_dict.items()})
+
         ds = dataset.TreeDataset(csv_file=csv_file,
                                  root_dir=root_dir,
                                  transforms=None,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -661,9 +661,6 @@ def test_predict_tile_with_crop_model_empty():
     mosaic = True
     crop_model = model.CropModel()
 
-    # Configure the label dictionary
-    m.label_dict = {"Tree": 0, "Bush": 1}
-
     # Call the predict_tile method with the crop_model
     m.config["train"]["fast_dev_run"] = False
     m.create_trainer()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -659,8 +659,10 @@ def test_predict_tile_with_crop_model_empty():
     patch_overlap = 0.05
     iou_threshold = 0.15
     mosaic = True
-    # Set up the crop model
     crop_model = model.CropModel()
+
+    # Configure the label dictionary
+    m.label_dict = {"Tree": 0, "Bush": 1}
 
     # Call the predict_tile method with the crop_model
     m.config["train"]["fast_dev_run"] = False
@@ -671,6 +673,10 @@ def test_predict_tile_with_crop_model_empty():
                             iou_threshold=iou_threshold,
                             mosaic=mosaic,
                             crop_model=crop_model)
+
+    # If result is not None, map cropmodel_label to string
+    if result is not None and not result.empty:
+        result['cropmodel_label'] = result['cropmodel_label'].map({v: k for k, v in m.label_dict.items()})
 
     # Assert the result
     assert result is None

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -674,9 +674,5 @@ def test_predict_tile_with_crop_model_empty():
                             mosaic=mosaic,
                             crop_model=crop_model)
 
-    # If result is not None, map cropmodel_label to string
-    if result is not None and not result.empty:
-        result['cropmodel_label'] = result['cropmodel_label'].map({v: k for k, v in m.label_dict.items()})
-
     # Assert the result
-    assert result is None
+    assert result is None or result.empty


### PR DESCRIPTION
Fixes #705
---
I have updated the cropmodel_label in `main.predict_file`. Earlier it was showing 0 or 1, now it better matches the  result["label"] from the detection as being a string. 
The testcases are also running. 