### PR TITLE
Fix typos, organize imports, and remove duplicate imports

### DIFF
--- a/docs/user_guide/11_training.md
+++ b/docs/user_guide/11_training.md
@@ -60,7 +60,7 @@ m.trainer.fit(model)
 If you want to disable the progress bar while training change the `create_trainer` call to:
 
 ```python
-from deepforest import model 
+from deepforest import model
 
  model.create_trainer(enable_progress_bar=False)
 ```
@@ -136,13 +136,13 @@ image_path, xmin, ymin, xmax, ymax, label
 myimage.png, 0,0,0,0,"Tree"
 ```
 
-Excessive use of negative samples may have a negative impact on model performance, but when used sparingly, they can increase precision. 
+Excessive use of negative samples may have a negative impact on model performance, but when used sparingly, they can increase precision.
 
 ### Model checkpoints
 
 Pytorch lightning allows you to [save a model](https://pytorch-lightning.readthedocs.io/en/stable/common/trainer.html#checkpoint-callback) at the end of each epoch. By default this behevaior is turned off since it slows down training and quickly fills up storage. To restore model checkpointing
 
-```python 
+```python
 from pytorch_lightning.callbacks import ModelCheckpoint
 from pytorch_lightning.loggers import TensorBoardLogger
 
@@ -251,7 +251,7 @@ m.config["workers"] = 5
 
 It is not foolproof, and occasionally 0 workers, in which data loading is run on the main thread, is optimal : https://stackoverflow.com/questions/73331758/can-ideal-num-workers-for-a-large-dataset-in-pytorch-be-0.
 
-For large training runs, setting preload_images to True can be helpful. 
+For large training runs, setting preload_images to True can be helpful.
 
 ```
 m.config["preload_images"] = True
@@ -268,14 +268,14 @@ Remember to call m.create_trainer() after updating the config dictionary.
 
 ### Avoiding **Weakly referenced objects** errors
 
-On some devices and systems we have found an error referencing the model.trainer object that was created in m.create_trainer(). 
+On some devices and systems we have found an error referencing the model.trainer object that was created in m.create_trainer().
 We welcome a reproducible issue to address this error as it appears highly variable and relates to upstream issues. It appears more common on google colab and github actions.
 
 In most cases, this error appears when running multiple calls to model.predict or model.train. We believe this occurs because garbage collection has deleted the model.trainer object see:
 https://github.com/Lightning-AI/lightning/issues/12233
 https://github.com/weecology/DeepForest/issues/338
 
