### PR TITLE
Fix #961: Removed old visualization code from evaluate.py 

### DIFF
--- a/src/deepforest/evaluate.py
+++ b/src/deepforest/evaluate.py
@@ -3,36 +3,26 @@ import pandas as pd
 import geopandas as gpd
 import shapely
 import numpy as np
-import cv2
-from PIL import Image
 import warnings
 
 from deepforest import IoU
-from deepforest import visualize
 from deepforest.utilities import determine_geometry_type
 
 
-def evaluate_image_boxes(predictions, ground_df, root_dir, savedir=None):
+def evaluate_image_boxes(predictions, ground_df):
     """Compute intersection-over-union matching among prediction and ground
     truth boxes for one image.
 
     Args:
-        df: a geopandas dataframe with geometry columns
         predictions: a geopandas dataframe with geometry columns
         ground_df: a geopandas dataframe with geometry columns
-        summarize: Whether to group statistics by plot and overall score
-        image_coordinates: Whether the current boxes are in coordinate system of the image, e.g. origin (0,0) upper left.
-        root_dir: Where to search for image names in df
-        savedir: optional directory to save image with overlaid predictions and annotations
 
     Returns:
-        result: pandas dataframe with crown ids of prediciton and ground truth and the IoU score.
+        result: pandas dataframe with crown ids of prediction and ground truth and the IoU score.
     """
     plot_names = predictions["image_path"].unique()
     if len(plot_names) > 1:
         raise ValueError("More than one plot passed to image crown: {}".format(plot_name))
-    else:
-        plot_name = plot_names[0]
 
     # match
     result = IoU.compute_IoU(ground_df, predictions)
@@ -41,12 +31,6 @@ def evaluate_image_boxes(predictions, ground_df, root_dir, savedir=None):
     result["predicted_label"] = result.prediction_id.apply(
         lambda x: predictions.label.loc[x] if pd.notnull(x) else x)
     result["true_label"] = result.truth_id.apply(lambda x: ground_df.label.loc[x])
-
-    if savedir:
-        image = np.array(Image.open("{}/{}".format(root_dir, plot_name)))[:, :, ::-1]
-        image = visualize.plot_predictions(image, df=predictions)
-        image = visualize.plot_predictions(image, df=ground_df, color=(0, 165, 255))
-        cv2.imwrite("{}/{}".format(savedir, plot_name), image)
 
     return result
 
@@ -91,16 +75,13 @@ def compute_class_recall(results):
 
 def __evaluate_wrapper__(predictions,
                          ground_df,
-                         root_dir,
                          iou_threshold,
-                         numeric_to_label_dict,
-                         savedir=None):
+                         numeric_to_label_dict):
     """Evaluate a set of predictions against a ground truth csv file
         Args:   
             predictions: a pandas dataframe, if supplied a root dir is needed to give the relative path of files in df.name. The labels in ground truth and predictions must match. If one is numeric, the other must be numeric.
-            root_dir: location of files in the dataframe 'name' column.
+            ground_df: a pandas dataframe, if supplied a root dir is needed to give the relative path of files in df.name
             iou_threshold: intersection-over-union threshold, see deepforest.evaluate
-            savedir: optional directory to save image with overlaid predictions and annotations
         Returns:
             results: a dictionary of results with keys, results, box_recall, box_precision, class_recall
         """
@@ -128,9 +109,7 @@ def __evaluate_wrapper__(predictions,
     elif prediction_geometry == "box":
         results = evaluate_boxes(predictions=predictions,
                                  ground_df=ground_df,
-                                 root_dir=root_dir,
-                                 iou_threshold=iou_threshold,
-                                 savedir=savedir)
+                                 iou_threshold=iou_threshold)
     else:
         raise NotImplementedError(
             "Geometry type {} not implemented".format(prediction_geometry))
