### PR TITLE
Fix #545: Add "path" arg and deprecate "raster_path"  in predict_tile()

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,12 @@
 DeepForest Changelog
 ====================
 
+Version x.x.x (Date: )
+---------------------------------
+
+- **Deprecation:** ``predict_tile`` in ``deepforest/main.py``. The ``raster_path`` argument is deprecated and will be removed in a future version.
+
+- **Enhancement:** Updated the ``predict_tile()`` function to use the ``path`` argument (replacing ``raster_path``) across all code, tests, and documentation for consistency.
 
 Version 1.5.2 (Date: Feb 7, 2025)
 ---------------------------------
@@ -47,7 +53,7 @@ Version 1.4.0 (Date: Oct 9, 2024)
 1. New model loading framework using HuggingFace. DeepForest models are now available on https://huggingface.co/weecology. The models can be loaded using load_model() and used for inference.
 2. An all purpose read_file method is introduced to read annotations from various formats including CSV, JSON, and Pascal VOC.
 3. The CropModel class is introduced to classify detected objects using a trained classification model. Use when a multi-class DeepForest model is not sufficiently flexible, such as when new data sources are used for fine-grained classification and class imbalance.
-4. deepforest.visualize.plot_results is now the primary method for visualizing predictions. The function is more flexible and allows for customizing the plot using supervision package. 
+4. deepforest.visualize.plot_results is now the primary method for visualizing predictions. The function is more flexible and allows for customizing the plot using supervision package.
 
 Additional features and enhancements include:
 

--- a/docs/getting_started/intro_tutorials/04_predict_large_tile.rst
+++ b/docs/getting_started/intro_tutorials/04_predict_large_tile.rst
@@ -21,9 +21,9 @@ Let’s show an example with a small image. For larger images, patch_size should
    # Load a pretrained tree detection model from Hugging Face
    model.load_model(model_name="weecology/deepforest-tree", revision="main")
    # Predict on large geospatial tiles using overlapping windows
-   raster_path = get_data("OSBS_029.tif")
-   predicted_raster = model.predict_tile(raster_path, patch_size=300, patch_overlap=0.25)
-   plot_results(predicted_raster)
+   path = get_data("OSBS_029.tif")
+   predicted_image = model.predict_tile(path=path, patch_size=300, patch_overlap=0.25)
+   plot_results(predicted_image)
 
 .. note::
 

--- a/docs/user_guide/03_cropmodels.rst
+++ b/docs/user_guide/03_cropmodels.rst
@@ -36,7 +36,7 @@ Consider a test file with tree boxes and an 'Alive/Dead' label that comes with a
     # Or set up the crop model or load weights model.CropModel.load_from_checkpoint(<path>)
 
     m.create_trainer()
-    result = m.predict_tile(raster_path=raster_path, crop_model=crop_model)
+    result = m.predict_tile(path=path, crop_model=crop_model)
 
 .. code-block:: python
 

--- a/docs/user_guide/07_scaling.md
+++ b/docs/user_guide/07_scaling.md
@@ -2,7 +2,7 @@
 
 ### Increase batch size
 
-It is more efficient to run a larger batch size on a single GPU. This is because the overhead of loading data and moving data between the CPU and GPU is relatively large. By running a larger batch size, we can reduce the overhead of these operations. 
+It is more efficient to run a larger batch size on a single GPU. This is because the overhead of loading data and moving data between the CPU and GPU is relatively large. By running a larger batch size, we can reduce the overhead of these operations.
 
 ```
 m.config["batch_size"] = 16
@@ -66,13 +66,13 @@ dask_client = Client(cluster)
 ```
 
 This job script gets a single GPUs with "40GB" of memory with 10 cpus. We then ask for 10 instances of this setup.
-Now that we have a dask client, we can send our custom function. 
+Now that we have a dask client, we can send our custom function.
 
 ```
 def function_to_parallelize(tile):
     m = main.deepforest()
     m.load_model("weecology/deepforest-tree") # sub in the custom logic to load your own models
-    boxes = m.predict_tile(raster_path=tile)
+    boxes = m.predict_tile(path=tile)
     # save the predictions using the tile pathname
     filename = "{}.csv".format(os.path.splitext(os.path.basename(tile))[0])
     filename = os.path.join(<savedir>,filename)
@@ -89,7 +89,7 @@ for tile in tiles:
     futures.append(future)
 ```
 