-If you run into this error, users (e.g https://github.com/weecology/DeepForest/issues/443), have found that creating the trainer object within the loop can resolve this issue. 
+If you run into this error, users (e.g https://github.com/weecology/DeepForest/issues/443), have found that creating the trainer object within the loop can resolve this issue.
 
 ```python
 for tile in tiles_to_predict:
@@ -287,9 +287,9 @@ Usually creating this object does not cost too much computational time.
 
 #### Training across multiple nodes on a HPC system
 
-We have heard that this error can appear when trying to deep copy the pytorch lighnting module. The trainer object is not pickleable.
-For example, on multi-gpu enviroments when trying to scale the deepforest model the entire module is copied leading to this error.
-Setting the trainer object to None and directly using the pytorch object is a reasonable workaround. 
+We have heard that this error can appear when trying to deep copy the pytorch lightning module. The trainer object is not pickleable.
+For example, on multi-gpu environments when trying to scale the deepforest model the entire module is copied leading to this error.
+Setting the trainer object to None and directly using the pytorch object is a reasonable workaround.
 
 Replace
 
@@ -316,6 +316,6 @@ from pytorch_lightning import Trainer
 trainer.fit(m)
 ```
 
-The added benefits of this is more control over the trainer object. 
-The downside is that it doesn't align with the .config pattern where a user now has to look into the config to create the trainer. 
+The added benefits of this is more control over the trainer object.
+The downside is that it doesn't align with the .config pattern where a user now has to look into the config to create the trainer.
 We are open to changing this to be the default pattern in the future and welcome input from users.

--- a/src/deepforest/utilities.py
+++ b/src/deepforest/utilities.py
@@ -11,7 +11,6 @@ from tqdm import tqdm
 
 from PIL import Image
 from deepforest import _ROOT
-import warnings
 import json
 import urllib.request
 from huggingface_hub import hf_hub_download

--- a/src/deepforest/visualize.py
+++ b/src/deepforest/visualize.py
@@ -136,7 +136,7 @@ def plot_prediction_dataframe(df,
 def plot_points(image, points, color=None, radius=5, thickness=1):
     """Plot points on an image
     Args:
-        image: a numpy array in *BGR* color order! Channel order is channels first 
+        image: a numpy array in *BGR* color order! Channel order is channels first
         points: a numpy array of shape (N, 2) representing the coordinates of the points
         color: color of the points as a tuple of BGR color, e.g. orange points is (0, 165, 255)
         radius: radius of the points in px
@@ -517,11 +517,11 @@ def plot_results(results,
         image_path = os.path.join(root_dir, results.image_path.unique()[0])
         image = np.array(Image.open(image_path))
 
-        # Drop alpha channel if present and warn 
+        # Drop alpha channel if present and warn
         if image.shape[2] == 4:
             warnings.warn("Image has an alpha channel. Dropping alpha channel.")
             image = image[:, :, :3]
-            
+
     # Plot the results following https://supervision.roboflow.com/annotators/
     fig, ax = plt.subplots()
     annotated_scene = _plot_image_with_geometry(df=results,

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -10,6 +10,9 @@ import numpy as np
 import tempfile
 import rasterio as rio
 from deepforest.dataset import BoundingBoxDataset
+from deepforest.dataset import RasterDataset
+from torch.utils.data import DataLoader
+
 
 
 def single_class():
@@ -189,23 +192,20 @@ def test_bounding_box_dataset():
 
 def test_raster_dataset():
     """Test the RasterDataset class"""
-    from deepforest.dataset import RasterDataset
-    import torch
-    from torch.utils.data import DataLoader
-    
+
     # Test initialization and context manager
     ds = RasterDataset(get_data("test_tiled.tif"), patch_size=256, patch_overlap=0.1)
-    
+
     # Test basic properties
     assert hasattr(ds, 'windows')
-        
+
     # Test first window
     first_crop = ds[0]
     assert isinstance(first_crop, torch.Tensor)
     assert first_crop.dtype == torch.float32
     assert first_crop.shape[0] == 3  # RGB channels first
     assert 0 <= first_crop.min() <= first_crop.max() <= 1.0  # Check normalization
-        
+
     # Test with DataLoader
     dataloader = DataLoader(ds, batch_size=2, num_workers=0)
     batch = next(iter(dataloader))

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -924,7 +924,7 @@ def test_empty_frame_accuracy_without_predictions(tmpdir):
     results = m.trainer.validate(m)
     assert results[0]["empty_frame_accuracy"] == 1
 
-def test_mulit_class_with_empty_frame_accuracy_without_predictions(two_class_m, tmpdir):
+def test_multi_class_with_empty_frame_accuracy_without_predictions(two_class_m, tmpdir):
     """Create a ground truth with empty frames, the accuracy should be 1 with a random model"""
     # Create ground truth with empty frames
     ground_df = pd.read_csv(get_data("testfile_deepforest.csv"))

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -275,7 +275,7 @@ def test_split_raster_with_polygon_annotations(tmpdir, config):
 
 def test_split_raster_from_csv(tmpdir):
     """Read in annotations, convert to a projected shapefile, read back in and crop,
-    the output annotations should still be mantained in logical place"""
+    the output annotations should still be maintained in logical place"""
     annotations = get_data("2018_SJER_3_252000_4107000_image_477.csv")
     path_to_raster = get_data("2018_SJER_3_252000_4107000_image_477.tif")
 

--- a/tests/test_retinanet.py
+++ b/tests/test_retinanet.py
@@ -62,7 +62,7 @@ def test_forward_empty(config):
 
 
 # Can we update parameters after training
-def test_mantain_parameters(config):
+def test_maintain_parameters(config):
     config["retinanet"]["score_thresh"] = 0.4
     retinanet_model = retinanet.Model(config).create_model()
     assert retinanet_model.score_thresh == config["retinanet"]["score_thresh"]


### PR DESCRIPTION
In this PR, I fixed minor typos in function names and documentation. Then, I removed some duplicate imports and moved all imports to the top of their respective files for better readability and consistency.