### PR TITLE
Transformers/DETR integration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "1.5.3-dev0"
 description = "Tree crown prediction using deep learning retinanets"
 readme = "README.md"
 license = { text = "MIT" }
-requires-python = ">=3.8,<3.13"
+requires-python = ">=3.9,<3.13"
 classifiers = [
     "Development Status :: 6 - Mature",
     "License :: OSI Approved :: MIT License",
@@ -40,7 +40,7 @@ urls.Source = "https://github.com/Weecology/DeepForest"
 urls.Contributors = "https://github.com/Weecology/DeepForest/graphs/contributors"
 
 dependencies = [
-    "albumentations>=1.0.0,<2.0.0",
+    "albumentations>=2.0.0",
     "aiolimiter",
     "aiohttp",
     "docformatter",
@@ -72,6 +72,7 @@ dependencies = [
     "tqdm",
     "xmltodict",
     "transformers>=4.46.3",
+    "timm>=1.0.15",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ dependencies = [
     "torchvision>=0.13",
     "tqdm",
     "xmltodict",
+    "transformers>=4.46.3",
 ]
 
 [project.optional-dependencies]

--- a/src/deepforest/conf/config.yaml
+++ b/src/deepforest/conf/config.yaml
@@ -11,6 +11,7 @@ batch_size: 1
 architecture: 'retinanet'
 num_classes: 1
 nms_thresh: 0.05
+score_thresh: 0.1
 
 model:
     name: 'weecology/deepforest-tree'
@@ -23,11 +24,6 @@ patch_overlap: 0.05
 annotations_xml:
 rgb_dir:
 path_to_rgb:
-
-# Architecture specific params
-retinanet:
-    # Non-max suppression of overlapping predictions
-    score_thresh: 0.1
 
 train:
     csv_file:

--- a/src/deepforest/main.py
+++ b/src/deepforest/main.py
@@ -145,7 +145,7 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
 
         # Set bird-specific settings if loading the bird model
         if model_name == "weecology/deepforest-bird":
-            self.config.retinanet.score_thresh = 0.3
+            self.config.score_thresh = 0.3
             self.label_dict = {"Bird": 0}
             self.numeric_to_label_dict = {v: k for k, v in self.label_dict.items()}
 

--- a/src/deepforest/main.py
+++ b/src/deepforest/main.py
@@ -63,7 +63,8 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
         # If not provided, load default config via hydra.
         if config is None:
             config = utilities.load_config(overrides=config_args)
-        elif 'config_file' in config:
+        # Hub overrides
+        elif 'config_file' in config or 'config_args' in config:
             config = utilities.load_config(overrides=config['config_args'])
         elif config_args is not None:
             warnings.warn(
@@ -118,7 +119,7 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
 
         self.save_hyperparameters()
 
-    def load_model(self, model_name="weecology/deepforest-tree", revision='main'):
+    def load_model(self, model_name=None, revision=None):
         """Loads a model that has already been pretrained for a specific task,
         like tree crown detection.
 
@@ -136,8 +137,14 @@ class deepforest(pl.LightningModule, PyTorchModelHubMixin):
         Returns:
             None
         """
+
+        if model_name is None:
+            model_name = self.config.model.name
+
+        if revision is None:
+            revision = self.config.model.revision
+
         # Load the model using from_pretrained
-        self.create_model()
         loaded_model = self.from_pretrained(model_name, revision=revision)
         self.label_dict = loaded_model.label_dict
         self.model = loaded_model.model

--- a/src/deepforest/model.py
+++ b/src/deepforest/model.py
@@ -20,11 +20,7 @@ class Model():
     statement below.
 
     Args:
-        num_classes (int): number of classes in the model
-        nms_thresh (float): non-max suppression threshold for intersection-over-union [0,1]
-        score_thresh (float): minimum prediction score to keep during prediction  [0,1]
-    Returns:
-        model: a pytorch nn module
+        config (DictConfig): DeepForest config settings object
     """
 
     def __init__(self, config):

--- a/src/deepforest/model.py
+++ b/src/deepforest/model.py
@@ -27,6 +27,7 @@ class Model():
 
         # Check for required properties and formats
         self.config = config
+        self.nms_thresh = None  # Required for some models but not all
 
     def create_model(self):
         """This function converts a deepforest config file into a model.

--- a/src/deepforest/models/DeformableDetr.py
+++ b/src/deepforest/models/DeformableDetr.py
@@ -1,7 +1,10 @@
 import warnings
-from transformers import DeformableDetrForObjectDetection, DeformableDetrConfig, DeformableDetrImageProcessor
+from transformers import DeformableDetrForObjectDetection, DeformableDetrImageProcessor, logging
 from deepforest.model import Model
 from torch import nn
+
+# Suppress huge amounts of unnecessary warnings from transformers.
+logging.set_verbosity_error()
 
 
 class TransformersWrapper(nn.Module):

--- a/src/deepforest/models/DeformableDetr.py
+++ b/src/deepforest/models/DeformableDetr.py
@@ -7,12 +7,12 @@ from torch import nn
 logging.set_verbosity_error()
 
 
-class TransformersWrapper(nn.Module):
-    """This class wraps a transformers AutoModelForObjectDetection model so
-    that input pre- and post-processing happens transparently."""
+class DeformableDetrWrapper(nn.Module):
+    """This class wraps a transformers DeformableDetrForObjectDetection model
+    so that input pre- and post-processing happens transparently."""
 
     def __init__(self, config, name, revision):
-        """Initialize an AutoModelForObjectDetection model.
+        """Initialize a DeformableDetrForObjectDetection model.
 
         We assume that the provided name applies to both model and
         processor. By default this function creates a model with MS-COCO
@@ -34,7 +34,7 @@ class TransformersWrapper(nn.Module):
             self.processor = DeformableDetrImageProcessor.from_pretrained(
                 name, revision=revision)
 
-    def prepare_targets(self, targets):
+    def _prepare_targets(self, targets):
 
         if not isinstance(targets, list):
             targets = [targets]
@@ -70,7 +70,7 @@ class TransformersWrapper(nn.Module):
         """
 
         if targets and prepare_targets:
-            targets = self.prepare_targets(targets)
+            targets = self._prepare_targets(targets)
 
         encoded_inputs = self.processor.preprocess(images=images,
                                                    annotations=targets,
@@ -101,7 +101,7 @@ class Model(Model):
         """Create a Deformable DETR model from pretrained weights.
 
         The number of classes set via config and will override the
-        downloaded checkpoint, which is expected if training from a
-        model derived from MS-COCO.
+        downloaded checkpoint. The default weights will load a model
+        trained on MS-COCO that should fine-tune well on other tasks.
         """
-        return TransformersWrapper(self.config, name, revision)
+        return DeformableDetrWrapper(self.config, name, revision)

--- a/src/deepforest/models/detr.py
+++ b/src/deepforest/models/detr.py
@@ -55,7 +55,8 @@ class TransformersWrapper(nn.Module):
             return self.processor.post_process_object_detection(
                 preds,
                 threshold=self.config.score_thresh,
-                target_sizes=[i.shape[-2:] for i in images])
+                target_sizes=[i.shape[-2:] for i in images]
+                if isinstance(images, list) else [images.shape[-2:]])
         else:
             return preds.loss_dict
 

--- a/src/deepforest/models/detr.py
+++ b/src/deepforest/models/detr.py
@@ -1,0 +1,78 @@
+import warnings
+from transformers import AutoModelForObjectDetection, AutoImageProcessor
+from deepforest.model import Model
+from torch import nn
+
+
+class TransformersWrapper(nn.Module):
+    """This class wraps a transformers AutoModelForObjectDetection model so
+    that input pre- and post-processing happens transparently."""
+
+    def __init__(self, config):
+        """Initialize an AutoModelForObjectDetection model.
+
+        We assume that the provided model.name specified via config
+        applies to both the model and the processor.
+        """
+        super().__init__()
+        self.config = config
+
+        # This suppresses a bunch of messages which are specific to DETR,
+        # but do not impact model function.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=UserWarning)
+
+            self.net = AutoModelForObjectDetection.from_pretrained(
+                self.config.model.name,
+                revision=self.config.model.revision,
+                num_labels=self.config.num_classes,
+                ignore_mismatched_sizes=True,
+            )
+
+        self.processor = AutoImageProcessor.from_pretrained(
+            self.config.model.name,
+            revision=self.config.model.revision,
+        )
+
+    def forward(self, images, targets=None):
+        """AutoModelForObjectDetection forward pass. If targets are provided
+        the function returns a loss dictionary, otherwise it returns processed
+        predictions. For details, see the transformers documentation for
+        "post_process_object_detection".
+
+        Returns:
+            predictions: list of dictionaries with "score", "boxes" and "labels", or
+                          a loss dict for training.
+        """
+        encoded_inputs = self.processor.preprocess(images=images,
+                                                   annotations=targets,
+                                                   return_tensors="pt",
+                                                   do_rescale=False)
+
+        preds = self.net(**encoded_inputs)
+
+        if targets is None:
+            return self.processor.post_process_object_detection(
+                preds,
+                threshold=self.config.score_thresh,
+                target_sizes=[i.shape[-2:] for i in images])
+        else:
+            return preds.loss_dict
+
+
+class Model(Model):
+
+    def __init__(self, config, **kwargs):
+        """
+        Args:
+        """
+        super().__init__(config)
+
+    def create_model(self):
+        """Create a Deformable DETR model from pretrained weights.
+
+        The number of classes set via config and will override the
+        downloaded checkpoint, which is expected if training from a
+        model derived from MS-COCO.
+        """
+        return TransformersWrapper(self.config)

--- a/src/deepforest/models/retinanet.py
+++ b/src/deepforest/models/retinanet.py
@@ -41,11 +41,8 @@ class Model(Model):
         return anchor_generator
 
     def create_model(self):
-        """Create a retinanet model
-        Args:
-            num_classes (int): number of classes in the model
-            nms_thresh (float): non-max suppression threshold for intersection-over-union [0,1]
-            score_thresh (float): minimum prediction score to keep during prediction  [0,1]
+        """Create a retinanet model.
+
         Returns:
             model: a pytorch nn module
         """
@@ -54,7 +51,7 @@ class Model(Model):
 
         model = RetinaNet(backbone=backbone, num_classes=self.config.num_classes)
         model.nms_thresh = self.config.nms_thresh
-        model.score_thresh = self.config.retinanet.score_thresh
+        model.score_thresh = self.config.score_thresh
 
         # Optionally allow anchor generator parameters to be created here
         # https://pytorch.org/vision/stable/_modules/torchvision/models/detection/retinanet.html

--- a/src/deepforest/visualize.py
+++ b/src/deepforest/visualize.py
@@ -396,11 +396,13 @@ def plot_results(results,
         root_dir = root_dir.iloc[0] if isinstance(root_dir, pd.Series) else root_dir
         image_path = os.path.join(root_dir, results.image_path.unique()[0])
         image = np.array(Image.open(image_path))
+    elif isinstance(image, str):
+        image = np.array(Image.open(image))
 
-        # Drop alpha channel if present and warn
-        if image.shape[2] == 4:
-            warnings.warn("Image has an alpha channel. Dropping alpha channel.")
-            image = image[:, :, :3]
+    # Drop alpha channel if present and warn
+    if image.shape[2] == 4:
+        warnings.warn("Image has an alpha channel. Dropping alpha channel.")
+        image = image[:, :, :3]
 
     # Plot the results following https://supervision.roboflow.com/annotators/
     fig, ax = plt.subplots()

--- a/tests/deepforest_config_test.yml
+++ b/tests/deepforest_config_test.yml
@@ -11,16 +11,12 @@ batch_size: 1
 architecture: 'retinanet'
 num_classes: 1
 nms_thresh: 0.05
-
-# Architecture specific params
-retinanet:
-    # Non-max suppression of overlapping predictions
-    score_thresh: 0.1
+score_thresh: 0.1
 
 train:
     csv_file:
     root_dir:
-    
+
     # Optimizer initial learning rate
     lr: 0.001
     scheduler:
@@ -50,10 +46,10 @@ train:
     fast_dev_run: False
     # pin images to GPU memory for fast training. This depends on GPU size and number of images.
     preload_images: False
-    
+
 validation:
     # callback args
-    csv_file: 
+    csv_file:
     root_dir:
     # Intersection over union evaluation
     iou_threshold: 0.4

--- a/tests/test_FasterRCNN.py
+++ b/tests/test_FasterRCNN.py
@@ -26,7 +26,7 @@ def _make_empty_sample():
     return images, targets
 
 
-def test_retinanet(config):
+def test_faster_rcnn(config):
     r = FasterRCNN.Model(config)
     assert r
 
@@ -48,10 +48,10 @@ def test_check_model(config):
 @pytest.mark.parametrize("num_classes", [1, 2, 10])
 def test_create_model(config, num_classes):
     config.num_classes = num_classes
-    retinanet_model = FasterRCNN.Model(config).create_model()
-    retinanet_model.eval()
+    faster_rcnn_model = FasterRCNN.Model(config).create_model()
+    faster_rcnn_model.eval()
     x = [torch.rand(3, 300, 400), torch.rand(3, 500, 400)]
-    predictions = retinanet_model(x)
+    predictions = faster_rcnn_model(x)
 
 
 def test_forward_empty(config):

--- a/tests/test_detr.py
+++ b/tests/test_detr.py
@@ -1,0 +1,81 @@
+# test Transformers/detr
+from deepforest.models import detr
+from deepforest import utilities
+from deepforest import get_data
+import pytest
+import torch
+from PIL import Image
+import numpy as np
+
+@pytest.fixture()
+def config():
+    config = utilities.load_config()
+    config.model.name = "joshvm/milliontrees-detr"
+    config.architecture = "detr"
+    config.train.fast_dev_run = True
+    config.batch_size = 1 #True Why is this true?
+    return config
+
+@pytest.fixture()
+def coco_sample():
+    images = [torch.rand((3, 100, 100), dtype=torch.float32)]
+    negative_target = {
+        "labels": torch.zeros(0, dtype=torch.int64),
+        "image_id": 4,
+        "annotations": [{
+            "id": 0,
+            "image_id": 4,
+            "category_id": 0,
+            "bbox": [0, 0, 10, 10],
+            "area": 10,
+            "iscrowd": 0,
+        }]
+    }
+
+    targets = [negative_target]
+    return images, targets
+
+def test_check_model(config):
+    r = detr.Model(config)
+    r.check_model()
+
+# The test case "2" currently fails due to a bug in transformers
+# which is fixed in transformers-4.53.0, related to the
+# from_pretrained logic.
+@pytest.mark.parametrize("num_classes", [1, 5, 10])
+def test_create_model(config, num_classes):
+    config.num_classes = num_classes
+    detr_model = detr.Model(config).create_model()
+    detr_model.eval()
+    x = [torch.rand(3, 300, 400), torch.rand(3, 500, 400)]
+    _ = detr_model(x)
+
+def test_boxes_in_output(config):
+    detr_model = detr.Model(config).create_model()
+    detr_model.eval()
+
+    image_path = get_data("OSBS_029.png")
+
+    # Passing a numpy array (or tensor) should work:
+    result = detr_model(np.array(Image.open(image_path)))
+
+    assert "boxes" in result[0]
+    assert "scores" in result[0]
+    assert "labels" in result[0]
+
+    # Passing a list is also allowed:
+    result = detr_model([np.array(Image.open(image_path))])
+
+    assert "boxes" in result[0]
+    assert "scores" in result[0]
+    assert "labels" in result[0]
+
+# Test
+def test_forward_sample(config, coco_sample):
+    r = detr.Model(config)
+    model = r.create_model()
+    image, targets = coco_sample
+    loss_dict = model(image, targets)
+
+    # Assert non-zero loss
+    assert sum([loss for loss in loss_dict.values()]) > 0

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -17,7 +17,7 @@ from albumentations.pytorch import ToTensorV2
 from deepforest import main, get_data, model
 from deepforest.utilities import read_file, format_geometry
 from deepforest.datasets import prediction
-from deepforest.visualize import plot_results 
+from deepforest.visualize import plot_results
 
 from pytorch_lightning import Trainer
 from pytorch_lightning.callbacks import Callback
@@ -222,7 +222,7 @@ def test_validate(m):
 
 
 # Test train with each architecture
-@pytest.mark.parametrize("architecture", ["retinanet", "FasterRCNN"])
+@pytest.mark.parametrize("architecture", ["retinanet", "FasterRCNN", "DeformableDetr"])
 def test_train_single(m_without_release, architecture):
     m_without_release.config.architecture = architecture
     m_without_release.create_model()
@@ -417,7 +417,7 @@ def test_predict_tile_from_array(m, path):
     m.create_trainer()
     prediction = m.predict_tile(image=image, patch_size=300)
 
-    assert not prediction.empty    
+    assert not prediction.empty
 
 def test_evaluate(m, tmpdir):
     csv_file = get_data("OSBS_029.csv")
@@ -468,7 +468,7 @@ def test_checkpoint_label_dict(m, tmpdir):
     m.config["train"]["root_dir"] = os.path.dirname(csv_file)
     m.config["validation"]["csv_file"] = os.path.join(tmpdir, "example.csv")
     m.config["validation"]["root_dir"] = os.path.dirname(csv_file)
-    
+
     m.config.train.fast_dev_run = True
     m.create_trainer()
     m.label_dict = {"Object": 0}
@@ -763,10 +763,10 @@ def test_predict_tile_with_crop_model_empty():
     """If the model return is empty, the crop model should return an empty dataframe"""
     path = get_data("SOAP_061.png")
     m = main.deepforest()
-    
+
     # Set up the crop model
     crop_model = model.CropModel(num_classes=2, label_dict = {"Dead": 0, "Alive": 1})
-    
+
     # Call the predict_tile method with the crop_model
     m.config.train.fast_dev_run = False
     m.create_trainer()
@@ -775,7 +775,7 @@ def test_predict_tile_with_crop_model_empty():
                             patch_overlap=0.05,
                             iou_threshold=0.15,
                             crop_model=crop_model)
-    
+
 
     # Assert the result
     assert result is None or result.empty
@@ -841,7 +841,7 @@ def test_batch_prediction(m, path):
         batch_predictions = m.predict_batch(batch)
         predictions.extend(batch_predictions)
 
-    # Check results  
+    # Check results
     assert len(predictions) == len(ds)
     for image_pred in predictions:
         assert isinstance(image_pred, pd.DataFrame)
@@ -944,7 +944,7 @@ def test_empty_frame_accuracy_all_empty_with_predictions(m, tmpdir):
 
     m.create_trainer()
     results = m.trainer.validate(m)
-    
+
     # This is bit of a preference, if there are no predictions, the empty frame accuracy should be 0, precision is 0, and accuracy is None.
     assert results[0]["empty_frame_accuracy"] == 0.0
     assert results[0]["box_precision"] == 0.0

--- a/tests/test_retinanet.py
+++ b/tests/test_retinanet.py
@@ -67,13 +67,13 @@ def test_forward_empty(config):
 
 # Can we update parameters after training
 def test_maintain_parameters(config):
-    config.retinanet.score_thresh = 0.4
+    config.score_thresh = 0.4
     retinanet_model = retinanet.Model(config).create_model()
-    assert retinanet_model.score_thresh == config.retinanet.score_thresh
+    assert retinanet_model.score_thresh == config.score_thresh
     retinanet_model.eval()
     x = [torch.rand(3, 300, 400), torch.rand(3, 500, 400)]
     predictions = retinanet_model(x)
-    assert retinanet_model.score_thresh == config.retinanet.score_thresh
+    assert retinanet_model.score_thresh == config.score_thresh
 
     retinanet_model.score_thresh = 0.9
     retinanet_model.eval()


### PR DESCRIPTION
This PR includes rudimentary support for transformers object detection models, specifically those supported by `AutoModelForObjectDetection`. I've trained a simple DeformableDetr model as a demonstration using the latest public release of MillionTrees which is hosted here (for testing): https://huggingface.co/joshvm/milliontrees-detr

The PR fixes a few issues in the process:

- Fixed an issue with albumentations versioning which can be rebased once the other PR is approved
- Adds dependencies for transformers and timm. I think as I used `uv` to add the pyproject line, it should be compatible with the python versions that we support.
- The `config.score_thresh` parameter is moved to be a top-level config item as there's no need for it to be specific to retinanet, and other places it's referenced have been updated. This is also used for post-processing results from DETR.
- Removed a comment in the config file that incorrectly suggests that threshold is NMS-related
- Removed some docstrings in models that were out of date (referring to constructor arguments that no longer exist)
- Adds a model class currently called `DeformableDETR`, but really it could support a variety of models. These can be separate files, but we would likely want to re-use the wrapper.
- A small improvement to plot_results to allow an image path to provided instead of an array instead of erroring.

An advantage of the current approach is that it requires no changes to `main` at the moment, the implementation is isolated to `models/detr.py`. I need to check compatibility with other prediction routes (like via the trainer) but the `forward` function returns [boxes, labels, scores] in a DeepForest-friendly format without any modification. The wrapper class is a bit awkward, but necessary because of the way that `Model` and sub-classes are currently implemented (since we need to run pre- and post-process which is transformers specific).

The model and processor (and their config as it relates to DeepForest) should be coupled, so I don't think we need to worry about exposing the details. So I think it's OK to have both loaded with `config.model.name` and keep the config fixed, rather than allow users to mess with image resizing. Other options like rescaling (1/255) and normalization should be preset so that the processor works with our dataset + loader.

NMS for `predict_image` doesn't seem to be working though, and I'm not sure why (@bw4sz?), see the following test script:

```python
from deepforest.main import deepforest
from deepforest.visualize import plot_results

m = deepforest(config_args={"model": {"name": "joshvm/milliontrees-detr"},
                            "score_thresh": 0.25, # This does work, at least.
                            "architecture": "detr"})

image_path = "src/deepforest/data/2018_SJER_3_252000_4107000_image_477.tif"

results = m.predict_image(path=image_path)

plot_results(results, image=image_path)
```

![image](https://github.com/user-attachments/assets/fff0772b-4a2a-4680-af60-5076a263b034)

Training is going to need a bigger refactor (probably) because the various Lightning `step`s in `main` make assumptions that might be tied to torchvision-type models.

TODO:

- Test suite. And fix the stuff that's currently breaking.
- Tidy up docstrings etc.
- Check prediction with other functions.
- Think about how we can enable training as well, vs just loading models.
- Evaluation check vs retinanet.
- Docs for what is required to pull in a model from HF and configuration parameters.