### PR TITLE
on_validation_epoch_end() during sanity checking will not run if val-accuracy-interval is greater than max epochs.

### DIFF
--- a/src/deepforest/main.py
+++ b/src/deepforest/main.py
@@ -806,7 +806,10 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
             self.predictions_df = pd.concat(self.predictions)
 
         #Evaluate every n epochs
-        if self.current_epoch % self.config["validation"]["val_accuracy_interval"] == 0:
+        if (self.config["validation"]["val_accuracy_interval"]
+                <= self.config["train"]["epochs"] and
+                self.current_epoch % self.config["validation"]["val_accuracy_interval"]
+                == 0):
             #Create a geospatial column
             ground_df = utilities.read_file(self.config["validation"]["csv_file"])
             ground_df["label"] = ground_df.label.apply(lambda x: self.label_dict[x])

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -970,3 +970,14 @@ def test_set_labels_invalid_length(m): # Expect a ValueError when setting an inv
     invalid_mapping = {"Object": 0, "Extra": 1}
     with pytest.raises(ValueError):
         m.set_labels(invalid_mapping)
+    
+def test_validation_interval_greater_than_epochs(m):
+    # Set interval higher than max_epochs to disable evaluation
+    m.config["validation"]["val_accuracy_interval"] = 3
+    m.config["train"]["epochs"] = 2
+    m.create_trainer()
+    m.trainer.fit(m)
+    
+    assert "box_precision" not in m.trainer.logged_metrics
+    assert "box_recall" not in m.trainer.logged_metrics
+    assert "empty_frame_accuracy" not in m.trainer.logged_metrics


### PR DESCRIPTION
Fixes #859 

As part of the issue investigation, I tested the initial behavior by creating a dataset with annotations and passing it to the Jupyter notebook. I monkey-patched on_validation_epoch_end() to track and print how often full validation runs and at which epochs. For the test, I set val_accuracy_interval = 30 and max_epochs = 5 (i.e., val_accuracy_interval > max_epochs). As per the documentation, full validation should not run in this case. But it is actually running full validation. 

![WhatsApp Image 2025-04-08 at 08 30 00_49f42cb4](https://github.com/user-attachments/assets/3591c21c-4d3a-483d-a5b0-623cf5ebb367)

Initally sanity checking happens - 
![WhatsApp Image 2025-04-08 at 08 24 47_2042adf9](https://github.com/user-attachments/assets/1a943b5b-42a6-4557-bb21-534ee669f9b3)

Right after the sanity check, we see on_validation_epoch_end() being called and the complete validation check running - 
![WhatsApp Image 2025-04-08 at 08 26 16_28f12444](https://github.com/user-attachments/assets/18ef5f62-80bc-4422-9fcb-54dd5b826413)

After training on epoch 0, we see on_validation_epoch_end() being called again and the complete validation check running, since current_epoch is 0 (0 % 30 = 0) - 
![WhatsApp Image 2025-04-08 at 08 28 59_222e236c](https://github.com/user-attachments/assets/68463651-f8c2-4284-9064-fcc84aed2d0e)

In the final phase, all epochs trigger on_validation_epoch_end(), but the complete validation check runs only twice—once during sanity checking and once after training when current_epoch = 0 - 
![WhatsApp Image 2025-04-08 at 08 35 19_667760b1](https://github.com/user-attachments/assets/9df94153-9f14-4d2a-a21f-93c1fc7eb411)

All epochs have completed, and the final result is shown below: 
![WhatsApp Image 2025-04-08 at 08 37 59_f7c0d97e](https://github.com/user-attachments/assets/0f6485bc-934e-4ac2-b4ce-795d9246dbd7)

All epochs have completed, and the final result is shown below. As expected, complete validation runs four times: during sanity checking, and when current_epoch is 0, 2, and 4 
![WhatsApp Image 2025-04-08 at 09 02 32_8b039106](https://github.com/user-attachments/assets/1090229a-b771-4eb4-ae83-5610e1ea0365)



Now, I have modified the code to include a condition that checks if val_accuracy_interval is less than or equal to max_epochs. In this test, val_accuracy_interval = 30 and max_epochs = 5 (i.e., val_accuracy_interval > max_epochs), as shown below - 
![WhatsApp Image 2025-04-08 at 10 21 25_9aba91d2](https://github.com/user-attachments/assets/60e542d4-2609-4e19-8bd5-fde9dc1e48b6)

For this case, we can see that on_validation_epoch_end() is being called, but complete validation is not performed.
![WhatsApp Image 2025-04-08 at 10 26 44_6aeee6a2](https://github.com/user-attachments/assets/a9885b67-c7d4-4384-95c9-6055af6f5faf)

I have fixed this line in the code and tested the behavior. Please let me know if any further enhancements are needed. Thank you!