-We can wait to see the futures as they complete! Dask also has a beautiful visualization tool using bokeh. 
+We can wait to see the futures as they complete! Dask also has a beautiful visualization tool using bokeh.
 
 ```
 for x in futures:

--- a/docs/user_guide/08_visualizations.md
+++ b/docs/user_guide/08_visualizations.md
@@ -26,7 +26,7 @@ model = main.deepforest()
 model.load_model(model_name="weecology/deepforest-tree", revision="main")
 
 img_path = get_data(path="2019_YELL_2_528000_4978000_image_crop2.png")
-results = model.predict_tile(img_path, patch_overlap=0, patch_size=400)
+results = model.predict_tile(path=img_path, patch_overlap=0, patch_size=400)
 plot_results(results)
 ```
 

--- a/docs/user_guide/10_better.rst
+++ b/docs/user_guide/10_better.rst
@@ -21,7 +21,7 @@ example, here is a drone collected data at the standard 400px.
 
 .. code:: python
 
-   tile = model.predict_tile("/Users/ben/Desktop/test.jpg",return_plot=True,patch_overlap=0,iou_threshold=0.05,patch_size=400)
+   tile = model.predict_tile(path="/Users/ben/Desktop/test.jpg",return_plot=True,patch_overlap=0,iou_threshold=0.05,patch_size=400)
 
 |image1|
 

