### PR TITLE
Fix #943: Added Kangas Visualization to DeepForest

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -8,6 +8,7 @@ pydata-sphinx-theme
 geopandas
 huggingface_hub>=0.25.0
 h5py
+kangas
 matplotlib
 nbmake
 nbsphinx

--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,7 @@ dependencies:
   - geopandas
   - huggingface_hub>=0.25.0
   - h5py
+  - kangas
   - matplotlib
   - nbmake
   - nbsphinx

--- a/src/deepforest/main.py
+++ b/src/deepforest/main.py
@@ -3,7 +3,7 @@ import importlib
 import os
 import typing
 import warnings
-
+import kangas as kg
 import numpy as np
 import pandas as pd
 import pytorch_lightning as pl
@@ -34,6 +34,10 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
             e.g. {"batch_size":10}. This is useful for iterating over arguments during model testing.
         existing_train_dataloader: a Pytorch dataloader that yields a tuple path, images, targets
         existing_val_dataloader: a Pytorch dataloader that yields a tuple path, images, targets
+
+    Notes:
+        Kangas visualization is supported in predict_* and evaluate methods with visualize_with="kangas".
+        Install Kangas with `pip install kangas` to enable this optional feature.
 
     Returns:
         self: a deepforest pytorch lightning module
@@ -125,6 +129,134 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
             self.transforms = transforms
 
         self.save_hyperparameters()
+
+    def visualize_evaluation_kangas(
+            self,
+            predictions: pd.DataFrame,
+            ground_df: pd.DataFrame,
+            root_dir: str,
+            evaluation_results: typing.Optional[dict] = None) -> None:
+        """Use Kangas to visualize predictions and ground truth data from
+        evaluation.
+
+        Args:
+            predictions: Predictions DataFrame with columns "image_path", "xmin", "ymin", "xmax", "ymax", "label", "score".
+            ground_df: Ground truth DataFrame with columns "image_path", "xmin", "ymin", "xmax", "ymax", "label".
+            root_dir: Directory where images are stored.
+            evaluation_results: Optional dictionary of metrics (e.g., precision, recall) to display alongside.
+
+        Returns:
+            None
+        """
+        if kg is None:
+            print(
+                "Kangas is not installed. Run 'pip install kangas' to enable visualization."
+            )
+            return
+
+        kangas_data = []
+        for _, row in ground_df.iterrows():
+            image_path = os.path.join(root_dir, row["image_path"])
+            kangas_data.append({
+                "image_path":
+                    image_path,
+                "bounding_boxes": [{
+                    "xmin": row["xmin"],
+                    "ymin": row["ymin"],
+                    "xmax": row["xmax"],
+                    "ymax": row["ymax"],
+                    "label": f"GT_{row['label']}",
+                    "score": 1.0
+                }]
+            })
+
+        for _, row in predictions.iterrows():
+            image_path = os.path.join(root_dir, row["image_path"])
+            kangas_data.append({
+                "image_path":
+                    image_path,
+                "bounding_boxes": [{
+                    "xmin": row["xmin"],
+                    "ymin": row["ymin"],
+                    "xmax": row["xmax"],
+                    "ymax": row["ymax"],
+                    "label": f"Pred_{row['label']}",
+                    "score": row["score"]
+                }]
+            })
+
+        try:
+            grid = kg.DataGrid(kangas_data, name="DeepForest Evaluation")
+            grid.show()
+        except Exception as e:
+            print(f"Kangas evaluation failed :{e}")
+
+        if evaluation_results:
+            metrics_data = [{
+                "Metric": key,
+                "Value": value
+            }
+                            for key, value in evaluation_results.items()
+                            if isinstance(value, (int, float))]
+            if metrics_data:
+                metrics_grid = kg.DataGrid(metrics_data, name="Evaluation Metrics")
+                metrics_grid.show()
+
+    def visualize_kangas(self,
+                         predictions: typing.Union[pd.DataFrame,
+                                                   typing.List[pd.DataFrame]],
+                         image_paths: typing.Optional[typing.List[str]] = None) -> None:
+        """Visualize predictions using Kangas.
+
+        Args:
+            predictions: DataFrame or list of DataFrames with "image_path", "xmin", "ymin", "xmax", "ymax", "label", "score"
+            image_paths: Optional list of image paths if not included in predictions
+        """
+        if kg is None:
+            print(
+                "Kangas is not installed. Run 'pip install kangas' to enable visualization."
+            )
+            return
+
+        # Handle different prediction formats
+        if isinstance(predictions, pd.DataFrame):
+            df = predictions
+        elif isinstance(predictions, list) and all(
+                isinstance(p, pd.DataFrame) for p in predictions):
+            df = pd.concat(predictions, ignore_index=True)
+        else:
+            raise ValueError("Predictions must be a DataFrame or list of DataFrames")
+
+        # Ensure image paths are available
+        if "image_path" not in df.columns:
+            if not image_paths:
+                raise ValueError("image_paths must be provided if not in predictions")
+            if len(image_paths) != (len(predictions)
+                                    if isinstance(predictions, list) else 1):
+                raise ValueError("Length of image_paths must match predictions")
+            df["image_path"] = image_paths if isinstance(
+                predictions, list) else [image_paths[0]] * len(df)
+
+        # Use root_dir if available
+        root_dir = getattr(df, "root_dir", None) if hasattr(df, "root_dir") else None
+        if root_dir and not os.path.isabs(df["image_path"].iloc[0]):
+            df["image_path"] = df["image_path"].apply(lambda x: os.path.join(root_dir, x))
+
+        # Group predictions by image_path
+        grouped = df.groupby("image_path")
+        kangas_data = [{
+            "image_path":
+                image_path,
+            "bounding_boxes":
+                group[["xmin", "ymin", "xmax", "ymax", "label",
+                       "score"]].to_dict(orient="records")
+        } for image_path, group in grouped]
+
+        try:
+            grid = kg.DataGrid(kangas_data, name="DeepForest Predictions")
+            grid.show()
+        except Exception as e:
+            print(f"Kangas visualization failed: {e}")
 
     def load_model(self, model_name="weecology/deepforest-tree", revision='main'):
         """Loads a model that has already been pretrained for a specific task,
@@ -336,7 +468,10 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
                                        batch_size=self.config["batch_size"])
         return loader
 
-    def predict_dataloader(self, ds):
+    def predict_dataloader(
+            self,
+            ds: torch.utils.data.Dataset,
+            visualize_with: typing.Optional[str] = None) -> torch.utils.data.DataLoader:
         """Create a PyTorch dataloader for prediction.
 
         Args:
