### PR TITLE
plot results was using cv2 needs to be BGR order:

### DIFF
--- a/src/deepforest/visualize.py
+++ b/src/deepforest/visualize.py
@@ -532,6 +532,8 @@ def plot_results(results,
                 results.image_path.unique()[0]))[0]
         image_name = "{}.png".format(basename)
         image_path = os.path.join(savedir, image_name)
+        # Flip RGB to BGR
+        annotated_scene = annotated_scene[:, :, ::-1]
         cv2.imwrite(image_path, annotated_scene)
     else:
         # Display the image using Matplotlib


### PR DESCRIPTION
I was noticing that in milliontrees, the color was flipped in the images. CV2 wants blue green red, not red green blue, only for saved plots.

Fixed -> 
<img width="906" alt="image" src="https://github.com/user-attachments/assets/bd0525c0-13c6-40a4-8c1a-242381463416" />
