### PR TITLE
Update `images_callback` to use `plot_results` and fix `root_dir` issue (fixed #934)

### DIFF
--- a/src/deepforest/visualize.py
+++ b/src/deepforest/visualize.py
@@ -503,6 +503,8 @@ def plot_results(results,
     # Read images
     if image is None:
         root_dir = results.root_dir
+        # expected str, bytes or os.PathLike object, not Series
+        root_dir = root_dir.iloc[0] if isinstance(root_dir, pd.Series) else root_dir
         image_path = os.path.join(root_dir, results.image_path.unique()[0])
         image = np.array(Image.open(image_path))
 


### PR DESCRIPTION
#### **Description**
This PR updates the `images_callback` class in `callbacks.py` to use the `plot_results` function instead of the deprecated `plot_prediction_dataframe`. The changes include:

1. Replaced `plot_prediction_dataframe` with `plot_results`.
2. Added dynamic color handling using `sv.ColorPalette` for multi-class labels.
3. Fixed the `root_dir` issue by adding the `root_dir` column to the dataframe before calling `plot_results`.

#### **Errors Faced During Testing**
While testing the changes, the following errors were encountered:

1. **`AttributeError: 'DataFrame' object has no attribute 'root_dir'`**
   - **Cause:** The `plot_results` function expects a `root_dir` column in the dataframe, but it was missing.
   - **Fix:** Added the `root_dir` column to the dataframe using `pl_module.config["validation"]["root_dir"]`.

2. **`TypeError: expected str, bytes or os.PathLike object, not Series`**
- **Cause:** The `results.image_path.unique()[0]` was returning a Series instead of a string.
- **Fix:** Used `.iloc[0]` to extract the first unique value as a string.

#### **Changes Made**
- Updated `callbacks.py` to use `plot_results` instead of `plot_prediction_dataframe`.
- Added dynamic color handling for multi-class labels.
- Fixed the `root_dir` issue by adding the `root_dir` column to the dataframe.

#### **Verification Steps**
To verify the changes, follow these steps:

**Test Script:**
   ```python
   import os
   import pandas as pd
   import numpy as np
   from deepforest import visualize
   from matplotlib import pyplot as plt
   import tempfile
   from deepforest.callbacks import images_callback
   import supervision as sv
   from shapely.geometry import box

   # Mock the pl_module object
   class MockPLModule:
       def __init__(self, predictions, config):
           self.predictions = predictions
           self.config = config
           self.logger = None  # Add a dummy logger attribute

   # Create a sample dataframe
   data = {
       "image_path": ["OSBS_029.png", "SOAP_031.png", "SOAP_061.png"],
       "xmin": [10, 50, 20],
       "xmax": [100, 150, 120],
       "ymin": [10, 50, 20],
       "ymax": [100, 150, 120],
       "label": ["tree", "car", "tree"]
   }
   df = pd.DataFrame(data)

   # Convert bounding box coordinates to geometry objects
   df["geometry"] = df.apply(lambda row: box(row["xmin"], row["ymin"], row["xmax"], row["ymax"]), axis=1)

   # Root directory where images are stored
   root_dir = "src/deepforest/data"

   # Mock the pl_module object
   pl_module = MockPLModule(
       predictions=[df],  # Predictions is a list of dataframes
       config={"validation": {"root_dir": root_dir}}  # Root directory for images
   )

   # Create a temporary directory to save plots
   savedir = tempfile.mkdtemp()

   # Create a ColorPalette for multi-class labels
   num_classes = len(df["label"].unique())
   results_color = sv.ColorPalette.from_matplotlib('viridis', num_classes)

   # Instantiate the callback
   callback = images_callback(
       savedir=savedir,
       n=2,  # Number of images to plot
       every_n_epochs=1,
       select_random=False,
       color=results_color,  # Use ColorPalette for multi-class labels
       thickness=2
   )

   # Call the log_images method
   callback.log_images(pl_module)

   # Check the saved plots
   saved_plots = os.listdir(savedir)
   print("Saved plots:", saved_plots)

   # Display one of the saved plots
   if saved_plots:
       image_path = os.path.join(savedir, saved_plots[0])
       image = plt.imread(image_path)
       plt.imshow(image)
       plt.axis('off')  # Hide axes
       plt.show()
   ```

#### **Testing Environment**
- Windows 11 home
- Python: 3.11.11

---

### **Screenshot of Output**
![image](https://github.com/user-attachments/assets/74c56e23-0386-4b53-8e14-f825ce57b820)

---