### PR TITLE
Fixed broken Developer's Guide link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Get suggestions on how to improve a model by using the [discussion board](https:
 
 # Developer Guidelines
 
-We welcome pull requests for any issue or extension of the models. Please follow the [developers guide](https://deepforest.readthedocs.io/en/latest/CONTRIBUTING.html).
+We welcome pull requests for any issue or extension of the models. Please follow the [developer's guide](https://deepforest.readthedocs.io/en/latest/development/contributing.html).
 
 ## License
 


### PR DESCRIPTION
# Fixes Issue #922 

### I have corrected the link to the Developer's Guide in the Developer's Guideline section of the README.md file to resolve the broken link issue.

### Screenshot of the Corrected Link :-

![Screenshot 2025-02-15 203412](https://github.com/user-attachments/assets/b9d58e2b-b947-445d-a746-783579d5b7a6)
