### PR TITLE
Add test and functionality to save the label_dict in the cropmodel

### DIFF
--- a/src/deepforest/model.py
+++ b/src/deepforest/model.py
@@ -140,6 +140,9 @@ class CropModel(LightningModule):
         self.batch_size = batch_size
         self.lr = lr
 
+    def on_save_checkpoint(self, checkpoint):
+        checkpoint['label_dict'] = self.label_dict
+
     def create_trainer(self, **kwargs):
         """Create a pytorch lightning trainer object."""
         self.trainer = Trainer(**kwargs)
@@ -162,6 +165,7 @@ class CropModel(LightningModule):
             "Accuracy": self.total_accuracy,
             "Precision": self.precision_metric
         })
+        self.label_dict = checkpoint['label_dict']
 
     def load_from_disk(self, train_dir, val_dir):
         self.train_ds = ImageFolder(root=train_dir,

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -169,7 +169,7 @@ def test_crop_model_load_checkpoint_with_explicit_num_classes(tmpdir, crop_model
     crop_model = model.CropModel(num_classes=num_classes)
     crop_model.create_trainer(fast_dev_run=True)
     crop_model.load_from_disk(train_dir=tmpdir, val_dir=tmpdir)
-
+    crop_model.label_dict = {0: "label1", 1: "label2", 2: "label3"}
     crop_model.trainer.fit(crop_model)
     checkpoint_path = os.path.join(tmpdir, "epoch=0-step=0.ckpt")
     crop_model.trainer.save_checkpoint(checkpoint_path)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -124,6 +124,25 @@ def test_crop_model_load_checkpoint(tmpdir, crop_model_data):
         for p1, p2 in zip(crop_model.parameters(), loaded_model.parameters()):
             assert torch.equal(p1, p2)
 
+def test_crop_model_mantain_label_dict(tmpdir, crop_model_data):
+    """
+    Test that the label dictionary is maintained when loading a checkpoint.
+    """
+    crop_model = model.CropModel(num_classes=2)
+    crop_model.create_trainer(fast_dev_run=True)
+    crop_model.load_from_disk(train_dir=tmpdir, val_dir=tmpdir)
+
+    crop_model.trainer.fit(crop_model)
+    checkpoint_path = os.path.join(tmpdir, "epoch=0-step=0.ckpt")
+    crop_model.trainer.save_checkpoint(checkpoint_path)
+    
+    # Load from checkpoint
+    loaded_model = model.CropModel.load_from_checkpoint(checkpoint_path)
+    
+    # Check that the label dictionary is maintained
+    assert crop_model.label_dict == loaded_model.label_dict
+    
+    
 def test_crop_model_init_no_num_classes():
     """
     Test that initializing CropModel() without num_classes


### PR DESCRIPTION
I found that when you save and reload a CropModel, the label_dict isn't recovered, so you don't know the names of the classes!

- Added a test showing that this fails on main
- Added the correct hook to deepforest.models.CropModel.on_save_checkpoint
- Reloaded on load
- Tests pass. 