### PR TITLE
Fix #1000: Improve deepforest.utilities.image_to_geo_coordinates to Use root_dir Attribute if Available

### DIFF
--- a/citation_count.json
+++ b/citation_count.json
@@ -1,6 +1,6 @@
 {
     "schemaVersion": 1,
     "label": "Citations",
-    "message": "88",
+    "message": "90",
     "color": "blue"
 }

--- a/docs/user_guide/15_Writing_data.md
+++ b/docs/user_guide/15_Writing_data.md
@@ -25,7 +25,7 @@ path_to_raster = get_data("2018_SJER_3_252000_4107000_image_477.tif")
 src = rio.open(path_to_raster)
 original = utilities.read_file(annotations)
 
-geo_coords = utilities.image_to_geo_coordinates(original, root_dir=os.path.dirname(path_to_raster))
+geo_coords = utilities.image_to_geo_coordinates(original)
 src_window = geometry.box(*src.bounds)
 
 fig, ax = plt.subplots(figsize=(10, 10))

--- a/src/deepforest/utilities.py
+++ b/src/deepforest/utilities.py
@@ -542,18 +542,29 @@ def check_image(image):
                          "found image with shape {}".format(image.shape))
 
 
-def image_to_geo_coordinates(gdf, root_dir, flip_y_axis=False):
+def image_to_geo_coordinates(gdf, root_dir=None, flip_y_axis=False):
     """Convert from image coordinates to geographic coordinates.
 
     Args:
         gdf: A geodataframe.
-        root_dir: Directory of images to lookup image_path column.
+        root_dir: Directory of images to lookup image_path column. If None, it will attempt to use gdf.root_dir.
         flip_y_axis: If True, reflect predictions over y axis to align with raster data in QGIS, which uses a negative y origin compared to numpy.
 
     Returns:
         transformed_gdf: A geospatial dataframe with the boxes optionally transformed to the target crs.
     """
     transformed_gdf = gdf.copy(deep=True)
+
+    # Attempt to use root_dir from gdf if not provided
+    if root_dir is None:
+        if hasattr(gdf, "root_dir") and gdf.root_dir:
+            root_dir = gdf.root_dir
+        else:
+            raise ValueError(
+                "root_dir is not provided and could not be inferred from the predictions."
+                "Ensure that the predictions have a root_dir attribute or pass root_dir explicitly."
+            )
+
     plot_names = transformed_gdf.image_path.unique()
     if len(plot_names) > 1:
         raise ValueError(

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -301,8 +301,7 @@ def test_split_raster_from_shp(tmpdir):
     annotations = get_data("2018_SJER_3_252000_4107000_image_477.csv")
     path_to_raster = get_data("2018_SJER_3_252000_4107000_image_477.tif")
     gdf = utilities.read_file(annotations)
-    geo_coords = utilities.image_to_geo_coordinates(
-        gdf, root_dir=os.path.dirname(path_to_raster))
+    geo_coords = utilities.image_to_geo_coordinates(gdf)
     annotations_file = tmpdir.join("projected_annotations.shp").strpath
     geo_coords.to_file(annotations_file)
 

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -283,7 +283,7 @@ def test_geo_to_image_coordinates_UTM_N(tmpdir):
     original = utilities.read_file(annotations)
     assert original.crs is None
 
-    geo_coords = utilities.image_to_geo_coordinates(original, root_dir=os.path.dirname(path_to_raster))
+    geo_coords = utilities.image_to_geo_coordinates(original)
     assert geo_coords.crs == src.crs
     src_window = geometry.box(*src.bounds)
 
@@ -367,7 +367,7 @@ def test_image_to_geo_coordinates(tmpdir):
 
     # Convert to geo coordinates
     src = rio.open(path_to_raster)
-    geo_coords = utilities.image_to_geo_coordinates(gdf, root_dir=os.path.dirname(path_to_raster))
+    geo_coords = utilities.image_to_geo_coordinates(gdf)
     src_window = geometry.box(*src.bounds)
     assert geo_coords[geo_coords.intersects(src_window)].shape[0] == pd.read_csv(annotations).shape[0]
 
@@ -399,7 +399,7 @@ def test_image_to_geo_coordinates_boxes(tmpdir):
 
     # Convert to geo coordinates
     src = rio.open(path_to_raster)
-    geo_coords = utilities.image_to_geo_coordinates(gdf, root_dir=os.path.dirname(path_to_raster))
+    geo_coords = utilities.image_to_geo_coordinates(gdf)
     src_window = geometry.box(*src.bounds)
     assert geo_coords[geo_coords.intersects(src_window)].shape[0] == pd.read_csv(annotations).shape[0]
 
@@ -432,7 +432,7 @@ def test_image_to_geo_coordinates_points(tmpdir):
 
     # Convert to geo coordinates
     src = rio.open(path_to_raster)
-    geo_coords = utilities.image_to_geo_coordinates(gdf, root_dir=os.path.dirname(path_to_raster))
+    geo_coords = utilities.image_to_geo_coordinates(gdf)
     src_window = geometry.box(*src.bounds)
     assert geo_coords[geo_coords.intersects(src_window)].shape[0] == pd.read_csv(annotations).shape[0]
 
@@ -466,7 +466,7 @@ def test_image_to_geo_coordinates_polygons(tmpdir):
 
     # Convert to geo coordinates
     src = rio.open(path_to_raster)
-    geo_coords = utilities.image_to_geo_coordinates(gdf, root_dir=os.path.dirname(path_to_raster))
+    geo_coords = utilities.image_to_geo_coordinates(gdf)
     src_window = geometry.box(*src.bounds)
     assert geo_coords[geo_coords.intersects(src_window)].shape[0] == pd.read_csv(annotations).shape[0]
 


### PR DESCRIPTION
This PR enhances the `deepforest.utilities.image_to_geo_coordinates` by ensuring that the `root_dir` attribute is automatically inferred from the geodataframe if it exists. If `root_dir` cannot be determined, a clear error message is provided for better debugging.

**Changes**:
- Updated `image_to_geo_coordinates()` logic in `src/deepforest/utilities.py`. Previously, users had to manually specify `root_dir`. Now, the function attempts to infer it from the geodataframe. If `root_dir` is missing, an explicit error message is raised to guide users.
- Modified test cases:
  - In `test_preprocess.py`, updated `test_split_raster_from_shp()` to avoid explicitly assigning `root_dir`, ensuring expected behavior.
  - In `test_utilities.py`, updated occurrences of `image_to_geo_coordinates()` to align with the new logic.
- Updated documentation:
  - Modified `docs/user_guide/15_Writing_data.md` to reflect the new behavior.

✅ All existing tests passed.

**Open Question:** I think in here
https://github.com/weecology/DeepForest/blob/1acab8b8169ed929e89eda80de38642b235071aa/tests/test_utilities.py#L358
a similar case occurs where the geodataframe already has a `root_dir` attribute. Should we also update `visualize.py` and other similar occurrences where `root_dir` is explicitly passed but already available in the dataframe?

- Fixes #1000 