### PR TITLE
When reloading crop_model, regenerate the numeric_to_label_dict

### DIFF
--- a/src/deepforest/model.py
+++ b/src/deepforest/model.py
@@ -108,11 +108,16 @@ class CropModel(LightningModule):
                  batch_size=4,
                  num_workers=0,
                  lr=0.0001,
+                 label_dict=None,
                  model=None):
         super().__init__()
         self.num_classes = num_classes
         self.num_workers = num_workers
-        self.numeric_to_label_dict = None
+        self.label_dict = label_dict
+        if label_dict is not None:
+            self.numeric_to_label_dict = {v: k for k, v in label_dict.items()}
+        else:
+            self.numeric_to_label_dict = None
         self.save_hyperparameters()
 
         if num_classes is not None:
@@ -166,6 +171,7 @@ class CropModel(LightningModule):
             "Precision": self.precision_metric
         })
         self.label_dict = checkpoint['label_dict']
+        self.numeric_to_label_dict = {v: k for k, v in self.label_dict.items()}
 
     def load_from_disk(self, train_dir, val_dir):
         self.train_ds = ImageFolder(root=train_dir,

--- a/src/deepforest/predict.py
+++ b/src/deepforest/predict.py
@@ -249,10 +249,7 @@ def _predict_crop_model_(crop_model,
         label_column = f"cropmodel_label_{model_index}"
         score_column = f"cropmodel_score_{model_index}"
 
-    if crop_model.numeric_to_label_dict is not None:
-        results[label_column] = [crop_model.numeric_to_label_dict[x] for x in label]
-    else:
-        results[label_column] = label
+    results[label_column] = [crop_model.numeric_to_label_dict[x] for x in label]
 
     results[score_column] = score
 

--- a/src/deepforest/predict.py
+++ b/src/deepforest/predict.py
@@ -249,6 +249,9 @@ def _predict_crop_model_(crop_model,
         label_column = f"cropmodel_label_{model_index}"
         score_column = f"cropmodel_score_{model_index}"
 
+    if crop_model.numeric_to_label_dict is None:
+        raise ValueError(f"The numeric_to_label_dict is not set, and the label_dict is {crop_model.label_dict}, set either when loading CropModel(label_dict=), which creates the numeric_to_label_dict, or load annotations from CropModel.load_from_disk(), which creates the dictionaries based on file contents.")
+    
     results[label_column] = [crop_model.numeric_to_label_dict[x] for x in label]
 
     results[score_column] = score

--- a/src/deepforest/predict.py
+++ b/src/deepforest/predict.py
@@ -250,8 +250,10 @@ def _predict_crop_model_(crop_model,
         score_column = f"cropmodel_score_{model_index}"
 
     if crop_model.numeric_to_label_dict is None:
-        raise ValueError(f"The numeric_to_label_dict is not set, and the label_dict is {crop_model.label_dict}, set either when loading CropModel(label_dict=), which creates the numeric_to_label_dict, or load annotations from CropModel.load_from_disk(), which creates the dictionaries based on file contents.")
-    
+        raise ValueError(
+            f"The numeric_to_label_dict is not set, and the label_dict is {crop_model.label_dict}, set either when loading CropModel(label_dict=), which creates the numeric_to_label_dict, or load annotations from CropModel.load_from_disk(), which creates the dictionaries based on file contents."
+        )
+
     results[label_column] = [crop_model.numeric_to_label_dict[x] for x in label]
 
     results[score_column] = score

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -699,7 +699,8 @@ def test_predict_tile_with_crop_model(m, config):
     iou_threshold = 0.15
     mosaic = True
     # Set up the crop model
-    crop_model = model.CropModel(num_classes=2)
+    crop_model = model.CropModel(num_classes=2, label_dict = {"Dead":0, "Alive":1})
+
     # Call the predict_tile method with the crop_model
     m.config.train.fast_dev_run = False
     m.create_trainer()
@@ -717,6 +718,10 @@ def test_predict_tile_with_crop_model(m, config):
         "cropmodel_score", "image_path"
     }
 
+    # Assert cropmodel_label is in the label_dict
+    labels = [x for x in crop_model.label_dict]
+    assert result.cropmodel_label.isin(labels).all()
+
 
 def test_predict_tile_with_crop_model_empty():
     """If the model return is empty, the crop model should return an empty dataframe"""
@@ -726,8 +731,10 @@ def test_predict_tile_with_crop_model_empty():
     patch_overlap = 0.05
     iou_threshold = 0.15
     mosaic = True
+    
     # Set up the crop model
-    crop_model = model.CropModel(num_classes=2)
+    crop_model = model.CropModel(num_classes=2, label_dict = {"Dead": 0, "Alive": 1})
+    
     # Call the predict_tile method with the crop_model
     m.config.train.fast_dev_run = False
     m.create_trainer()
@@ -737,6 +744,7 @@ def test_predict_tile_with_crop_model_empty():
                             iou_threshold=iou_threshold,
                             mosaic=mosaic,
                             crop_model=crop_model)
+    
 
     # Assert the result
     assert result is None or result.empty
@@ -749,7 +757,7 @@ def test_predict_tile_with_multiple_crop_models(m, config):
     mosaic = True
 
     # Create multiple crop models
-    crop_model = [model.CropModel(num_classes=2), model.CropModel(num_classes=3)]
+    crop_model = [model.CropModel(num_classes=2, label_dict={"Dead":0, "Alive":1}), model.CropModel(num_classes=3, label_dict={"Dead":0, "Alive":1, "Sapling":2})]
 
     # Call predict_tile with multiple crop models
     m.config.train.fast_dev_run = False
@@ -784,8 +792,8 @@ def test_predict_tile_with_multiple_crop_models_empty():
     mosaic = True
 
     # Create multiple crop models
-    crop_model_1 = model.CropModel(num_classes=2)
-    crop_model_2 = model.CropModel(num_classes=3)
+    crop_model_1 = model.CropModel(num_classes=2, label_dict={"Dead":0, "Alive":1})
+    crop_model_2 = model.CropModel(num_classes=3, label_dict={"Dead":0, "Alive":1, "Sapling":2})
 
     m.config.train.fast_dev_run = False
     m.create_trainer()
@@ -884,6 +892,7 @@ def test_epoch_evaluation_end_empty(m):
     boxes["image_path"] = "test"
     m.predictions = [boxes]
     m.on_validation_epoch_end()
+
 def test_empty_frame_accuracy_all_empty_with_predictions(m, tmpdir):
     """Test empty frame accuracy when all frames are empty but model predicts objects.
     The accuracy should be 0 since model incorrectly predicts objects in empty frames."""


### PR DESCRIPTION
In #705, on reload, we didn't recreate the numeric_to_label_dict as well as the label_dict. Removed the conditional in prediction, there is no reason this shouldn't exist.