### PR TITLE
Fix path separator inconsistency in crop_raster tests on Windows

### DIFF
--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -211,9 +211,9 @@ def test_crop_raster_valid_crop(tmpdir):
     # Call the function under test
     result = utilities.crop_raster(bounds, rgb_path=rgb_path, savedir=tmpdir, filename="crop")
 
-    # Assert the output filename
+    # Assert the output filename (normalize both paths)
     expected_filename = str(tmpdir.join("crop.tif"))
-    assert result == expected_filename
+    assert os.path.normpath(result) == os.path.normpath(expected_filename)
 
     # Assert the saved crop
     with rio.open(result) as src:
@@ -263,9 +263,9 @@ def test_crop_raster_png_unprojected(tmpdir):
     # Call the function under test
     result = utilities.crop_raster(bounds, rgb_path=rgb_path, savedir=savedir, filename=filename, driver="PNG")
 
-    # Assert the output filename
+    # Assert the output filename (normalize both paths)
     expected_filename = os.path.join(savedir, "crop.png")
-    assert result == expected_filename
+    assert os.path.normpath(result) == os.path.normpath(expected_filename)
 
     # Assert the saved crop
     with rio.open(result) as src:


### PR DESCRIPTION
This PR fixes the path separator inconsistency in the `test_crop_raster_valid_crop` and `test_crop_raster_png_unprojected` tests on Windows (Issue #924). The issue occurs because the `crop_raster` function returns paths with forward slashes (`/`), while the tests expect backslashes (`\`).

Changes:
- Normalized both the `result` and `expected_filename` paths in the tests using `os.path.normpath()`.
- Ensured that the tests work correctly on all operating systems.

Testing:
- Ran the test suite on Windows and confirmed that the tests pass:
  pytest -v
  
  
![image](https://github.com/user-attachments/assets/5c342f35-9309-4252-9b93-04a876dc1434)
