### PR TITLE
Checking for empty dataset

### DIFF
--- a/src/deepforest/main.py
+++ b/src/deepforest/main.py
@@ -300,6 +300,8 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
                                  transforms=self.transforms(augment=augment),
                                  label_dict=self.label_dict,
                                  preload_images=self.config["train"]["preload_images"])
+        if len(ds) == 0:
+          raise ValueError(f"Dataset from {csv_file} is empty. Check CSV for valid entries and columns.")
 
         data_loader = torch.utils.data.DataLoader(
             ds,

--- a/src/deepforest/main.py
+++ b/src/deepforest/main.py
@@ -301,7 +301,9 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
                                  label_dict=self.label_dict,
                                  preload_images=self.config["train"]["preload_images"])
         if len(ds) == 0:
-          raise ValueError(f"Dataset from {csv_file} is empty. Check CSV for valid entries and columns.")
+            raise ValueError(
+                f"Dataset from {csv_file} is empty. Check CSV for valid entries and columns."
+            )
 
         data_loader = torch.utils.data.DataLoader(
             ds,


### PR DESCRIPTION
Added a validation check before load_dataset(...) so that trainer.fit(..) cannot throw errors when an empty dataframe is passed. 

Fixes #867 