### PR TITLE
Fix #956: Fixed misspellings of "suppression"

### DIFF
--- a/deepforest_config.yml
+++ b/deepforest_config.yml
@@ -14,7 +14,7 @@ nms_thresh: 0.05
 
 # Architecture specific params
 retinanet:
-    # Non-max supression of overlapping predictions
+    # Non-max suppression of overlapping predictions
     score_thresh: 0.1
 
 train:

--- a/docs/user_guide/09_configuration_file.md
+++ b/docs/user_guide/09_configuration_file.md
@@ -24,7 +24,7 @@ nms_thresh: 0.05
 
 # Architecture specific params
 retinanet:
-    # Non-max supression of overlapping predictions
+    # Non-max suppression of overlapping predictions
     score_thresh: 0.1
 
 train:

--- a/src/deepforest/data/deepforest_config.yml
+++ b/src/deepforest/data/deepforest_config.yml
@@ -14,7 +14,7 @@ nms_thresh: 0.05
 
 # Architecture specific params
 retinanet:
-    # Non-max supression of overlapping predictions
+    # Non-max suppression of overlapping predictions
     score_thresh: 0.1
 
 train:

--- a/src/deepforest/predict.py
+++ b/src/deepforest/predict.py
@@ -24,7 +24,7 @@ def _predict_image_(model,
         model: a deepforest.main.model object
         image: a tensor of shape (channels, height, width)
         path: optional path to read image from disk instead of passing image arg
-        nms_thresh: Non-max supression threshold, see config["nms_thresh"]
+        nms_thresh: Non-max suppression threshold, see config["nms_thresh"]
         return_plot: Return image with plotted detections
         thickness: thickness of the rectangle border line in px
         color: color of the bounding box as a tuple of BGR color, e.g. orange annotations is (0, 165, 255)
@@ -72,7 +72,7 @@ def mosiac(boxes, windows, sigma=0.5, thresh=0.001, iou_threshold=0.1):
 
     predicted_boxes = pd.concat(boxes)
     print(
-        f"{predicted_boxes.shape[0]} predictions in overlapping windows, applying non-max supression"
+        f"{predicted_boxes.shape[0]} predictions in overlapping windows, applying non-max suppression"
     )
     # move prediciton to tensor
     boxes = torch.tensor(predicted_boxes[["xmin", "ymin", "xmax", "ymax"]].values,
@@ -153,7 +153,7 @@ def _dataloader_wrapper_(model,
         dataloader: pytorch dataloader object
         root_dir: directory of images. If none, uses "image_dir" in config
         annotations: a pandas dataframe of annotations
-        nms_thresh: Non-max supression threshold, see config["nms_thresh"]
+        nms_thresh: Non-max suppression threshold, see config["nms_thresh"]
         savedir: Optional. Directory to save image plots.
         color: color of the bounding box as a tuple of BGR color, e.g. orange annotations is (0, 165, 255)
         thickness: thickness of the rectangle border line in px

--- a/tests/deepforest_config_test.yml
+++ b/tests/deepforest_config_test.yml
@@ -14,7 +14,7 @@ nms_thresh: 0.05
 
 # Architecture specific params
 retinanet:
-    # Non-max supression of overlapping predictions
+    # Non-max suppression of overlapping predictions
     score_thresh: 0.1
 
 train:


### PR DESCRIPTION
Fixes #956 by changing "supression" to "suppression" across all 5 files where I found the typo.