### PR TITLE
Add Axis Return to visualize.plot_results

### DIFF
--- a/src/deepforest/visualize.py
+++ b/src/deepforest/visualize.py
@@ -472,7 +472,7 @@ def plot_results(results,
                  basename=None,
                  radius=3,
                  image=None,
-                 axes=True):
+                 axes=False):
     """Plot the prediction results.
 
     Args:

--- a/src/deepforest/visualize.py
+++ b/src/deepforest/visualize.py
@@ -471,7 +471,8 @@ def plot_results(results,
                  thickness=2,
                  basename=None,
                  radius=3,
-                 image=None):
+                 image=None,
+                 axes=True):
     """Plot the prediction results.
 
     Args:
@@ -486,8 +487,9 @@ def plot_results(results,
         basename: optional basename for the saved figure. If None (default), the basename will be extracted from the image path.
         radius: radius of the points in px
         image: an optional numpy array of an image to annotate. If None (default), the image will be loaded from the results dataframe.
+        axes: returns matplotlib axes object if True
     Returns:
-        None
+        Matplotlib axes object if axes=True, otherwise None
     """
     # Convert colors, check for multi-class labels
     num_labels = len(results.label.unique())
@@ -530,6 +532,8 @@ def plot_results(results,
     else:
         # Display the image using Matplotlib
         plt.imshow(annotated_scene)
+        if axes:
+            return ax
         plt.axis('off')  # Hide axes for a cleaner look
         plt.show()
 


### PR DESCRIPTION
Fixes #866  

Modified `visualize.plot_results` to return the Matplotlib axis object when `axes=True`. Retains current behavior of displaying the plot as default.