### PR TITLE
Update deepforest_config.yml

### DIFF
--- a/deepforest_config.yml
+++ b/deepforest_config.yml
@@ -42,7 +42,7 @@ train:
             threshold_mode: "rel"
             cooldown: 0
             min_lr: 0
-            eps: 1e-08
+            eps: 0.00000001
 
     # Print loss every n epochs
     epochs: 1


### PR DESCRIPTION
The config was not reading scientific notation. I think this another example of how moving to hydra (#847) would help us. Closes #881