### PR TITLE
num_classes shouldn't be an optional arg for CropModel

### DIFF
--- a/src/deepforest/model.py
+++ b/src/deepforest/model.py
@@ -82,7 +82,7 @@ class CropModel(LightningModule):
     """An architecture agnostic class for classification based on crops coming
     from the core detection models."""
 
-    def __init__(self, num_classes=2, batch_size=4, num_workers=0, lr=0.0001, model=None):
+    def __init__(self, num_classes, batch_size=4, num_workers=0, lr=0.0001, model=None):
         super().__init__()
 
         # Model

--- a/src/deepforest/predict.py
+++ b/src/deepforest/predict.py
@@ -225,10 +225,10 @@ def _predict_crop_model_(crop_model,
         root_dir=os.path.dirname(raster_path),
         transform=transform,
         augment=augment)
-    
+
     crop_dataloader = crop_model.predict_dataloader(bounding_box_dataset)
     crop_results = trainer.predict(crop_model, crop_dataloader)
-    
+
     stacked_outputs = np.vstack(np.concatenate(crop_results))
     label = np.argmax(stacked_outputs, 1)
     score = np.max(stacked_outputs, 1)

--- a/src/deepforest/predict.py
+++ b/src/deepforest/predict.py
@@ -216,13 +216,19 @@ def _predict_crop_model_(crop_model,
         print("No predictions to run crop model on, returning empty dataframe")
         return results
 
+    # Remove any boxes where xmin = xmax or ymin = ymax
+    results = results[results.xmin != results.xmax]
+    results = results[results.ymin != results.ymax]
+
     bounding_box_dataset = dataset.BoundingBoxDataset(
         results,
         root_dir=os.path.dirname(raster_path),
         transform=transform,
         augment=augment)
+    
     crop_dataloader = crop_model.predict_dataloader(bounding_box_dataset)
     crop_results = trainer.predict(crop_model, crop_dataloader)
+    
     stacked_outputs = np.vstack(np.concatenate(crop_results))
     label = np.argmax(stacked_outputs, 1)
     score = np.max(stacked_outputs, 1)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -647,7 +647,7 @@ def test_configure_optimizers(scheduler, expected):
 
 @pytest.fixture()
 def crop_model():
-    return model.CropModel()
+    return model.CropModel(num_classes=2)
 
 
 def test_predict_tile_with_crop_model(m, config):
@@ -657,7 +657,7 @@ def test_predict_tile_with_crop_model(m, config):
     iou_threshold = 0.15
     mosaic = True
     # Set up the crop model
-    crop_model = model.CropModel()
+    crop_model = model.CropModel(num_classes=2)
 
     # Call the predict_tile method with the crop_model
     m.config["train"]["fast_dev_run"] = False

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -686,7 +686,7 @@ def test_predict_tile_with_crop_model_empty():
     iou_threshold = 0.15
     mosaic = True
     # Set up the crop model
-    crop_model = model.CropModel()
+    crop_model = model.CropModel(num_classes=2)
 
     # Call the predict_tile method with the crop_model
     m.config["train"]["fast_dev_run"] = False


### PR DESCRIPTION
This is more of a style change than a bug. CropModel had num_classes = 2 as a default. But there is no reason besides the example we gave that this should be the case. Having it be an optional argument in reloading from checkpoint, since I forgot to specify num_classes=5 and it silently failed. I added a test for better coverage. 