### PR TITLE
profiled test_main.py to improve speed

### DIFF
--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -8,9 +8,8 @@ from pytorch_lightning.callbacks import ModelCheckpoint
 from deepforest import get_data
 
 
-@pytest.mark.parametrize("every_n_epochs", [1, 2, 3])
-def test_log_images(m, every_n_epochs, tmpdir):
-    im_callback = callbacks.images_callback(savedir=tmpdir, every_n_epochs=every_n_epochs)
+def test_log_images(m, tmpdir):
+    im_callback = callbacks.images_callback(savedir=tmpdir, every_n_epochs=2)
     m.create_trainer(callbacks=[im_callback])
     m.trainer.fit(m)
     saved_images = glob.glob("{}/*.png".format(tmpdir))


### PR DESCRIPTION
<img width="1707" alt="Screenshot 2025-02-09 at 7 31 44 PM" src="https://github.com/user-attachments/assets/9918f434-3f8f-4361-82d5-88ec53dd4f67" />
I was able to bring tests in test_main.py in half by making sure that we never run trainer.fit unless we fully need to. Still more work to be done, but a good start. 

Before, 34 minutes.

<img width="1707" alt="Screenshot 2025-02-09 at 7 31 44 PM" src="https://github.com/user-attachments/assets/2b311ee7-7f89-4203-816a-8226d46c65d9" />

After 18, note this is just test_main.py

```
--------------- generated report log file: reportlog_test_main2.jsonl ----------------
=================== 54 passed, 128 warnings in 1117.63s (0:18:37) ====
```