@@ -149,15 +128,14 @@ def __evaluate_wrapper__(predictions,
     return results
 
 
-def evaluate_boxes(predictions, ground_df, root_dir, iou_threshold=0.4, savedir=None):
+def evaluate_boxes(predictions, ground_df, iou_threshold=0.4):
     """Image annotated crown evaluation routine submission can be submitted as
     a .shp, existing pandas dataframe or .csv path.
 
     Args:
-        predictions: a pandas dataframe, if supplied a root dir is needed to give the relative path of files in df.name. The labels in ground truth and predictions must match. If one is numeric, the other must be numeric.
-        ground_df: a pandas dataframe, if supplied a root dir is needed to give the relative path of files in df.name
-        root_dir: location of files in the dataframe 'name' column.
-        savedir: optional directory to save image with overlaid predictions and annotations
+        predictions: a pandas dataframe with geometry columns. The labels in ground truth and predictions must match. If one is numeric, the other must be numeric.
+        ground_df: a pandas dataframe with geometry columns
+        iou_threshold: intersection-over-union threshold, see deepforest.evaluate
 
     Returns:
         results: a dataframe of match bounding boxes
@@ -192,9 +170,7 @@ def evaluate_boxes(predictions, ground_df, root_dir, iou_threshold=0.4, savedir=
         else:
             group = group.reset_index(drop=True)
             result = evaluate_image_boxes(predictions=image_predictions,
-                                          ground_df=group,
-                                          root_dir=root_dir,
-                                          savedir=savedir)
+                                          ground_df=group)
 
         result["image_path"] = image_path
         result["match"] = result.IoU > iou_threshold
@@ -222,15 +198,13 @@ def evaluate_boxes(predictions, ground_df, root_dir, iou_threshold=0.4, savedir=
     }
 
 
-def _point_recall_image_(predictions, ground_df, root_dir=None, savedir=None):
+def _point_recall_image_(predictions, ground_df):
     """Compute intersection-over-union matching among prediction and ground
     truth boxes for one image.
 
     Args:
         predictions: a pandas dataframe. The labels in ground truth and predictions must match. For example, if one is numeric, the other must be numeric.
         ground_df: a pandas dataframe
-        root_dir: location of files in the dataframe 'name' column, only needed if savedir is supplied
-        savedir: optional directory to save image with overlaid predictions and annotations
 
     Returns:
         result: pandas dataframe with crown ids of prediciton and ground truth and the IoU score.
@@ -259,20 +233,10 @@ def _point_recall_image_(predictions, ground_df, root_dir=None, savedir=None):
         })
     result = result.drop(columns=["index_right"])
 
-    if savedir:
-        if root_dir is None:
-            raise AttributeError("savedir is {}, but root dir is None".format(savedir))
-        image = np.array(Image.open("{}/{}".format(root_dir, plot_name)))[:, :, ::-1]
-        image = visualize.plot_predictions(image, df=predictions)
-        image = visualize.plot_points(image,
-                                      points=ground_df[["x", "y"]].values,
-                                      color=(0, 165, 255))
-        cv2.imwrite("{}/{}".format(savedir, plot_name), image)
-
     return result
 
 
-def point_recall(predictions, ground_df, root_dir=None, savedir=None):
+def point_recall(predictions, ground_df):
     """Evaluate the proportion on ground truth points overlap with predictions
     submission can be submitted as a .shp, existing pandas dataframe or .csv
     path For bounding box recall, see evaluate().
@@ -280,18 +244,12 @@ def point_recall(predictions, ground_df, root_dir=None, savedir=None):
     Args:
         predictions: a pandas dataframe, if supplied a root dir is needed to give the relative path of files in df.name. The labels in ground truth and predictions must match. If one is numeric, the other must be numeric.
         ground_df: a pandas dataframe, if supplied a root dir is needed to give the relative path of files in df.name
-        root_dir: location of files in the dataframe 'name' column.
-        savedir: optional directory to save image with overlaid predictions and annotations
 
     Returns:
         results: a dataframe of matched bounding boxes and ground truth labels
         box_recall: proportion of true positives between predicted boxes and ground truth points, regardless of class
         class_recall: a pandas dataframe of class level recall and precision with class sizes
     """
-    if savedir:
-        if root_dir is None:
-            raise AttributeError("savedir is {}, but root dir is None".format(savedir))
-
     # Run evaluation on all images
     results = []
     box_recalls = []
