### PR TITLE
Fixed broken prebuilt link in overview.rst

### DIFF
--- a/docs/getting_started/overview.rst
+++ b/docs/getting_started/overview.rst
@@ -81,7 +81,7 @@ The first is the DeepForest paper, which describes the Python package:
 
    Weinstein, B.G., Marconi, S., Aubry‐Kientz, M., Vincent, G., Senyondo, H. and White, E.P., 2020. DeepForest: A Python package for RGB deep learning tree crown delineation. Methods in Ecology and Evolution, 11(12), pp.1743-1751. `https://doi.org/10.1111/2041-210X.13472 <https://doi.org/10.1111/2041-210X.13472>`_
 
-The second is the paper describing the particular model. See `Prebuilt Setup <../user_guide/prebuilt.html>`_ for citations for each model.
+The second is the paper describing the particular model. See `Prebuilt Setup <../user_guide/02_prebuilt.html>`_ for citations for each model.
 
 .. _issue page: https://github.com/weecology/DeepForest/issues
 


### PR DESCRIPTION
Before
![image](https://github.com/user-attachments/assets/e6bae045-bfca-44e7-b459-0af379a1c11a)

After
![image](https://github.com/user-attachments/assets/eddf696a-10df-4fd5-8ebf-68cb4cfff5e8)

Take 3!