### PR TITLE
Adds main.deepforest.set_label function

### DIFF
--- a/src/deepforest/main.py
+++ b/src/deepforest/main.py
@@ -156,6 +156,20 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
             self.label_dict = {"Bird": 0}
             self.numeric_to_label_dict = {v: k for k, v in self.label_dict.items()}
 
+    def set_labels(self, label_dict):
+        """
+        Set new label mapping, updating both the label dictionary (str -> int) and its inverse (int -> str).
+        
+        Args:
+            label_dict (dict): Dictionary mapping class names to numeric IDs.
+        """
+        if len(label_dict) != self.config["num_classes"]:
+            raise ValueError("The length of label_dict must match the number of classes.")
+        
+        self.label_dict = label_dict
+        self.numeric_to_label_dict = {v: k for k, v in label_dict.items()}
+
+
     def use_release(self, check_release=True):
         """Use the latest DeepForest model release from Hugging Face,
         downloading if necessary. Optionally download if release doesn't exist.

--- a/tests/.cph/.test_label.py_4200d1ad985f20bf17fc839da7ee73f2.prob
+++ b/tests/.cph/.test_label.py_4200d1ad985f20bf17fc839da7ee73f2.prob
@@ -1,0 +1,1 @@
+{"name":"Local: test_label","url":"/home/nakshatra/Documents/DeepForest/tests/test_label.py","tests":[{"id":1740601101077,"input":"","output":""}],"interactive":false,"memoryLimit":1024,"timeLimit":3000,"srcPath":"/home/nakshatra/Documents/DeepForest/tests/test_label.py","group":"local","local":true}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -865,3 +865,20 @@ def test_evaluate_on_epoch_interval(m):
     m.trainer.fit(m)
     assert m.trainer.logged_metrics["box_precision"]
     assert m.trainer.logged_metrics["box_recall"]
+
+def test_set_labels_updates_mapping(m):
+    new_mapping = {"Object": 0}
+    m.set_labels(new_mapping)
+    
+    # Verify that the label dictionary has been updated.
+    assert m.label_dict == new_mapping
+    
+    # Verify that the inverse mapping is correctly computed.
+    expected_inverse = {0: "Object"}
+    assert m.numeric_to_label_dict == expected_inverse
+
+def test_set_labels_invalid_length(m): # Expect a ValueError when setting an invalid label mapping.
+    # This mapping has two entries, which should be invalid since m.config["num_classes"] is 1.
+    invalid_mapping = {"Object": 0, "Extra": 1}
+    with pytest.raises(ValueError):
+        m.set_labels(invalid_mapping)


### PR DESCRIPTION
I have created  `main.deepforest.set_label` function `main.py` which Sets new label mapping, updating both the label dictionary (str -> int) and its inverse (int -> str). 
It take label_dict as input which is basically a dictionary that maps class names to unique numeric IDs.