### PR TITLE
Added default labels for each model

### DIFF
--- a/src/deepforest/main.py
+++ b/src/deepforest/main.py
@@ -146,24 +146,9 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
         # Load the model using from_pretrained
         self.create_model()
         loaded_model = self.from_pretrained(model_name, revision=revision)
+        self.label_dict = loaded_model.label_dict
         self.model = loaded_model.model
-
-        # Set label_dict and other configurations based on the model_name
-        if model_name == "weecology/deepforest-tree":
-            self.label_dict = {"Tree": 0}
-        elif model_name == "weecology/deepforest-bird":
-            self.label_dict = {"Bird": 0}
-            self.config['retinanet']["score_thresh"] = 0.3  # Bird-specific threshold
-        elif model_name == "weecology/deepforest-livestock":
-            self.label_dict = {"Livestock": 0}
-        elif model_name == "weecology/everglades-nest-detection":
-            self.label_dict = {"Nest": 0}
-        else:
-            # For custom or unspecified models, use the loaded model's label_dict
-            self.label_dict = loaded_model.label_dict
-
-        # Update numeric_to_label_dict based on the defined label_dict
-        self.numeric_to_label_dict = {v: k for k, v in self.label_dict.items()}
+        self.numeric_to_label_dict = loaded_model.numeric_to_label_dict
 
     def set_labels(self, label_dict):
         """Set new label mapping, updating both the label dictionary (str ->

--- a/src/deepforest/main.py
+++ b/src/deepforest/main.py
@@ -146,14 +146,24 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
         # Load the model using from_pretrained
         self.create_model()
         loaded_model = self.from_pretrained(model_name, revision=revision)
-        self.label_dict = loaded_model.label_dict
         self.model = loaded_model.model
-        self.numeric_to_label_dict = loaded_model.numeric_to_label_dict
-        # Set bird-specific settings if loading the bird model
-        if model_name == "weecology/deepforest-bird":
-            self.config['retinanet']["score_thresh"] = 0.3
+
+        # Set label_dict and other configurations based on the model_name
+        if model_name == "weecology/deepforest-tree":
+            self.label_dict = {"Tree": 0}
+        elif model_name == "weecology/deepforest-bird":
             self.label_dict = {"Bird": 0}
-            self.numeric_to_label_dict = {v: k for k, v in self.label_dict.items()}
+            self.config['retinanet']["score_thresh"] = 0.3  # Bird-specific threshold
+        elif model_name == "weecology/deepforest-livestock":
+            self.label_dict = {"Livestock": 0}
+        elif model_name == "weecology/everglades-nest-detection":
+            self.label_dict = {"Nest": 0}
+        else:
+            # For custom or unspecified models, use the loaded model's label_dict
+            self.label_dict = loaded_model.label_dict
+
+        # Update numeric_to_label_dict based on the defined label_dict
+        self.numeric_to_label_dict = {v: k for k, v in self.label_dict.items()}
 
     def set_labels(self, label_dict):
         """Set new label mapping, updating both the label dictionary (str ->


### PR DESCRIPTION
Fixes #1027 
Previously, the `load_model()` function only had a default label set for `deepforest-bird` as `'Bird'`. For all other models, the default label `'Tree'` was displayed. By explicitly specifying the label for each model, I was able to assign appropriate labels as follows:

- `deepforest-tree`: `'Tree'`  
- `deepforest-livestock`: `'Livestock'`  
- `deepforest-bird`: `'Bird'`  
- `everglades-nest-detection`: `'Nest'`  
- `cropmodel`: default label remains `'Tree'`

After making these changes and re-running the same piece of code, I obtained the expected output.

![image](https://github.com/user-attachments/assets/767e7c1b-f2a0-45fe-8cf5-11e0479d5542)
