### PR TITLE
bump albumentations to >=2.0.0 and python to 3.9+

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Developer's Guide
 
-Depends on Python 3.5+
+Depends on Python 3.9+
 
 ## Getting started
 
@@ -9,7 +9,7 @@ Depends on Python 3.5+
 2. Clone your copy of the repository.
 
    - **Using ssh**:
-   
+
      ```bash
      git clone git@github.com:[your user name]/DeepForest.git
      ```
@@ -83,7 +83,7 @@ $ pytest -v
 
 We use [yapf](https://github.com/google/yapf) for code formatting and style checking.
 
-The easiest way to make sure your code is formatted correctly is to integrate it into your editor.  
+The easiest way to make sure your code is formatted correctly is to integrate it into your editor.
 See [EDITOR SUPPORT](https://github.com/google/yapf/blob/main/EDITOR%20SUPPORT.md).
 
 You can also run yapf from the command line to cleanup the style in your changes:
@@ -111,7 +111,7 @@ $ conda build conda_recipe/meta.yaml -c conda-forge -c defaults
 
 Update the Conda recipe after every release.
 
-Clone the [Weecology staged recipes](https://github.com/weecology/staged-recipes).  
+Clone the [Weecology staged recipes](https://github.com/weecology/staged-recipes).
 Checkout the deepforest branch, update the `deepforest/meta.yaml` with the new version and the sha256 values. Sha256 values are obtained from the source on [PYPI download files](https://pypi.org/project/deepforest/#files) using the deepforest-{version-number}.tar.gz.
 
 ```jinja
@@ -131,7 +131,7 @@ $ docformatter --in-place --recursive src/deepforest/
 
 ### Update Documentation
 
-The documentation is automatically updated for changes in functions.  
+The documentation is automatically updated for changes in functions.
 However, the documentation should be updated after the addition of new functions or modules.
 
 Change to the docs directory and use `sphinx-apidoc` to update the doc's `source`. Exclude the tests and setup.py documentation.

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,4 +1,4 @@
-albumentations>=1.0.0,<2.0.0
+albumentations>=2.0.0
 aiolimiter
 aiohttp
 bump-my-version

--- a/environment.yml
+++ b/environment.yml
@@ -39,7 +39,7 @@ dependencies:
   - yapf
   - pip:
     - sphinx-markdown-tables
-    - albumentations>=1.0.0,<2.0.0
+    - albumentations>=2.0.0
     - comet_ml
     - pycocotools
     - aiolimiter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "1.5.3-dev0"
 description = "Tree crown prediction using deep learning retinanets"
 readme = "README.md"
 license = { text = "MIT" }
-requires-python = ">=3.8,<3.13"
+requires-python = ">=3.9,<3.13"
 classifiers = [
     "Development Status :: 6 - Mature",
     "License :: OSI Approved :: MIT License",
@@ -40,7 +40,7 @@ urls.Source = "https://github.com/Weecology/DeepForest"
 urls.Contributors = "https://github.com/Weecology/DeepForest/graphs/contributors"
 
 dependencies = [
-    "albumentations>=1.0.0,<2.0.0",
+    "albumentations>=2.0.0",
     "aiolimiter",
     "aiohttp",
     "docformatter",


### PR DESCRIPTION
This PR relates to https://github.com/weecology/DeepForest/issues/1058. We intended to pin Albumentations to 2+ for future versions of DeepForest (via #1057), but it seems like this got missed. This has a knock-on effect that we must also bump compatible versions of Python to at least 3.9+ (with `uv`'s resolver):

```bash
  × No solution found when resolving dependencies for split (python_full_version == '3.8.*'):
  ╰─▶ Because the requested Python version (>=3.8, <3.13) does not satisfy Python>=3.9 and albumentations>=2.0.1 depends on Python>=3.9, we can conclude that albumentations>=2.0.1 cannot be used.
      And because only the following versions of albumentations are available:
          albumentations<2.0.0
          albumentations==2.0.1
          albumentations==2.0.2
          albumentations==2.0.3
          albumentations==2.0.4
          albumentations==2.0.5
          albumentations==2.0.6
          albumentations==2.0.7
          albumentations==2.0.8
      we can conclude that albumentations>2.0.0 cannot be used.
      And because your project depends on albumentations>2.0.0 and your project requires deepforest[dev], we can conclude that your project's requirements are unsatisfiable.

      hint: The `requires-python` value (>=3.8, <3.13) includes Python versions that are not supported by your dependencies (e.g., albumentations>=2.0.1 only supports >=3.9). Consider using a more restrictive `requires-python` value (like >=3.9).
```

This PR sets albumentations to `>=2.0.0` and `uv sync --all-extras --dev` now works. There may be some additional constraints for `darwin/arm64` but this resolves on my M2.  I also bumped the Python version in `contributing` which was out of date. I assume the CI passed this because it was able to find a matching version to run the test matrix, but I discovered when trying to make a clean environment on my laptop and ran into some weird numpy incompatibility error.

I don't see any issue raising the minimum Python version. We only CI 3.10, 3.11 and 3.12 so the minimum version could be raised to 3.10 anyway. Definitely should be re-evaluated for the version 2 milestone.

Of note: some minor inconsistencies in the install instructions, where we initially recommend a minimum version "3.11" but then instruct users to install `python=3` for other environment versions. Suggest we consider going through the docs to make this consistent.