### PR TITLE
Fix broken image link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 DeepForest is a python package for training and predicting ecological objects in airborne imagery. DeepForest currently comes with a tree crown object detection model and a bird detection model. Both are single class modules that can be extended to species classification based on new data. Users can extend these models by annotating and training custom models.
 
-![](../www/image.png)
+![](www/image.png)
 
 # Documentation
 


### PR DESCRIPTION
This fixes an incorrect image path in the README.md file that was preventing the image from rendering correctly. The previous path used "../www/image.png", which likely caused issues with Markdown rendering on GitHub. 
The path has been updated to "www/image.png" to ensure proper display.