@@ -350,6 +485,20 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
                                              shuffle=False,
                                              num_workers=self.config["workers"])
 
+        if visualize_with == "kangas":
+            # Generate predictions and visualize
+            predictions = self.trainer.predict(self, loader)
+            if predictions:
+                flattened_predictions = [item for batch in predictions for item in batch]
+                # Extract image paths from dataset if available, else use placeholder
+                image_paths = [
+                    getattr(ds, "paths",
+                            [f"image_{i}"
+                             for i in range(len(flattened_predictions))])[i]
+                    for i in range(len(flattened_predictions))
+                ]
+                self.visualize_kangas(flattened_predictions, image_paths)
+
         return loader
 
     def predict_image(self,
@@ -357,7 +506,8 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
                       path: typing.Optional[str] = None,
                       return_plot: bool = False,
                       color: typing.Optional[tuple] = (0, 165, 255),
-                      thickness: int = 1):
+                      thickness: int = 1,
+                      visualize_with: typing.Optional[str] = None):
         """Predict a single image with a deepforest model.
 
         Deprecation warning: The 'return_plot', and related 'color' and 'thickness' arguments
@@ -428,10 +578,19 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
         else:
             root_dir = os.path.dirname(path)
             result = utilities.read_file(result, root_dir=root_dir)
+        # Visualize if requested
+        if visualize_with == "kangas":
+            self.visualize_kangas(result)
 
         return result
 
-    def predict_file(self, csv_file, root_dir, savedir=None, color=None, thickness=1):
+    def predict_file(self,
+                     csv_file,
+                     root_dir,
+                     savedir=None,
+                     color=None,
+                     thickness=1,
+                     visualize_with=None):
         """Create a dataset and predict entire annotation file Csv file format
         is .csv file with the columns "image_path", "xmin","ymin","xmax","ymax"
         for the image name and bounding box position. Image_path is the
@@ -469,6 +628,9 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
                                                thickness=thickness)
 
         results.root_dir = root_dir
+        # Visualize if requested
+        if visualize_with == "kangas":
+            self.visualize_kangas(results)
 
         return results
 
@@ -487,7 +649,8 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
                      thickness=1,
                      crop_model=None,
                      crop_transform=None,