@@ -314,9 +272,7 @@ def point_recall(predictions, ground_df, root_dir=None, savedir=None):
         else:
             group = group.reset_index(drop=True)
             result = _point_recall_image_(predictions=image_predictions,
-                                          ground_df=group,
-                                          root_dir=root_dir,
-                                          savedir=savedir)
+                                          ground_df=group)
 
         result["image_path"] = image_path
 

--- a/src/deepforest/evaluate.py
+++ b/src/deepforest/evaluate.py
@@ -22,7 +22,8 @@ def evaluate_image_boxes(predictions, ground_df):
     """
     plot_names = predictions["image_path"].unique()
     if len(plot_names) > 1:
-        raise ValueError("More than one plot passed to image crown: {}".format(plot_names))
+        raise ValueError(
+            "More than one plot passed to image crown: {}".format(plot_names))
 
     # match
     result = IoU.compute_IoU(ground_df, predictions)
@@ -73,10 +74,7 @@ def compute_class_recall(results):
     return class_recall
 
 
-def __evaluate_wrapper__(predictions,
-                         ground_df,
-                         iou_threshold,
-                         numeric_to_label_dict):
+def __evaluate_wrapper__(predictions, ground_df, iou_threshold, numeric_to_label_dict):
     """Evaluate a set of predictions against a ground truth csv file
         Args:   
             predictions: a pandas dataframe, if supplied a root dir is needed to give the relative path of files in df.name. The labels in ground truth and predictions must match. If one is numeric, the other must be numeric.
@@ -169,8 +167,7 @@ def evaluate_boxes(predictions, ground_df, iou_threshold=0.4):
             continue
         else:
             group = group.reset_index(drop=True)
-            result = evaluate_image_boxes(predictions=image_predictions,
-                                          ground_df=group)
+            result = evaluate_image_boxes(predictions=image_predictions, ground_df=group)
 
         result["image_path"] = image_path
         result["match"] = result.IoU > iou_threshold
@@ -271,8 +268,7 @@ def point_recall(predictions, ground_df):
             continue
         else:
             group = group.reset_index(drop=True)
-            result = _point_recall_image_(predictions=image_predictions,
-                                          ground_df=group)
+            result = _point_recall_image_(predictions=image_predictions, ground_df=group)
 
         result["image_path"] = image_path
 

--- a/src/deepforest/evaluate.py
+++ b/src/deepforest/evaluate.py
@@ -22,7 +22,7 @@ def evaluate_image_boxes(predictions, ground_df):
     """
     plot_names = predictions["image_path"].unique()
     if len(plot_names) > 1:
-        raise ValueError("More than one plot passed to image crown: {}".format(plot_name))
+        raise ValueError("More than one plot passed to image crown: {}".format(plot_names))
 
     # match
     result = IoU.compute_IoU(ground_df, predictions)

--- a/src/deepforest/main.py
+++ b/src/deepforest/main.py
@@ -823,9 +823,7 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
                 results = evaluate_iou.__evaluate_wrapper__(
                     predictions=self.predictions_df,
                     ground_df=ground_df,
-                    root_dir=self.config["validation"]["root_dir"],
                     iou_threshold=self.config["validation"]["iou_threshold"],
-                    savedir=None,
                     numeric_to_label_dict=self.numeric_to_label_dict)
 
                 if empty_accuracy is not None:
@@ -957,22 +955,20 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
         else:
             return optimizer
 
-    def evaluate(self, csv_file, root_dir, iou_threshold=None, savedir=None):
+    def evaluate(self, csv_file, iou_threshold=None):
         """Compute intersection-over-union and precision/recall for a given
         iou_threshold.
 
         Args:
             csv_file: location of a csv file with columns "name","xmin","ymin","xmax","ymax","label"
-            root_dir: location of files in the dataframe 'name' column
             iou_threshold: float [0,1] intersection-over-union threshold for true positive
