### PR TITLE
Update read_file and TreeDataset class to look at geometry column in shapefiles without geospatial reference data.

### DIFF
--- a/src/deepforest/dataset.py
+++ b/src/deepforest/dataset.py
@@ -28,6 +28,7 @@ from rasterio.windows import Window
 from torchvision import transforms
 import slidingwindow
 import warnings
+import shapely
 
 
 def get_transform(augment):
@@ -105,8 +106,12 @@ class TreeDataset(Dataset):
             image_annotations = self.annotations[self.annotations.image_path ==
                                                  self.image_names[idx]]
             targets = {}
-            targets["boxes"] = image_annotations[["xmin", "ymin", "xmax",
-                                                  "ymax"]].values.astype("float32")
+
+            if "geometry" in image_annotations.columns:
+                targets["boxes"] = np.array([shapely.wkt.loads(x).bounds for x in image_annotations.geometry]).astype("float32")
+            else:
+                targets["boxes"] = image_annotations[["xmin", "ymin", "xmax",
+                                                      "ymax"]].values.astype("float32")
 
             # Labels need to be encoded
             targets["labels"] = image_annotations.label.apply(

--- a/src/deepforest/dataset.py
+++ b/src/deepforest/dataset.py
@@ -108,7 +108,9 @@ class TreeDataset(Dataset):
             targets = {}
 
             if "geometry" in image_annotations.columns:
-                targets["boxes"] = np.array([shapely.wkt.loads(x).bounds for x in image_annotations.geometry]).astype("float32")
+                targets["boxes"] = np.array([
+                    shapely.wkt.loads(x).bounds for x in image_annotations.geometry
+                ]).astype("float32")
             else:
                 targets["boxes"] = image_annotations[["xmin", "ymin", "xmax",
                                                       "ymax"]].values.astype("float32")

--- a/src/deepforest/utilities.py
+++ b/src/deepforest/utilities.py
@@ -145,7 +145,6 @@ def xml_to_annotations(xml_path):
     return read_pascal_voc(xml_path)
 
 
-# TO DO -> Should this whole function hae a deprecation warning? Shouldn't users just use the read_file function?
 def shapefile_to_annotations(shapefile,
                              rgb=None,
                              root_dir=None,
@@ -225,9 +224,10 @@ def shapefile_to_annotations(shapefile,
                 "The shapefile crs {} does not match the image crs {}".format(
                     gdf.crs.to_string(), src.crs.to_string()), UserWarning)
 
-    if src.crs is not None:
-        print("CRS of shapefile is {}".format(src.crs))
-        gdf = geo_to_image_coordinates(gdf, src.bounds, src.res[0])
+        if src.crs is not None:
+            print("CRS of shapefile is {}".format(gdf.crs))
+            print("CRS of image is {}".format(raster_crs))
+            gdf = geo_to_image_coordinates(gdf, src.bounds, src.res[0])
 
     # check for label column
     if "label" not in gdf.columns:


### PR DESCRIPTION

# What this PR does.

- Updates read_file to only convert to geocoordinates if the shapefile in question has a geospatial crs. 
- Updates dataset.TreeDataset to grab the annotations from the geometry column as we migrate towards multi-geometry setup.
- Adds a test to ensure behavior and replicates the errors in #992.

# Closes

closes #992 

My only lingering doubt was whether to fully delete the if statement and just insist all inputs have a geometry column, that would have been backward breaking and require 1.6.0, which didn't seem wholly needed and could be avoided.

In general this is an edge case, but points to overall themes of trying to improve data import, which is always the hardest part, and the conflict between image coordinate and geospatial coordinate system, which underly many issues.