### PR TITLE
Adds a simple utility to strip and convert .tif file with alpha channels

### DIFF
--- a/src/deepforest/utilities.py
+++ b/src/deepforest/utilities.py
@@ -755,10 +755,9 @@ def project_boxes(df, root_dir, transform=True):
     return df
 
 
-def read_tile(raster_path):
+def remove_alpha_channel(raster_path):
     """Read a raster from disk, remove alpha channel if present, and reorder
-    dimensions to channel-last (H, W, C) for consistency with DeepForest input
-    expectations.
+    dimensions to channel-last (H, W, C) for consistency.
 
     Args:
         raster_path (str): Path to the GeoTIFF (or other supported raster format).
@@ -770,16 +769,11 @@ def read_tile(raster_path):
     with rasterio.open(raster_path) as src:
         image = src.read()
 
-    if image.shape[0] == 4:
-        warnings.warn(
-            "Detected an alpha channel, removing it to match DeepForest's requirement of 3 bands."
-        )
-        image = image[:3]
-
-    # Confirm we now have 3 bands
-    if image.shape[0] != 3:
-        raise ValueError(
-            f"Expected 3 bands, but got {image.shape[0]}. Please check your raster.")
+        if image.shape[0] == 4:
+            warnings.warn(
+                "Detected an alpha channel, removing it to match DeepForest's requirement of 3 bands."
+            )
+            image = image[:3]
 
     image = np.moveaxis(image, 0, -1)
 

--- a/src/deepforest/visualize.py
+++ b/src/deepforest/visualize.py
@@ -12,6 +12,7 @@ import warnings
 import supervision as sv
 import shapely
 from deepforest.utilities import determine_geometry_type
+from deepforest.utilities import remove_alpha_channel
 
 
 def view_dataset(ds, savedir=None, color=None, thickness=1):
@@ -518,9 +519,8 @@ def plot_results(results,
         image = np.array(Image.open(image_path))
 
         # Drop alpha channel if present and warn
-        if image.shape[2] == 4:
-            warnings.warn("Image has an alpha channel. Dropping alpha channel.")
-            image = image[:, :, :3]
+        if image.shape[2] > 3:
+            image = remove_alpha_channel(image)
 
     # Plot the results following https://supervision.roboflow.com/annotators/
     fig, ax = plt.subplots()

--- a/src/deepforest/visualize.py
+++ b/src/deepforest/visualize.py
@@ -517,11 +517,11 @@ def plot_results(results,
         image_path = os.path.join(root_dir, results.image_path.unique()[0])
         image = np.array(Image.open(image_path))
 
-        # Drop alpha channel if present and warn 
+        # Drop alpha channel if present and warn
         if image.shape[2] == 4:
             warnings.warn("Image has an alpha channel. Dropping alpha channel.")
             image = image[:, :, :3]
-            
+
     # Plot the results following https://supervision.roboflow.com/annotators/
     fig, ax = plt.subplots()
     annotated_scene = _plot_image_with_geometry(df=results,


### PR DESCRIPTION
Fixes #998
Added a new function, `utilities.read_tile(raster_path)`, that uses rasterio to read a raster and automatically remove an alpha channel if present.
- Reordered dimensions from channel-first to channel-last for consistency with DeepForest’s three-band input requirement.
- Created 4 Pytest tests to check that read_tile handles 3-band, 4-band, and invalid band count data properly.
- Ensured the output shape is (height, width, channels) and that it can be used directly with PIL and other NumPy-based pipelines in DeepForest.