-            savedir: location to save images with bounding boxes
 
         Returns:
             dict: Results dictionary containing precision, recall and other metrics
         """
         ground_df = utilities.read_file(csv_file)
         ground_df["label"] = ground_df.label.apply(lambda x: self.label_dict[x])
-        predictions = self.predict_file(csv_file=csv_file, root_dir=root_dir)
+        predictions = self.predict_file(csv_file=csv_file, root_dir=os.path.dirname(csv_file))
 
         if iou_threshold is None:
             iou_threshold = self.config["validation"]["iou_threshold"]
@@ -980,7 +976,6 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
         results = evaluate_iou.__evaluate_wrapper__(
             predictions=predictions,
             ground_df=ground_df,
-            root_dir=root_dir,
             iou_threshold=iou_threshold,
             numeric_to_label_dict=self.numeric_to_label_dict)
 

--- a/src/deepforest/main.py
+++ b/src/deepforest/main.py
@@ -968,7 +968,8 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
         """
         ground_df = utilities.read_file(csv_file)
         ground_df["label"] = ground_df.label.apply(lambda x: self.label_dict[x])
-        predictions = self.predict_file(csv_file=csv_file, root_dir=os.path.dirname(csv_file))
+        predictions = self.predict_file(csv_file=csv_file,
+                                        root_dir=os.path.dirname(csv_file))
 
         if iou_threshold is None:
             iou_threshold = self.config["validation"]["iou_threshold"]

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -101,41 +101,6 @@ def test_compute_class_recall(sample_results):
     assert evaluate.compute_class_recall(sample_results).equals(expected_recall)
 
 
-@pytest.mark.parametrize("root_dir", [None, "tmpdir"])
-def test_point_recall_image(root_dir, tmpdir):
-    img_path = get_data("OSBS_029.png")
-    if root_dir == "tmpdir":
-        root_dir = os.path.dirname(img_path)
-    else:
-        root_dir = None
-
-    # create sample dataframes
-    predictions = pd.DataFrame({
-        "image_path": ["OSBS_029.png", "OSBS_029.png"],
-        "xmin": [1, 150],
-        "xmax": [100, 200],
-        "ymin": [1, 75],
-        "ymax": [50, 100],
-        "label": ["A", "B"],
-    })
-    ground_df = pd.DataFrame({
-        "image_path": ["OSBS_029.png", "OSBS_029.png"],
-        "x": [5, 20],
-        "y": [30, 300],
-        "label": ["A", "B"],
-    })
-
-    # run the function
-    result = evaluate._point_recall_image_(predictions, ground_df)
-
-    # check the output, 1 match of 2 ground truth
-    assert all(result.predicted_label.isnull().values == [False, True])
-    assert isinstance(result, gpd.GeoDataFrame)
-    assert "predicted_label" in result.columns
-    assert "true_label" in result.columns
-    assert "geometry" in result.columns
-
-
 def test_point_recall():
     # create sample dataframes
     predictions = pd.DataFrame({

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -18,8 +18,7 @@ def test_evaluate_image(m):
     ground_truth = read_file(csv_file)
     predictions.label = 0
     result = evaluate.evaluate_image_boxes(predictions=predictions,
-                                           ground_df=ground_truth,
-                                           root_dir=os.path.dirname(csv_file))
+                                           ground_df=ground_truth)
 
     assert result.shape[0] == ground_truth.shape[0]
     assert sum(result.IoU) > 10
@@ -32,8 +31,7 @@ def test_evaluate_boxes(m, tmpdir):
     ground_truth = read_file(csv_file)
     predictions = predictions.loc[range(10)]
     results = evaluate.evaluate_boxes(predictions=predictions,
-                                      ground_df=ground_truth,
-                                      root_dir=os.path.dirname(csv_file))
+                                      ground_df=ground_truth)
 
     assert results["results"].shape[0] == ground_truth.shape[0]
     assert results["box_recall"] > 0.1
@@ -54,8 +52,7 @@ def test_evaluate_boxes_multiclass():
     predictions["score"] = 1
     predictions.iloc[[36, 35, 34], predictions.columns.get_indexer(['label'])]
     results = evaluate.evaluate_boxes(predictions=predictions,
-                                      ground_df=ground_truth,
-                                      root_dir=os.path.dirname(csv_file))
+                                      ground_df=ground_truth)
 
     assert results["results"].shape[0] == ground_truth.shape[0]
     assert results["class_recall"].shape == (2, 4)
