### PR TITLE
Newer versions of sphinx work with nbsphinx

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -31,7 +31,7 @@ recommonmark
 rtree
 safetensors
 slidingwindow
-sphinx<8.2.0
+sphinx
 sphinx_markdown_tables
 sphinx_rtd_theme
 sphinx-design

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ dependencies = [
     "scipy>1.5",
     "six",
     "slidingwindow",
-    "sphinx<8.2.0",
+    "sphinx",
     "supervision",
     "torch",
     "torchvision>=0.13",


### PR DESCRIPTION
We had temporarily limited the sphinx version due to compatibility issues
with nbsphinx. These issues have been addressed upstream, so we can return
to using the most recent version.

See: https://github.com/spatialaudio/nbsphinx/issues/825#issuecomment-2692944098
