### PR TITLE
Document Label Studio export type for read_file

### DIFF
--- a/docs/user_guide/13_annotation.rst
+++ b/docs/user_guide/13_annotation.rst
@@ -53,6 +53,19 @@ For long-term projects, we recommend using `Label Studio <https://labelstud.io/>
 
    Label Studio annotation platform.
 
+Exporting Annotations for DeepForest
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+To ensure compatibility with DeepForest, export your annotations from Label Studio in Pascal VOC XML format. This format is widely used for object detection tasks and can be directly read by DeepForest's ``read_pascal_voc`` function.
+
+Steps to Export in Pascal VOC Format:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+1. Navigate to your project in Label Studio.
+2. Click on the Export button.
+3. Select Pascal VOC XML as the export format.
+4. Save the exported XML file.
+
+For more details on reading Pascal VOC annotations in DeepForest, see: :ref:`reading-xml-annotations-in-pascal-voc-format`
+
 Do I Need to Annotate All Objects in My Image?
 ----------------------------------------------
 
@@ -144,6 +157,8 @@ You can speed up new annotations by starting with model predictions. Below is an
        basename = os.path.splitext(os.path.basename(path))[0]
        shp = boxes_to_shapefile(boxes, root_dir=PATH_TO_DIR, projected=False)
        shp.to_file(f"{PATH_TO_DIR}/{basename}.shp")
+
+.. _reading-xml-annotations-in-pascal-voc-format:
 
 Reading XML Annotations in Pascal VOC Format
 --------------------------------------------


### PR DESCRIPTION
This PR updates the documentation to include explicit instructions for exporting annotations from Label Studio in Pascal VOC XML format, ensuring compatibility with DeepForest's read_pascal_voc function. This addresses issue #861.

Changes:
1- Added a new subsection titled Exporting Annotations for DeepForest under the Label Studio section.
2- Provided step-by-step instructions for exporting annotations in Pascal VOC XML format.
3- Included a link to the relevant section on reading Pascal VOC annotations in DeepForest.

```rst
Exporting Annotations for DeepForest
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
To ensure compatibility with DeepForest, export your annotations from Label Studio in Pascal VOC XML format. This format is widely used for object detection tasks and can be directly read by DeepForest's ``read_pascal_voc`` function.

Steps to Export in Pascal VOC Format:
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1. Navigate to your project in Label Studio.
2. Click on the Export button.
3. Select Pascal VOC XML as the export format.
4. Save the exported XML file.

For more details on reading Pascal VOC annotations in DeepForest, see: `Reading XML Annotations in Pascal VOC Format <https://deepforest.readthedocs.io/en/v1.4.1/user_guide/13_annotation.html#reading-xml-annotations-in-pascal-voc-format>`_
```

Before and After Sections

Before 
![image](https://github.com/user-attachments/assets/befd3304-5118-454c-82ff-d57b7e14f557)

After
![image](https://github.com/user-attachments/assets/815e231c-c319-44ed-863e-5ba4b8e2b20b)


Related Issue:
Fixes #861 
