### PR TITLE
Fix #1023: Changed logic to detect GeoDataFrame before DataFrame in utilities.read_file

### DIFF
--- a/citation_count.json
+++ b/citation_count.json
@@ -1,6 +1,6 @@
 {
     "schemaVersion": 1,
     "label": "Citations",
-    "message": "90",
+    "message": "92",
     "color": "blue"
 }

--- a/src/deepforest/utilities.py
+++ b/src/deepforest/utilities.py
@@ -312,25 +312,17 @@ def read_coco(json_file):
 def read_file(input, root_dir=None, image_path=None, label=None):
     """Read a file and return a geopandas dataframe.
 
-    This is the main entry point for reading annotations into deepforest.
-
     Args:
-        input: a path to a file or a pandas dataframe
-        root_dir (str): location of the image files, if not in the same directory as the annotations file
+        input: A path to a file, a pandas DataFrame, or a geopandas GeoDataFrame.
+        root_dir (str): Location of the image files, if not in the same directory as the annotations file.
         image_path (str, optional): If provided, this value will be assigned to a new 'image_path' column
             for every row in the dataframe. Only use this when the file contains annotations from a single image.
         label (str, optional): If provided, this value will be assigned to a new 'label' column
             for every row in the dataframe. Only use this when all annotations share the same label.
 
     Returns:
-        df: a geopandas dataframe with the properly formatted geometry column
-        df.root_dir: the root directory of the image files
-
-    Warnings:
-        Passing `image_path` or `label` will apply the same value to all rows in the dataframe.
-        This should only be used when the input file contains annotations for a single image.
+        df: A geopandas dataframe with the properly formatted geometry column.
     """
-
     if image_path is not None:
         warnings.warn(
             "You have passed an image_path. This value will be assigned to every row in the dataframe. "
@@ -357,10 +349,11 @@ def read_file(input, root_dir=None, image_path=None, label=None):
                 "File type {} not supported. DeepForest currently supports .csv, .shp, .gpkg, .xml, and .json files. See https://deepforest.readthedocs.io/en/latest/annotation.html "
                 .format(df))
     else:
-        if isinstance(input, pd.DataFrame):
-            df = input.copy(deep=True)
-        elif isinstance(input, gpd.GeoDataFrame):
+        # Explicitly check for GeoDataFrame first
+        if isinstance(input, gpd.GeoDataFrame):
             return shapefile_to_annotations(input, root_dir=root_dir)
+        elif isinstance(input, pd.DataFrame):
+            df = input.copy(deep=True)
         else:
             raise ValueError(
                 "Input must be a path to a file, geopandas or a pandas dataframe")


### PR DESCRIPTION
* This PR addresses the issue #1023 where `GeoDataFrame` inputs were incorrectly handled as `DataFrame` due to the `isinstance()` check order. Previously, the method checked for `pd.DataFrame` before `gpd.GeoDataFrame`, causing `GeoDataFrame` inputs to bypass `shapefile_to_annotations()` logic. This required users to write `GeoDataFrames` to disk (e.g., .shp) as a workaround:
```python
gdf.to_file("annotations.shp")
result = read_file("annotations.shp")
```
By reversing the order of type checks `isinstance(input, gpd.GeoDataFrame)` before `pd.DataFrame` in`read_file()`, `GeoDataFrame` is now properly handled in-memory:
```python
result = read_file(gdf)
```
It also ensured `GeoDataFrame` paths are processed through `shapefile_to_annotations()`.


**Test Case Verification**

Two new test cases in `test_utilities.py` ensure correct behavior for both in-memory `GeoDataFrame` and `DataFrame` inputs:

* `test_read_file_in_memory_geodataframe()`
	→ Verifies in-memory `GeoDataFrame` is processed and coordinate conversion occurs.

* `test_read_file_in_memory_dataframe()`
	→ Verifies box geometry is correctly created from xmin, ymin, xmax, ymax.

* All test cases pass locally.


Let me know if you'd like me to any other modifications. Additionally, I noticed that some existing tests in `test_utilities.py` still use the workaround of saving GeoDataFrames to shapefiles before passing to `read_file()` like this:
https://github.com/weecology/DeepForest/blob/789974d744548e4eace0ca1b7fb4b34ac027de54/tests/test_utilities.py#L87
Would you prefer those be updated to use in-memory processing now that it's supported? Or should we keep them as-is to test .shp reading behavior separately?