### PR TITLE
Fix: Automatically handle root_dir in image_to_geo_coordinates function

### DIFF
--- a/src/deepforest/utilities.py
+++ b/src/deepforest/utilities.py
@@ -542,7 +542,7 @@ def check_image(image):
                          "found image with shape {}".format(image.shape))
 
 
-def image_to_geo_coordinates(gdf, root_dir, flip_y_axis=False):
+def image_to_geo_coordinates(gdf, flip_y_axis=False):
     """Convert from image coordinates to geographic coordinates.
 
     Args:
@@ -561,6 +561,13 @@ def image_to_geo_coordinates(gdf, root_dir, flip_y_axis=False):
             .format(plot_names))
     else:
         plot_name = plot_names[0]
+
+    # Automatically use root_dir if it exists in the 'predictions' object (passed as gdf)
+    if hasattr(gdf, 'root_dir') and gdf.root_dir:
+        root_dir = gdf.root_dir
+    else:
+        raise ValueError("root_dir is missing from the prediction object.")
+    
 
     rgb_path = "{}/{}".format(root_dir, plot_name)
     with rasterio.open(rgb_path) as dataset:

--- a/src/deepforest/utilities.py
+++ b/src/deepforest/utilities.py
@@ -567,7 +567,6 @@ def image_to_geo_coordinates(gdf, flip_y_axis=False):
         root_dir = gdf.root_dir
     else:
         raise ValueError("root_dir is missing from the prediction object.")
-    
 
     rgb_path = "{}/{}".format(root_dir, plot_name)
     with rasterio.open(rgb_path) as dataset:


### PR DESCRIPTION
This PR addresses issue #1000 by modifying the `image_to_geo_coordinates` function to automatically handle the `root_dir` attribute from the predictions object. The function now checks if `root_dir` exists within the predictions and uses it if available. If `root_dir` is missing, the function raises a clear error.

Changes made:

1. Removed `root_dir` as a function parameter.
2. Implemented automatic detection of `root_dir` within the predictions object.