-                     crop_augment=False):
+                     crop_augment=False,
+                     visualize_with=None):
         """For images too large to input into the model, predict_tile cuts the
         image into overlapping windows, predicts trees on each window and
         reassambles into a single array.
@@ -624,6 +787,11 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
         else:
             root_dir = os.path.dirname(raster_path)
             results = utilities.read_file(results, root_dir=root_dir)
+
+        if visualize_with == "kangas" and mosaic:
+            self.visualize_kangas(results)
+        elif visualize_with == "kangas":
+            print("Kangas visualization only supported with mosaic=True.")
 
         return results
 
@@ -819,6 +987,14 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
                 if empty_accuracy is not None:
                     results["empty_frame_accuracy"] = empty_accuracy
 
+                # Check config for Kangas visualization
+                if self.config.get("visualize_with") == "kangas":
+                    self.visualize_evaluation_kangas(
+                        predictions=self.predictions_df,
+                        ground_df=ground_df,
+                        root_dir=self.config["validation"]["root_dir"],
+                        evaluation_results=results)
+
                 # Log each key value pair of the results dict
                 if not results["class_recall"] is None:
                     for key, value in results.items():
@@ -844,16 +1020,32 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
                             except MisconfigurationException:
                                 pass
 
-    def predict_step(self, batch, batch_idx):
+    def predict_step(
+        self,
+        batch: typing.Any,
+        batch_idx: int,
+        visualize_with: typing.Optional[str] = None,
+        image_paths: typing.Optional[typing.List[str]] = None
+    ) -> typing.List[pd.DataFrame]:
+
         batch_results = self.model(batch)
 
         results = []
         for result in batch_results:
             boxes = visualize.format_boxes(result)
             results.append(boxes)
+
+        if visualize_with == "kangas":
+            self.visualize_kangas(results, image_paths)
         return results
 
-    def predict_batch(self, images, preprocess_fn=None):
+    def predict_batch(
+        self,
+        images: typing.Union[torch.Tensor, np.ndarray],
+        preprocess_fn: typing.Optional[typing.Callable] = None,
+        visualize_with: typing.Optional[str] = None,
+        image_paths: typing.Optional[typing.List[str]] = None
+    ) -> typing.List[pd.DataFrame]:
         """Predict a batch of images with the deepforest model.
 
         Args:
@@ -886,6 +1078,9 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
 
         #convert predictions to dataframes
         results = [utilities.read_file(pred) for pred in predictions if pred is not None]
+
+        if visualize_with == "kangas":
+            self.visualize_kangas(results, image_paths=image_paths)
 
         return results
 
@@ -945,7 +1140,12 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
         else:
             return optimizer
 
