### PR TITLE
Warn the user that the checkpoint doesn't have a label dict

### DIFF
--- a/src/deepforest/main.py
+++ b/src/deepforest/main.py
@@ -265,8 +265,12 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
         checkpoint["numeric_to_label_dict"] = self.numeric_to_label_dict
 
     def on_load_checkpoint(self, checkpoint):
-        self.label_dict = checkpoint["label_dict"]
-        self.numeric_to_label_dict = checkpoint["numeric_to_label_dict"]
+        try:
+            self.label_dict = checkpoint["label_dict"]
+            self.numeric_to_label_dict = checkpoint["numeric_to_label_dict"]
+        except KeyError:
+            print("No label_dict found in checkpoint, using default label_dict, please use deepforest.set_labels() to set the label_dict after loading the checkpoint.")
+        
 
     def save_model(self, path):
         """Save the trainer checkpoint in user defined path, in order to access


### PR DESCRIPTION
before the PR #1072 we need to warn the users of pre2.0 that their checkpoint needs to update the label_dict