@@ -71,18 +68,14 @@ def test_evaluate_boxes_save_images(tmpdir):
     predictions["score"] = 1
     predictions.iloc[[36, 35, 34], predictions.columns.get_indexer(['label'])]
     results = evaluate.evaluate_boxes(predictions=predictions,
-                                      ground_df=ground_truth,
-                                      root_dir=os.path.dirname(csv_file),
-                                      savedir=tmpdir)
-    assert all([os.path.exists("{}/{}".format(tmpdir, x)) for x in ground_truth.image_path])
+                                      ground_df=ground_truth)
 
 
 def test_evaluate_empty(m):
     m = main.deepforest()
     m.config["score_thresh"] = 0.8
     csv_file = get_data("OSBS_029.csv")
-    root_dir = os.path.dirname(csv_file)
-    results = m.evaluate(csv_file, root_dir, iou_threshold=0.4)
+    results = m.evaluate(csv_file, iou_threshold=0.4)
 
     # Does this make reasonable predictions, we know the model works.
     assert np.isnan(results["box_precision"])
@@ -113,9 +106,8 @@ def test_point_recall_image(root_dir, tmpdir):
     img_path = get_data("OSBS_029.png")
     if root_dir == "tmpdir":
         root_dir = os.path.dirname(img_path)
-        savedir = tmpdir
     else:
-        savedir = None
+        root_dir = None
 
     # create sample dataframes
     predictions = pd.DataFrame({
@@ -134,7 +126,7 @@ def test_point_recall_image(root_dir, tmpdir):
     })
 
     # run the function
-    result = evaluate._point_recall_image_(predictions, ground_df, root_dir=root_dir, savedir=savedir)
+    result = evaluate._point_recall_image_(predictions, ground_df)
 
     # check the output, 1 match of 2 ground truth
     assert all(result.predicted_label.isnull().values == [False, True])

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -101,6 +101,34 @@ def test_compute_class_recall(sample_results):
     assert evaluate.compute_class_recall(sample_results).equals(expected_recall)
 
 
+def test_point_recall_image():
+    # create sample dataframes
+    predictions = pd.DataFrame({
+        "image_path": ["OSBS_029.png", "OSBS_029.png"],
+        "xmin": [1, 150],
+        "xmax": [100, 200],
+        "ymin": [1, 75],
+        "ymax": [50, 100],
+        "label": ["A", "B"],
+    })
+    ground_df = pd.DataFrame({
+        "image_path": ["OSBS_029.png", "OSBS_029.png"],
+        "x": [5, 20],
+        "y": [30, 300],
+        "label": ["A", "B"],
+    })
+
+    # run the function
+    result = evaluate._point_recall_image_(predictions, ground_df)
+
+    # check the output, 1 match of 2 ground truth
+    assert all(result.predicted_label.isnull().values == [False, True])  # First point inside box, second point outside
+    assert isinstance(result, gpd.GeoDataFrame)
+    assert "predicted_label" in result.columns
+    assert "true_label" in result.columns
+    assert "geometry" in result.columns
+
+
 def test_point_recall():
     # create sample dataframes
     predictions = pd.DataFrame({

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -367,11 +367,8 @@ def test_predict_tile_no_mosaic(m, raster_path):
 
 def test_evaluate(m, tmpdir):
     csv_file = get_data("OSBS_029.csv")
-    root_dir = os.path.dirname(csv_file)
+    results = m.evaluate(csv_file, iou_threshold=0.4)
 
-    results = m.evaluate(csv_file, root_dir, iou_threshold=0.4)
-
-    # Does this make reasonable predictions, we know the model works.
     assert np.round(results["box_precision"], 2) > 0.5
     assert np.round(results["box_recall"], 2) > 0.5
     assert len(results["results"].predicted_label.dropna().unique()) == 1


### PR DESCRIPTION
fixes #961 
fixes #964

Removing root_dir from evaluate_image_boxes and evaluate_boxes.
Eliminating unnecessary visualize.plot_predictions and cv2.imwrite calls.

Co-authored-by: Samia Haque Tisha <samiatisha35@gmail.com>