### PR TITLE
Improve point plotting behavior for ground truth with no scores.

### DIFF
--- a/src/deepforest/visualize.py
+++ b/src/deepforest/visualize.py
@@ -347,7 +347,11 @@ def convert_to_sv_format(df, width=None, height=None):
         labels = df['label'].map(label_mapping).values.astype(int)
 
         # Extract scores as a numpy array
-        scores = np.array(df['score'].tolist())
+        try:
+            scores = np.array(df['score'].tolist())
+        except KeyError:
+            scores = np.ones(len(labels))
+        
         scores = np.expand_dims(np.stack(scores), 1)
 
         # Create a reverse mapping from integer to string labels

--- a/src/deepforest/visualize.py
+++ b/src/deepforest/visualize.py
@@ -351,7 +351,7 @@ def convert_to_sv_format(df, width=None, height=None):
             scores = np.array(df['score'].tolist())
         except KeyError:
             scores = np.ones(len(labels))
-        
+
         scores = np.expand_dims(np.stack(scores), 1)
 
         # Create a reverse mapping from integer to string labels

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -165,8 +165,7 @@ def test_plot_results_point(m, tmpdir):
         'y': [15, 25],
         'label': ['Tree', 'Tree'],
         'image_path': [get_data("OSBS_029.tif"), get_data("OSBS_029.tif")],
-        'score': [0.9, 0.8],
-        'label': ['Tree', 'Tree']
+        'score': [0.9, 0.8]
     }
     df = pd.DataFrame(data)
     gdf = read_file(df, root_dir=os.path.dirname(get_data("OSBS_029.tif")))
@@ -178,6 +177,23 @@ def test_plot_results_point(m, tmpdir):
     # Assertions
     assert os.path.exists(os.path.join(tmpdir, "OSBS_029.png"))
 
+def test_plot_results_point_no_label(m, tmpdir):
+    # Create a mock DataFrame with point annotations
+    data = {
+        'x': [15, 25],
+        'y': [15, 25],
+        'label': ['Tree', 'Tree'],
+        'image_path': [get_data("OSBS_029.tif"), get_data("OSBS_029.tif")],
+    }
+    df = pd.DataFrame(data)
+    gdf = read_file(df, root_dir=os.path.dirname(get_data("OSBS_029.tif")))
+    gdf.root_dir = os.path.dirname(get_data("OSBS_029.tif"))
+
+    # Call the function
+    visualize.plot_results(gdf, savedir=tmpdir)
+
+    # Assertions
+    assert os.path.exists(os.path.join(tmpdir, "OSBS_029.png"))
 
 def test_plot_results_polygon(m, tmpdir):
     # Create a mock DataFrame with polygon annotations


### PR DESCRIPTION
The current behavior fails if you have ground truth that don't have a 'scores' column. Which makes no sense, since ground truth don't have confidence scores, from the model atleast. This behavior was already fixed for boxes and polygons. I added a try except, added a dummy 1 for scores in the dataframe just within the plotting function, and added a test.