### PR TITLE
Fixing Code of Conduct list formatting in documentation

### DIFF
--- a/docs/development/code_of_conduct.rst
+++ b/docs/development/code_of_conduct.rst
@@ -12,18 +12,19 @@ Our Standards
 
 Examples of behavior that contributes to creating a positive environment include:
 
-Using welcoming and inclusive language
-Being respectful of differing viewpoints and experiences
-Gracefully accepting constructive criticism
-Focusing on what is best for the community
-Showing empathy towards other community members
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
 Examples of unacceptable behavior by participants include:
 
-The use of sexualized language or imagery and unwelcome sexual attention or advances
-Trolling, insulting/derogatory comments, and personal or political attacks
-Public or private harassment
-Publishing others' private information, such as a physical or electronic address, without explicit permission
-Other conduct which could reasonably be considered inappropriate in a professional setting
+- The use of sexualized language or imagery and unwelcome sexual attention or advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
 
 Our Responsibilities
 ^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This pull request addresses a formatting issue in the **docs/development/Code_of_Conduct.rst** documentation. The "Our Standards" section has been updated to use bullet points for readability. Before this change, the section was formatted as a continuous paragraph, making it difficult to read and identify where one sentence ended and the next began. By introducing bullet points, the list is now clearly segmented. 