-    def evaluate(self, csv_file, root_dir, iou_threshold=None, savedir=None):
+    def evaluate(self,
+                 csv_file,
+                 root_dir,
+                 iou_threshold=None,
+                 savedir=None,
+                 visualize_with=None):
         """Compute intersection-over-union and precision/recall for a given
         iou_threshold.
 
@@ -971,5 +1171,12 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
             root_dir=root_dir,
             iou_threshold=iou_threshold,
             numeric_to_label_dict=self.numeric_to_label_dict)
+        # If user wants Kangas visualization
+        if visualize_with == "kangas":
+            self.visualize_evaluation_kangas(predictions=predictions,
+                                             ground_df=ground_df,
+                                             root_dir=root_dir,
+                                             evaluation_results=results)
 
         return results
+

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -865,3 +865,102 @@ def test_evaluate_on_epoch_interval(m):
     m.trainer.fit(m)
     assert m.trainer.logged_metrics["box_precision"]
     assert m.trainer.logged_metrics["box_recall"]
+    
+# Test predict_dataloader with Kangas
+def test_predict_dataloader_kangas(m, tmpdir):
+    """Test predict_dataloader triggers Kangas visualization."""
+    csv_file = get_data("example.csv")
+    ds = dataset.TreeDataset(csv_file=csv_file, root_dir=os.path.dirname(csv_file), transforms=None, train=False)
+    loader = m.predict_dataloader(ds, visualize_with="kangas")
+    assert isinstance(loader, torch.utils.data.DataLoader), "Should return a DataLoader"
+    # Kangas UI should open; we verify no crash and correct type
+
+# Test predict_image with Kangas
+def test_predict_image_kangas(m, tmpdir):
+    """Test predict_image triggers Kangas visualization and returns correct output."""
+    image_path = get_data("2019_YELL_2_528000_4978000_image_crop2.png")
+    result = m.predict_image(path=image_path, visualize_with="kangas")
+    assert isinstance(result, pd.DataFrame) or result is None, "Should return DataFrame or None"
+    if result is not None:
+        assert "image_path" in result.columns, "Result should include image_path"
+        assert not result.empty, "Should predict trees with pre-trained model"
+
+# Test predict_file with Kangas
+def test_predict_file_kangas(m, tmpdir):
+    """Test predict_file triggers Kangas visualization and returns correct output."""
+    csv_file = get_data("OSBS_029.csv")
+    root_dir = os.path.dirname(csv_file)
+    result = m.predict_file(csv_file=csv_file, root_dir=root_dir, visualize_with="kangas")
+    assert isinstance(result, pd.DataFrame), "Should return a DataFrame"
+    assert "image_path" in result.columns, "Result should include image_path"
+    assert not result.empty, "Should predict trees with pre-trained model"
+
+# Test predict_tile with Kangas
+def test_predict_tile_kangas(m, raster_path):
+    """Test predict_tile triggers Kangas visualization with mosaic=True."""
+    result = m.predict_tile(raster_path=raster_path, patch_size=300, patch_overlap=0.1, visualize_with="kangas")
+    assert isinstance(result, pd.DataFrame) or result is None, "Should return DataFrame or None"
+    if result is not None:
+        assert "image_path" in result.columns, "Result should include image_path"
+        assert not result.empty, "Should predict trees with pre-trained model"
+
+# Test predict_tile no visualization with mosaic=False
+def test_predict_tile_kangas_no_mosaic(m, raster_path):
+    """Test predict_tile doesn’t visualize with mosaic=False."""
+    result = m.predict_tile(raster_path=raster_path, patch_size=300, patch_overlap=0.1, mosaic=False, visualize_with="kangas")
+    assert isinstance(result, list), "Should return a list of (prediction, crop) tuples"
+    assert all(isinstance(r[0], pd.DataFrame) and isinstance(r[1], np.ndarray) for r in result), "Each item should be (DataFrame, array)"
+    # Kangas won’t trigger; we verify output type only
+
+# Test predict_step with Kangas
+def test_predict_step_kangas(m, tmpdir):
+    """Test predict_step triggers Kangas visualization."""
+    image_path = get_data("2019_YELL_2_528000_4978000_image_crop2.png")
+    image = np.array(Image.open(image_path).convert("RGB")).astype("float32")
+    batch = torch.tensor(image).permute(2, 0, 1).unsqueeze(0) / 255
+    result = m.predict_step(batch, 0, visualize_with="kangas", image_paths=[image_path])
+    assert isinstance(result, list), "Should return a list of predictions"
+    assert all(isinstance(r, pd.DataFrame) for r in result), "Each item should be a DataFrame"
+    # Kangas UI should open; we verify no crash
+
+# Test predict_batch with Kangas
+def test_predict_batch_kangas(m, tmpdir):
+    """Test predict_batch triggers Kangas visualization."""
+    image_path = get_data("2019_YELL_2_528000_4978000_image_crop2.png")
+    image = np.array(Image.open(image_path).convert("RGB")).astype("float32")
+    images = np.stack([image] * 2)  # Batch of 2 images
+    image_paths = [image_path, image_path]
+    result = m.predict_batch(images, visualize_with="kangas", image_paths=image_paths)
+    assert isinstance(result, list), "Should return a list of DataFrames"
+    assert all(isinstance(r, pd.DataFrame) for r in result), "Each item should be a DataFrame"
+    assert all("image_path" in r.columns for r in result if not r.empty), "Results should include image_path"
+    # Kangas UI should open; we verify no crash
+
+# Test evaluate with Kangas
+def test_evaluate_kangas(m, tmpdir):
+    """Test evaluate triggers Kangas visualization with ground truth and metrics."""
+    csv_file = get_data("OSBS_029.csv")
+    root_dir = os.path.dirname(csv_file)
+    result = m.evaluate(csv_file=csv_file, root_dir=root_dir, visualize_with="kangas")
+    assert isinstance(result, dict), "Should return a dict of evaluation metrics"
+    assert "box_precision" in result, "Should include precision"
+    assert "box_recall" in result, "Should include recall"
+    assert isinstance(result["results"], pd.DataFrame), "Results should be a DataFrame"
+    # Kangas UI should open with predictions, ground truth, and metrics; we verify no crash
+
+# Test without Kangas installed (mock Kangas unavailable)
+def test_predict_image_no_kangas(m, tmpdir, monkeypatch):
+    """Test predict_image handles missing Kangas gracefully."""
+    monkeypatch.setattr("deepforest.main.kg", None)  # Simulate Kangas not installed
+    image_path = get_data("2019_YELL_2_528000_4978000_image_crop2.png")
+    result = m.predict_image(path=image_path, visualize_with="kangas")
+    assert isinstance(result, pd.DataFrame) or result is None, "Should return DataFrame or None despite no Kangas"
+
+# Test empty predictions with Kangas
+def test_predict_image_empty_kangas(m, tmpdir):
+    """Test predict_image with empty predictions still triggers Kangas."""
+    image = np.zeros((400, 400, 3), dtype=np.float32)  # Black image, likely no predictions
+    result = m.predict_image(image=image, visualize_with="kangas")
+    assert result is None or (isinstance(result, pd.DataFrame) and result.empty), "Should return None or empty DataFrame"
+
+    


### PR DESCRIPTION
I've added the Kangas visualization to the predict methods in main.py :
Bounding box visuals for predict_dataloader, predict_image, predict_file, predict_tile, predict_step, and predict_batch.
Side-by-side predicted and ground truth boxes in evaluate

and also added  test cases to  test_main.py :

test_predict_dataloader_kangas, test_predict_image_kangas, test_predict_file_kangas, test_predict_tile_kangas etc..

Please share any thoughts or changes you’d recommend.