### PR TITLE
on_validation_epoch_end() during sanity checking will not run if val-accuracy-interval is greater than max epochs. 

### DIFF
--- a/src/deepforest/main.py
+++ b/src/deepforest/main.py
@@ -791,9 +791,19 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
 
     def on_validation_epoch_end(self):
         """Compute metrics."""
+        # Check if we are in a standalone validation run
+        if self.trainer is not None:
+            is_validate_phase = self.trainer.state.fn == "validate"
+        else:
+            is_validate_phase = False
 
-        #Evaluate every n epochs
-        if self.current_epoch % self.config["validation"]["val_accuracy_interval"] == 0:
+        # Evaluate every n epochs or during standalone validation
+        evaluate_this_epoch = is_validate_phase or (
+            self.config["validation"]["val_accuracy_interval"]
+            <= self.config["train"]["epochs"] and
+            self.current_epoch % self.config["validation"]["val_accuracy_interval"] == 0)
+
+        if evaluate_this_epoch:
 
             if len(self.predictions) == 0:
                 return None

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -995,3 +995,14 @@ def test_set_labels_invalid_length(m): # Expect a ValueError when setting an inv
     invalid_mapping = {"Object": 0, "Extra": 1}
     with pytest.raises(ValueError):
         m.set_labels(invalid_mapping)
+
+def test_validation_interval_greater_than_epochs(m):
+    # Set interval higher than max_epochs to disable evaluation
+    m.config["validation"]["val_accuracy_interval"] = 3
+    m.config["train"]["epochs"] = 2
+    m.create_trainer()
+    m.trainer.fit(m)
+
+    assert "box_precision" not in m.trainer.logged_metrics
+    assert "box_recall" not in m.trainer.logged_metrics
+    assert "empty_frame_accuracy" not in m.trainer.logged_metrics


### PR DESCRIPTION
Fixes #859 

As part of the issue investigation, I tested the initial behavior by creating a dataset with annotations and passing it to the Jupyter notebook. I monkey-patched on_validation_epoch_end() to track and print how often full validation runs and at which epochs. For the test, I set val_accuracy_interval = 30 and max_epochs = 5 (i.e., val_accuracy_interval > max_epochs). As per the documentation, full validation should not run in this case. But it is actually running full validation.
![image](https://github.com/user-attachments/assets/e48d230c-1a28-4f20-915c-8144ff9e1e21)

Initally sanity checking happens -
![image](https://github.com/user-attachments/assets/0b130979-7d21-4361-b3bf-512c51874a84)

Right after the sanity check, we see on_validation_epoch_end() being called and the complete validation check running -
![image](https://github.com/user-attachments/assets/9985c12a-da44-4a65-946c-4ccc3a1a7e85)

After training on epoch 0, we see on_validation_epoch_end() being called again and the complete validation check running, since current_epoch is 0 (0 % 30 = 0) -
![image](https://github.com/user-attachments/assets/d8278ec3-ea2d-49bb-b712-88f0f26019e3)

In the final phase, all epochs trigger on_validation_epoch_end(), but the complete validation check runs only twice—once during sanity checking and once after training when current_epoch = 0 -
![image](https://github.com/user-attachments/assets/d706ec1e-1374-4124-8597-6d41384bb3a3)

All epochs have completed, and the final result is shown below:
![image](https://github.com/user-attachments/assets/a15b9d86-0e12-4ee3-b758-3d3bf90636c1)


All epochs have completed, and the final result is shown below. As expected, complete validation runs four times: during sanity checking, and when current_epoch is 0, 2, and 4
![image](https://github.com/user-attachments/assets/b49fe9a2-899a-40fc-9a7f-1d2a11b00d0d)

Now, I have modified the code to include a condition that checks if val_accuracy_interval is less than or equal to max_epochs. In this test, val_accuracy_interval = 30 and max_epochs = 5 (i.e., val_accuracy_interval > max_epochs). For this case, we can see that on_validation_epoch_end() is being called, but complete validation is not performed - 
![image](https://github.com/user-attachments/assets/f0518e37-ad97-4c0a-b6bf-8aa6b8076d93)



In addition to the Jupyter notebook testing, I’ve added `test_validation_interval_greater_than_epochs` in `test_main.py` to verify that no full validation metrics are logged when `val_accuracy_interval` (set to 3) is greater than `max_epochs` (set to 2). The test checks that `box_precision`, `box_recall`, and `empty_frame_accuracy` are not present in logged metrics, as full validation is skipped in this case.

Note: The case where `val_accuracy_interval` is less than or equal to `max_epochs` is already covered by `test_evaluate_on_epoch_interval` in the same file.

Please review and let me know if anything else is needed. Thanks!
