### PR TITLE
better test coverage for mixed empty and not empty

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -165,6 +165,23 @@ def test_train_empty(m, tmpdir):
     m.create_trainer()
     m.trainer.fit(m)
 
+def test_train_with_empty_validation(m, tmpdir):
+    empty_csv = pd.DataFrame({
+        "image_path": ["OSBS_029.png", "OSBS_029.tif"],
+        "xmin": [0, 10],
+        "xmax": [0, 20],
+        "ymin": [0, 20],
+        "ymax": [0, 30],
+        "label": ["Tree", "Tree"]
+    })
+    empty_csv.to_csv("{}/empty.csv".format(tmpdir))
+    m.config["train"]["csv_file"] = "{}/empty.csv".format(tmpdir)
+    m.config["validation"]["csv_file"] = "{}/empty.csv".format(tmpdir)
+    m.config["batch_size"] = 2
+    m.create_trainer()
+    m.trainer.fit(m)
+    m.trainer.validate(m)
+
 
 def test_validation_step(m):
     val_dataloader = m.val_dataloader()


### PR DESCRIPTION
The existing test is fine, but we have only covered validation data with annotations and validation data without annotations, but the more likely condition is some of both. I am facing an issue with the BOEM data, but this test still passes regardless. No reason to throw it away. 