### PR TITLE
Labels must always be int

### DIFF
--- a/src/deepforest/dataset.py
+++ b/src/deepforest/dataset.py
@@ -119,7 +119,7 @@ class TreeDataset(Dataset):
                 # channels last
                 image = np.rollaxis(image, 2, 0)
                 image = torch.from_numpy(image).float()
-                targets = {"boxes": boxes, "labels": labels.astype(np.int64)}
+                targets = {"boxes": boxes, "labels": labels}
 
                 return self.image_names[idx], image, targets
 

--- a/src/deepforest/dataset.py
+++ b/src/deepforest/dataset.py
@@ -119,19 +119,19 @@ class TreeDataset(Dataset):
                 # channels last
                 image = np.rollaxis(image, 2, 0)
                 image = torch.from_numpy(image).float()
-                targets = {"boxes": boxes, "labels": labels}
+                targets = {"boxes": boxes, "labels": labels.astype(np.int64)}
 
                 return self.image_names[idx], image, targets
 
             augmented = self.transform(image=image,
                                        bboxes=targets["boxes"],
-                                       category_ids=targets["labels"])
+                                       category_ids=targets["labels"].astype(np.int64))
             image = augmented["image"]
 
             boxes = np.array(augmented["bboxes"])
             boxes = torch.from_numpy(boxes).float()
             labels = np.array(augmented["category_ids"])
-            labels = torch.from_numpy(labels)
+            labels = torch.from_numpy(labels.astype(np.int64))
             targets = {"boxes": boxes, "labels": labels}
 
             return self.image_names[idx], image, targets

--- a/src/deepforest/main.py
+++ b/src/deepforest/main.py
@@ -157,8 +157,8 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
             self.numeric_to_label_dict = {v: k for k, v in self.label_dict.items()}
 
     def use_release(self, check_release=True):
-        """Use the latest DeepForest model release from Hugging Face, downloading if necessary.
-        Optionally download if release doesn't exist.
+        """Use the latest DeepForest model release from Hugging Face,
+        downloading if necessary. Optionally download if release doesn't exist.
 
         Args:
             check_release (logical): Deprecated, not in use.
@@ -172,8 +172,9 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
         self.load_model('weecology/deepforest-tree')
 
     def use_bird_release(self, check_release=True):
-        """Use the latest DeepForest bird model release from Hugging Face, downloading if necessary.
-        model. Optionally download if release doesn't exist.
+        """Use the latest DeepForest bird model release from Hugging Face,
+        downloading if necessary. model. Optionally download if release doesn't
+        exist.
 
         Args:
             check_release (logical): Deprecated, not in use.

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -42,6 +42,7 @@ def test_tree_dataset(csv_file, label_dict):
         assert image.min() >= 0
         assert targets["boxes"].shape == (raw_data.shape[0], 4)
         assert targets["labels"].shape == (raw_data.shape[0],)
+        assert targets["labels"].dtype == torch.int64
         assert len(np.unique(targets["labels"])) == len(raw_data.label.unique())
 
 
@@ -90,6 +91,7 @@ def test_tree_dataset_transform(augment):
 
         assert torch.is_tensor(targets["boxes"])
         assert torch.is_tensor(targets["labels"])
+        assert targets["labels"].dtype == torch.int64
         assert torch.is_tensor(image)
 
 


### PR DESCRIPTION
There is some platform specific error that I think can be avoided, by making sure the labels are always int dtype. I have a test, passing in one env, failing in another, no code differences. 