### PR TITLE
Add scholarly to dev dependencies for pre-commit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ dev = [
     "pytest-cov",
     "pytest-mock",
     "pytest-xdist",
+    "scholarly",
     "sphinx_design",
     "sphinx_markdown_tables",
     "sphinx_rtd_theme",


### PR DESCRIPTION
Pre-commit runs `fetch_google_scholar` which depends on `scholarly`. I've added this to the pyproject dev dependency list as it didn't seem to be included.

(I just saw the other issue that suggests we want to run this on a schedule though - not sure if the dependency should live here or not).