--- a/docs/user_guide/16_prediction.md
+++ b/docs/user_guide/16_prediction.md
@@ -2,7 +2,7 @@
 
 There are atleast four ways to make predictions with DeepForest.
 1. Predict an image using [model.predict_image](https://deepforest.readthedocs.io/en/latest/source/deepforest.html#deepforest.main.deepforest.predict_image)
-2. Predict a tile using [model.predict_tile](https://deepforest.readthedocs.io/en/latest/source/deepforest.html#deepforest.main.deepforest.predict_tile) 
+2. Predict a tile using [model.predict_tile](https://deepforest.readthedocs.io/en/latest/source/deepforest.html#deepforest.main.deepforest.predict_tile)
 3. Predict a directory of using a csv file using [model.predict_file](https://deepforest.readthedocs.io/en/latest/source/deepforest.html#deepforest.main.deepforest.predict_file)
 4. Predict a batch of images using [model.predict_batch](https://deepforest.readthedocs.io/en/latest/source/deepforest.html#deepforest.main.deepforest.predict_batch)
 
@@ -16,7 +16,7 @@ from deepforest.visualize import plot_results
 # Initialize the model class
 model = main.deepforest()
 
-# Load a pretrained tree detection model from Hugging Face 
+# Load a pretrained tree detection model from Hugging Face
 model.load_model(model_name="weecology/deepforest-tree", revision="main")
 
 sample_image_path = get_data("OSBS_029.png")
@@ -44,9 +44,9 @@ model = main.deepforest()
 model.load_model(model_name="weecology/deepforest-tree", revision="main")
 
 # Predict on large geospatial tiles using overlapping windows
-raster_path = get_data("OSBS_029.tif")
-predicted_raster = model.predict_tile(raster_path, patch_size=300, patch_overlap=0.25)
-plot_results(predicted_raster)
+path = get_data("OSBS_029.tif")
+predicted_image = model.predict_tile(path=path, patch_size=300, patch_overlap=0.25)
+plot_results(predicted_image)
 ```
 
 ### Patch Size
@@ -89,7 +89,7 @@ raster_path = get_data("OSBS_029.tif")
 tile = np.array(Image.open(raster_path))
 ds = dataset.TileDataset(tile=tile, patch_overlap=0.1, patch_size=100)
 dl = DataLoader(ds, batch_size=3)
-    
+
 # Perform prediction
 predictions = []
 for batch in dl:

--- a/docs/user_guide/examples/nest_detection.ipynb
+++ b/docs/user_guide/examples/nest_detection.ipynb
@@ -515,12 +515,12 @@
    "outputs": [],
    "source": [
     "# Add a path to an image to test the model on\n",
-    "raster_path = \"\"\n",
-    "predicted_raster = model.predict_tile(raster_path,\n",
+    "path = \"\"\n",
+    "predicted_image = model.predict_tile(path=path,\n",
     "                                      return_plot=True,\n",
     "                                      patch_size=300,\n",
     "                                      patch_overlap=0.25)\n",
-    "plt.imshow(predicted_raster)\n",
+    "plt.imshow(predicted_image)\n",
     "plt.show()"
    ]
   }

--- a/docs/user_guide/examples/simple_load_and_predict.py
+++ b/docs/user_guide/examples/simple_load_and_predict.py
@@ -8,7 +8,7 @@ m = main.deepforest()
 m.load_model(model_name="weecology/deepforest-tree")
 
 # Perform tree detection on the image
-trees = m.predict_tile(raster_path='<path to raster>', patch_size=3000, patch_overlap=0)
+trees = m.predict_tile(path='<path to image>', patch_size=3000, patch_overlap=0)
 
 # Filter out low-confidence detections
 trees = trees[trees.score > 0.3]

--- a/src/deepforest/main.py
+++ b/src/deepforest/main.py
@@ -486,6 +486,7 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
 
     def predict_tile(self,
                      raster_path=None,
+                     path=None,
                      image=None,
                      patch_size=400,
                      patch_overlap=0.05,
@@ -505,7 +506,8 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
         reassambles into a single array.
 
         Args:
-            raster_path: Path to image on disk
+            raster_path: [Deprecated] Use 'path' instead
+            path: Path to image on disk
             image (array): Numpy image array in BGR channel order following openCV convention
             patch_size: patch size for each window
             patch_overlap: patch overlap among windows
@@ -527,6 +529,13 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
         self.model.eval()
         self.model.nms_thresh = self.config["nms_thresh"]
 
+        # if 'raster_path' is used, give a deprecation warning and use 'path' instead
+        if raster_path is not None:
+            warnings.warn(
+                "The 'raster_path' argument is deprecated and will be removed in 2.0. Use 'path' instead.",
+                DeprecationWarning)
+            path = raster_path
+
         # if more than one GPU present, use only a the first available gpu
         if torch.cuda.device_count() > 1:
             # Get available gpus and regenerate trainer
@@ -535,24 +544,24 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
             self.config["devices"] = 1
             self.create_trainer()
 
-        if (raster_path is None) and (image is None):
+        if (path is None) and (image is None):
             raise ValueError(
                 "Both tile and tile_path are None. Either supply a path to a tile on disk, or read one into memory!"
             )
 
         if in_memory:
-            if raster_path is None:
+            if path is None:
                 image = image
             else:
-                image = rio.open(raster_path).read()
+                image = rio.open(path).read()
                 image = np.moveaxis(image, 0, 2)
 
             ds = dataset.TileDataset(tile=image,
                                      patch_overlap=patch_overlap,
                                      patch_size=patch_size)
         else:
-            if raster_path is None:
-                raise ValueError("raster_path is required if in_memory is False")
+            if path is None:
+                raise ValueError("path is required if in_memory is False")
 
             # Check for workers config when using out of memory dataset
             if self.config["workers"] > 0:
@@ -560,7 +569,7 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
                     "workers must be 0 when using out-of-memory dataset (in_memory=False). Set config['workers']=0 and recreate trainer self.create_trainer()."
                 )
 
-            ds = dataset.RasterDataset(raster_path=raster_path,
+            ds = dataset.RasterDataset(raster_path=path,
                                        patch_overlap=patch_overlap,
                                        patch_size=patch_size)
 
@@ -580,15 +589,15 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
                                      iou_threshold=iou_threshold)
             results["label"] = results.label.apply(
                 lambda x: self.numeric_to_label_dict[x])
-            if raster_path:
-                results["image_path"] = os.path.basename(raster_path)
+            if path:
+                results["image_path"] = os.path.basename(path)
             if return_plot:
                 # Add deprecated warning
                 warnings.warn("return_plot is deprecated and will be removed in 2.0. "
                               "Use visualize.plot_results on the result instead.")
                 # Draw predictions on BGR
-                if raster_path:
-                    tile = rio.open(raster_path).read()
+                if path:
+                    tile = rio.open(path).read()
                 else:
                     tile = image
                 drawn_plot = tile[:, :, ::-1]
@@ -603,10 +612,10 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
 
             # TODO this is the 2nd time the crops are generated? Could be more efficient, but memory intensive
             self.crops = []
-            if raster_path is None:
+            if path is None:
                 image = image
             else:
-                image = rio.open(raster_path).read()
+                image = rio.open(path).read()
                 image = np.moveaxis(image, 0, 2)
 
             for window in ds.windows:
@@ -619,7 +628,7 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
             # If a crop model is provided, predict on each crop
             results = predict._predict_crop_model_(crop_model=crop_model,
                                                    results=results,
-                                                   raster_path=raster_path,
+                                                   raster_path=path,
                                                    trainer=self.trainer,
                                                    transform=crop_transform,
                                                    augment=crop_augment)
@@ -627,14 +636,14 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
             warnings.warn("No predictions made, returning None")
             return None
 
-        if raster_path is None:
+        if path is None:
             warnings.warn(
                 "An image was passed directly to predict_tile, the results.root_dir attribute will be None in the output dataframe, to use visualize.plot_results, please assign results.root_dir = <directory name>"
             )
             results = utilities.read_file(results)
 
         else:
-            root_dir = os.path.dirname(raster_path)
+            root_dir = os.path.dirname(path)
             results = utilities.read_file(results, root_dir=root_dir)
 
         return results

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -89,7 +89,7 @@ def m_without_release():
 
 
 @pytest.fixture()
-def raster_path():
+def path():
     return get_data(path='OSBS_029.tif')
 
 
@@ -297,33 +297,33 @@ def test_predict_small_file(m, tmpdir):
     }
 
 @pytest.mark.parametrize("batch_size", [1, 2])
-def test_predict_dataloader(m, batch_size, raster_path):
+def test_predict_dataloader(m, batch_size, path):
     m.config["batch_size"] = batch_size
-    tile = np.array(Image.open(raster_path))
+    tile = np.array(Image.open(path))
     ds = dataset.TileDataset(tile=tile, patch_overlap=0.1, patch_size=100)
     dl = m.predict_dataloader(ds)
     batch = next(iter(dl))
     batch.shape[0] == batch_size
 
 
-def test_predict_tile_empty(raster_path):
+def test_predict_tile_empty(path):
     # Random weights
     m = main.deepforest()
-    predictions = m.predict_tile(raster_path=raster_path, patch_size=300, patch_overlap=0)
+    predictions = m.predict_tile(path=path, patch_size=300, patch_overlap=0)
     assert predictions is None
 
 @pytest.mark.parametrize("in_memory", [True, False])
-def test_predict_tile(m, raster_path, in_memory):
+def test_predict_tile(m, path, in_memory):
     m.create_model()
     m.config["train"]["fast_dev_run"] = False
     m.create_trainer()
 
     if in_memory:
-        raster_path = raster_path
+        path = path
     else:
-        raster_path = get_data("test_tiled.tif")
+        path = get_data("test_tiled.tif")
 
-    prediction = m.predict_tile(raster_path=raster_path,
+    prediction = m.predict_tile(path=path,
                                 patch_size=300,
                                 in_memory=in_memory,
                                 patch_overlap=0.1)
@@ -336,27 +336,27 @@ def test_predict_tile(m, raster_path, in_memory):
 
 # test equivalence for in_memory=True and False
 def test_predict_tile_equivalence(m):
-    raster_path = get_data("test_tiled.tif")
-    in_memory_prediction = m.predict_tile(raster_path=raster_path, patch_size=300, patch_overlap=0, in_memory=True)
-    not_in_memory_prediction = m.predict_tile(raster_path=raster_path, patch_size=300, patch_overlap=0, in_memory=False)
+    path = get_data("test_tiled.tif")
+    in_memory_prediction = m.predict_tile(path=path, patch_size=300, patch_overlap=0, in_memory=True)
+    not_in_memory_prediction = m.predict_tile(path=path, patch_size=300, patch_overlap=0, in_memory=False)
     assert in_memory_prediction.equals(not_in_memory_prediction)
 
-def test_predict_tile_from_array(m, raster_path):
+def test_predict_tile_from_array(m, path):
     # test predict numpy image
-    image = np.array(Image.open(raster_path))
+    image = np.array(Image.open(path))
     m.config["train"]["fast_dev_run"] = False
     m.create_trainer()
     prediction = m.predict_tile(image=image,
                                 patch_size=300)
-    
+
     assert not prediction.empty
 
 
-def test_predict_tile_no_mosaic(m, raster_path):
+def test_predict_tile_no_mosaic(m, path):
     # test no mosaic, return a tuple of crop and prediction
     m.config["train"]["fast_dev_run"] = False
     m.create_trainer()
-    prediction = m.predict_tile(raster_path=raster_path,
+    prediction = m.predict_tile(path=path,
                                 patch_size=300,
                                 patch_overlap=0,
                                 mosaic=False)
@@ -661,7 +661,7 @@ def crop_model():
 
 
 def test_predict_tile_with_crop_model(m, config):
-    raster_path = get_data("SOAP_061.png")
+    path = get_data("SOAP_061.png")
     patch_size = 400
     patch_overlap = 0.05
     iou_threshold = 0.15
@@ -672,7 +672,7 @@ def test_predict_tile_with_crop_model(m, config):
     # Call the predict_tile method with the crop_model
     m.config["train"]["fast_dev_run"] = False
     m.create_trainer()
-    result = m.predict_tile(raster_path=raster_path,
+    result = m.predict_tile(path=path,
                             patch_size=patch_size,
                             patch_overlap=patch_overlap,
                             iou_threshold=iou_threshold,
@@ -689,7 +689,7 @@ def test_predict_tile_with_crop_model(m, config):
 
 def test_predict_tile_with_crop_model_empty():
     """If the model return is empty, the crop model should return an empty dataframe"""
-    raster_path = get_data("SOAP_061.png")
+    path = get_data("SOAP_061.png")
     m = main.deepforest()
     patch_size = 400
     patch_overlap = 0.05
@@ -701,7 +701,7 @@ def test_predict_tile_with_crop_model_empty():
     # Call the predict_tile method with the crop_model
     m.config["train"]["fast_dev_run"] = False
     m.create_trainer()
-    result = m.predict_tile(raster_path=raster_path,
+    result = m.predict_tile(path=path,
                             patch_size=patch_size,
                             patch_overlap=patch_overlap,
                             iou_threshold=iou_threshold,
@@ -711,18 +711,18 @@ def test_predict_tile_with_crop_model_empty():
     # Assert the result
     assert result is None
 
-def test_batch_prediction(m, raster_path):
+def test_batch_prediction(m, path):
     # Prepare input data
-    tile = np.array(Image.open(raster_path))
+    tile = np.array(Image.open(path))
     ds = dataset.TileDataset(tile=tile, patch_overlap=0.1, patch_size=300)
     dl = DataLoader(ds, batch_size=3)
-    
+
     # Perform prediction
     predictions = []
     for batch in dl:
         prediction = m.predict_batch(batch)
         predictions.append(prediction)
-    
+
     # Check results
     assert len(predictions) == len(dl)
     for batch_pred in predictions:
@@ -732,25 +732,25 @@ def test_batch_prediction(m, raster_path):
             assert "score" in image_pred.columns
             assert "geometry" in image_pred.columns
 
-def test_batch_inference_consistency(m, raster_path):
-    tile = np.array(Image.open(raster_path))
+def test_batch_inference_consistency(m, path):
+    tile = np.array(Image.open(path))
     ds = dataset.TileDataset(tile=tile, patch_overlap=0.1, patch_size=300)
     dl = DataLoader(ds, batch_size=4)
-    
+
     batch_predictions = []
     for batch in dl:
         prediction = m.predict_batch(batch)
         batch_predictions.extend(prediction)
-    
+
     single_predictions = []
     for image in ds:
         image = image.permute(1,2,0).numpy() * 255
         prediction = m.predict_image(image=image)
         single_predictions.append(prediction)
-    
+
     batch_df = pd.concat(batch_predictions, ignore_index=True)
     single_df = pd.concat(single_predictions, ignore_index=True)
-    
+
     # Make all xmin, ymin, xmax, ymax integers
     for col in ["xmin", "ymin", "xmax", "ymax"]:
         batch_df[col] = batch_df[col].astype(int)
@@ -866,10 +866,10 @@ def test_evaluate_on_epoch_interval(m):
 def test_set_labels_updates_mapping(m):
     new_mapping = {"Object": 0}
     m.set_labels(new_mapping)
-    
+
     # Verify that the label dictionary has been updated.
     assert m.label_dict == new_mapping
-    
+
     # Verify that the inverse mapping is correctly computed.
     expected_inverse = {0: "Object"}
     assert m.numeric_to_label_dict == expected_inverse

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -73,7 +73,7 @@ def test_predict_image_and_plot(m, tmpdir):
 
 def test_predict_tile_and_plot(m, tmpdir):
     sample_image_path = get_data("OSBS_029.png")
-    results = m.predict_tile(raster_path=sample_image_path)
+    results = m.predict_tile(path=sample_image_path)
     visualize.plot_results(results, savedir=tmpdir)
 
     assert os.path.exists(os.path.join(tmpdir, "OSBS_029.png"))


### PR DESCRIPTION
I sincerely apologize for the inconvenience I caused earlier. I truly appreciate your patience and guidance. If it’s okay, I have now tried to organize everything freshly with an updated version.

This PR solves the issue #545 by updating the `predict_tile` function to use `path` as an alternative to `raster_path` while issuing a deprecation warning when `raster_path` is used. I have also tried to maintain the test cases.

Here's what I modified-
**In `main.py`:**  
- Introduced `path` as a replacement for `raster_path`.  
- Issued a `DeprecationWarning` when `raster_path` is provided.  
- Updated all references to `raster_path` to use `path`.  

**In `test_main.py`:**  Updated the test cases to use `path` instead of `raster_path`.

**In `test_visualize.py`:**  Modified `test_predict_tile_and_plot` to use `path` instead of `raster_path`.  


I did not modify the following function in `test_dataset.py`

```python
def raster_path():
    return get_data(path='OSBS_029.tif')
```
Please review this and let me know if this function should also be updated along with any further modifications.