### PR TITLE
refactor image loading in visualize

### DIFF
--- a/src/deepforest/visualize.py
+++ b/src/deepforest/visualize.py
@@ -430,7 +430,7 @@ def plot_results(results,
     image = _load_image(image, results)
 
     # Plot the results following https://supervision.roboflow.com/annotators/
-    plt.subplots()
+    _, ax = plt.subplots()
     annotated_scene = _plot_image_with_geometry(df=results,
                                                 image=image,
                                                 sv_color=results_color_sv,

--- a/src/deepforest/visualize.py
+++ b/src/deepforest/visualize.py
@@ -72,7 +72,7 @@ def _load_image(image: Optional[Union[np.typing.NDArray, str, Image.Image]] = No
 def draw_points(image, points, color=None, radius=5, thickness=1):
     """Draw points on an image, returns a copy of the array
     Args:
-        image: a numpy array in RGB order, CHW format
+        image: a numpy array in RGB order, HWC format
         points: a numpy array of shape (N, 2) representing the coordinates of the points
         color: color of the points as a tuple of BGR color, e.g. orange points is (0, 165, 255)
         radius: radius of the points in px
@@ -98,7 +98,7 @@ def draw_objects(image, df, color=None, thickness=1):
     """Draw geometries on an image, returns a copy of the array.
 
     Args:
-        image: a numpy array in RGB order, CHW format
+        image: a numpy array in RGB order, HWC format
         df: a pandas dataframe with xmin, xmax, ymin, ymax and label column
         color: color of the bounding box as a tuple of BGR color, e.g. orange annotations is (0, 165, 255)
         thickness: thickness of the rectangle border line in px

--- a/src/deepforest/visualize.py
+++ b/src/deepforest/visualize.py
@@ -109,7 +109,7 @@ def plot_points(image: np.typing.NDArray,
     warnings.warn(
         "plot_points will be deprecated in 2.0, please use draw_points instead.",
         DeprecationWarning)
-    draw_points(image, points, color, radius, thickness)
+    return draw_points(image, points, color, radius, thickness)
 
 
 def draw_points(image: np.typing.NDArray,
@@ -139,7 +139,7 @@ def draw_points(image: np.typing.NDArray,
                    radius=radius,
                    thickness=thickness)
 
-    return image
+    return cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
 
 
 def plot_predictions(image: np.typing.NDArray,
@@ -161,7 +161,7 @@ def plot_predictions(image: np.typing.NDArray,
     warnings.warn(
         "plot_predictions will be deprecated in 2.0, please use draw_predictions instead. Or plot_results if you need a figure.",
         DeprecationWarning)
-    draw_predictions(image, df, color, thickness)
+    return draw_predictions(image, df, color, thickness)
 
 
 def draw_predictions(image: np.typing.NDArray,
@@ -225,7 +225,7 @@ def draw_predictions(image: np.typing.NDArray,
             polygon = np.array(row["polygon"])
             cv2.polylines(image, [polygon], True, color, thickness=thickness)
 
-    return image
+    return cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
 
 
 def label_to_color(label: int) -> tuple:

--- a/src/deepforest/visualize.py
+++ b/src/deepforest/visualize.py
@@ -62,8 +62,15 @@ def _load_image(image: Optional[Union[np.typing.NDArray, str, Image.Image]] = No
         warnings.warn("Image has an alpha channel. Dropping alpha channel.")
         image = image[:, :, :3]
 
-    if image.dtype == "float32":
-        warnings.warn("Image provided as float array, casting to usnsign")
+    if image.dtype != np.uint8:
+
+        warnings.warn(f"Image is {image.dtype}. Will be cast to 8-bit unsigned")
+
+        # Images in [0,1] are allowed, but should be rescaled
+        if image.max() < 1:
+            warnings.warn(f"Assuming image is in [0,1, scalingg to [0,255]")
+            image *= 255
+
         image = image.astype("uint8")
 
     return image

--- a/src/deepforest/visualize.py
+++ b/src/deepforest/visualize.py
@@ -379,7 +379,7 @@ def plot_results(results,
         thickness: thickness of the rectangle border line in px
         basename: optional basename for the saved figure. If None (default), the basename will be extracted from the image path.
         radius: radius of the points in px
-        image: an optional numpy array of an image to annotate. If None (default), the image will be loaded from the results dataframe.
+        image: an optional numpy array or path to an image to annotate. If None (default), the image will be loaded from the results dataframe.
         axes: returns matplotlib axes object if True
     Returns:
         Matplotlib axes object if axes=True, otherwise None
@@ -396,11 +396,17 @@ def plot_results(results,
         root_dir = root_dir.iloc[0] if isinstance(root_dir, pd.Series) else root_dir
         image_path = os.path.join(root_dir, results.image_path.unique()[0])
         image = np.array(Image.open(image_path))
+    elif isinstance(image, str):
+        image = np.array(Image.open(image))
+    elif not isinstance(image, np.typing.NDArray):
+        raise ValueError(
+            "Unable to load image, please provide either a Numpy array, a string path or a suitable dataframe"
+        )
 
-        # Drop alpha channel if present and warn
-        if image.shape[2] == 4:
-            warnings.warn("Image has an alpha channel. Dropping alpha channel.")
-            image = image[:, :, :3]
+    # Drop alpha channel if present and warn
+    if image.shape[2] == 4:
+        warnings.warn("Image has an alpha channel. Dropping alpha channel.")
+        image = image[:, :, :3]
 
     # Plot the results following https://supervision.roboflow.com/annotators/
     fig, ax = plt.subplots()

--- a/src/deepforest/visualize.py
+++ b/src/deepforest/visualize.py
@@ -14,12 +14,12 @@ from typing import Optional, Union
 from deepforest.utilities import determine_geometry_type
 
 
-def _load_image(image: Optional[Union[np.typing.NDArray, str]] = None,
+def _load_image(image: Optional[Union[np.typing.NDArray, str, Image.Image]] = None,
                 df: Optional[pd.DataFrame] = None) -> np.typing.NDArray:
     """Utility function to load an image from either a path or a
     prediction/annotation dataframe.
 
-    Returns an image in RGB format with CHW channel ordering.
+    Returns an image in RGB format with HWC channel ordering.
 
     Args:
         image (optional): Numpy array or string
@@ -46,7 +46,9 @@ def _load_image(image: Optional[Union[np.typing.NDArray, str]] = None,
         image = np.array(Image.open(image_path))
     elif isinstance(image, str):
         image = np.array(Image.open(image))
-    elif not isinstance(image, np.typing.NDArray):
+    elif isinstance(image, Image.Image):
+        image = np.array(image)
+    elif not isinstance(image, np.ndarray):
         raise ValueError("Image")
 
     # Fix channel ordering

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -157,7 +157,7 @@ def test_draw_points():
 
 def test_draw_objects(gdf_poly):
     image = visualize._load_image(get_data("OSBS_029.tif"))
-    image = visualize.draw_objects(image, gdf_poly)
+    image = visualize.draw_predictions(image, gdf_poly)
     assert image is not None
 
 def test_image_from_path_or_array():

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -6,7 +6,7 @@ import os
 import pytest
 import numpy as np
 import pandas as pd
-
+from PIL import Image
 import geopandas as gpd
 from shapely import geometry
 import cv2
@@ -189,13 +189,27 @@ def test_draw_objects(gdf):
     image = visualize.draw_objects(image, gdf)
     assert image is not None
 
-def test_image_from_array():
-    image = visualize._load_image(get_data("OSBS_029.tif"))
+def test_image_from_path_or_array():
+    image_path = visualize._load_image(np.array(Image.open(get_data("OSBS_029.tif"))))
+    image_array = visualize._load_image(get_data("OSBS_029.tif"))
+    assert np.allclose(image_path, image_array)
+
+def test_image_from_pil():
+    image = visualize._load_image(Image.open(get_data("OSBS_029.tif")))
     assert image is not None
 
-def test_image_from_path():
-    image_path = get_data("OSBS_029.tif")
-    image = visualize._load_image(image_path)
+def test_load_chw_to_hwc():
+    image = np.random.randint(0, 255, size=(3, 100, 100), dtype=np.uint8)
+    image = visualize._load_image(image)
+    assert image.shape == (100, 100, 3)
+
+def test_load_drop_alpha():
+    image = np.random.randint(0, 255, size=(100, 100, 4), dtype=np.uint8)
+    image = visualize._load_image(image)
+    assert image.shape == (100, 100, 3)
+
+def test_image_from_gdf(gdf):
+    image = visualize._load_image(df=gdf)
     assert image is not None
 
 @pytest.mark.xfail

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -212,6 +212,13 @@ def test_image_from_gdf(gdf):
     image = visualize._load_image(df=gdf)
     assert image is not None
 
+def test_check_dtype_rescale():
+    image = np.random.random((100, 100, 3))
+    assert image.dtype != np.uint8
+    image = visualize._load_image(image)
+    assert image.dtype == np.uint8
+    assert image.max() > 1 and image.max() <= 255
+
 @pytest.mark.xfail
 def test_image_empty():
     image = visualize._load_image()

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -12,7 +12,7 @@ from shapely import geometry
 import cv2
 
 @pytest.fixture
-def gdf():
+def gdf_poly():
     data = {
         'geometry': [geometry.Polygon([(10, 10), (20, 10), (20, 20), (10, 20), (15, 25)]),
                         geometry.Polygon([(30, 30), (40, 30), (40, 40), (30, 40), (35, 35)])],
@@ -24,6 +24,37 @@ def gdf():
     gdf.root_dir = os.path.dirname(get_data("OSBS_029.tif"))
     return gdf
 
+@pytest.fixture
+def gdf_point():
+    # Create a mock DataFrame with point annotations
+    data = {
+        'x': [15, 25],
+        'y': [15, 25],
+        'label': ['Tree', 'Tree'],
+        'image_path': [get_data("OSBS_029.tif"), get_data("OSBS_029.tif")],
+    }
+    df = pd.DataFrame(data)
+    gdf = utilities.read_file(df, root_dir=os.path.dirname(get_data("OSBS_029.tif")))
+    gdf.root_dir = os.path.dirname(get_data("OSBS_029.tif"))
+    return gdf
+
+
+@pytest.fixture
+def gdf_box():
+    # Create a mock DataFrame with box annotations
+    data = {
+        'xmin': [10, 20],
+        'ymin': [10, 20],
+        'xmax': [30, 40],
+        'ymax': [30, 40],
+        'label': ['Tree', 'Tree'],
+        'image_path': [get_data("OSBS_029.tif"), get_data("OSBS_029.tif")],
+        "score": [0.9, 0.8]
+    }
+    df = pd.DataFrame(data)
+    gdf = utilities.read_file(df, root_dir=os.path.dirname(get_data("OSBS_029.tif")))
+    gdf.root_dir = os.path.dirname(get_data("OSBS_029.tif"))
+    return gdf
 
 def test_predict_image_and_plot(m, tmpdir):
     sample_image_path = get_data("OSBS_029.png")
@@ -46,25 +77,13 @@ def test_multi_class_plot(tmpdir):
 
     assert os.path.exists(os.path.join(tmpdir, "SOAP_061.png"))
 
-def test_convert_to_sv_format():
-    # Create a mock DataFrame
-    data = {
-        'xmin': [0, 10],
-        'ymin': [0, 20],
-        'xmax': [5, 15],
-        'ymax': [5, 25],
-        'label': ['Tree', 'Tree'],
-        'score': [0.9, 0.8],
-        'image_path': ['image1.jpg', 'image1.jpg']
-    }
-    df = pd.DataFrame(data)
-    df = utilities.read_file(df, root_dir=os.path.dirname(get_data("OSBS_029.tif")))
+def test_convert_to_sv_format(gdf_box):
 
     # Call the function
-    detections = visualize.convert_to_sv_format(df)
+    detections = visualize.convert_to_sv_format(gdf_box)
 
     # Expected values
-    expected_boxes = np.array([[0, 0, 5, 5], [10, 20, 15, 25]], dtype=np.float32)
+    expected_boxes = np.array([[10, 10, 30, 30], [20, 20, 40, 40]], dtype=np.float32)
     expected_labels = np.array([0, 0])
     expected_scores = np.array([0.9, 0.8])
 
@@ -74,64 +93,27 @@ def test_convert_to_sv_format():
     np.testing.assert_array_equal(detections.confidence, expected_scores)
     assert detections['class_name'] == ['Tree', 'Tree']
 
-def test_plot_annotations(tmpdir):
-    # Create a mock DataFrame with box annotations
-    data = {
-        'xmin': [10, 20],
-        'ymin': [10, 20],
-        'xmax': [30, 40],
-        'ymax': [30, 40],
-        'label': ['Tree', 'Tree'],
-        'image_path': [get_data("OSBS_029.tif"), get_data("OSBS_029.tif")],
-        "score": [0.9, 0.8]
-    }
-    df = pd.DataFrame(data)
-    gdf = utilities.read_file(df, root_dir=os.path.dirname(get_data("OSBS_029.tif")))
-    gdf.root_dir = os.path.dirname(get_data("OSBS_029.tif"))
+def test_plot_annotations(gdf_box, tmpdir):
 
     # Call the function
-    visualize.plot_annotations(gdf, savedir=tmpdir)
+    visualize.plot_annotations(gdf_box, savedir=tmpdir)
 
     # Assertions
     assert os.path.exists(os.path.join(tmpdir, "OSBS_029.png"))
 
 
-def test_plot_results_box(tmpdir):
-    # Create a mock DataFrame with box annotations
-    data = {
-        'xmin': [10, 20],
-        'ymin': [10, 20],
-        'xmax': [30, 40],
-        'ymax': [30, 40],
-        'label': ['Tree', 'Tree'],
-        'image_path': [get_data("OSBS_029.tif"), get_data("OSBS_029.tif")],
-        "score": [0.9, 0.8]
-    }
-    df = pd.DataFrame(data)
-    gdf = utilities.read_file(df, root_dir=os.path.dirname(get_data("OSBS_029.tif")))
-    gdf.root_dir = os.path.dirname(get_data("OSBS_029.tif"))
+def test_plot_results_box(gdf_box, tmpdir):
 
     # Call the function
-    visualize.plot_results(gdf, savedir=tmpdir)
+    visualize.plot_results(gdf_box, savedir=tmpdir)
 
     # Assertions
     assert os.path.exists(os.path.join(tmpdir, "OSBS_029.png"))
 
-def test_plot_results_point(tmpdir):
-    # Create a mock DataFrame with point annotations
-    data = {
-        'x': [15, 25],
-        'y': [15, 25],
-        'label': ['Tree', 'Tree'],
-        'image_path': [get_data("OSBS_029.tif"), get_data("OSBS_029.tif")],
-        'score': [0.9, 0.8]
-    }
-    df = pd.DataFrame(data)
-    gdf = utilities.read_file(df, root_dir=os.path.dirname(get_data("OSBS_029.tif")))
-    gdf.root_dir = os.path.dirname(get_data("OSBS_029.tif"))
+def test_plot_results_point(gdf_point, tmpdir):
 
     # Call the function
-    visualize.plot_results(gdf, savedir=tmpdir)
+    visualize.plot_results(gdf_point, savedir=tmpdir)
 
     # Assertions
     assert os.path.exists(os.path.join(tmpdir, "OSBS_029.png"))
@@ -141,7 +123,6 @@ def test_plot_results_point_no_label(tmpdir):
     data = {
         'x': [15, 25],
         'y': [15, 25],
-        'label': ['Tree', 'Tree'],
         'image_path': [get_data("OSBS_029.tif"), get_data("OSBS_029.tif")],
     }
     df = pd.DataFrame(data)
@@ -154,25 +135,15 @@ def test_plot_results_point_no_label(tmpdir):
     # Assertions
     assert os.path.exists(os.path.join(tmpdir, "OSBS_029.png"))
 
-def test_plot_results_polygon(tmpdir):
-    # Create a mock DataFrame with polygon annotations
-    data = {
-        'geometry': [geometry.Polygon([(10, 10), (20, 10), (20, 20), (10, 20), (15, 25)]),
-                        geometry.Polygon([(30, 30), (40, 30), (40, 40), (30, 40), (35, 35)])],
-        'label': ['Tree', 'Tree'],
-        'image_path': [get_data("OSBS_029.tif"), get_data("OSBS_029.tif")],
-        'score': [0.9, 0.8]
-    }
-    gdf = gpd.GeoDataFrame(data)
+def test_plot_results_polygon(gdf_poly, tmpdir):
 
     #Read in image and get height
     image = cv2.imread(get_data("OSBS_029.tif"))
     height = image.shape[0]
     width = image.shape[1]
-    gdf.root_dir = os.path.dirname(get_data("OSBS_029.tif"))
 
     # Call the function
-    visualize.plot_results(gdf, savedir=tmpdir,height=height, width=width)
+    visualize.plot_results(gdf_poly, savedir=tmpdir,height=height, width=width)
 
     # Assertions
     assert os.path.exists(os.path.join(tmpdir, "OSBS_029.png"))
@@ -184,9 +155,9 @@ def test_draw_points():
     image = visualize.draw_points(image, points)
     assert image is not None
 
-def test_draw_objects(gdf):
+def test_draw_objects(gdf_poly):
     image = visualize._load_image(get_data("OSBS_029.tif"))
-    image = visualize.draw_objects(image, gdf)
+    image = visualize.draw_objects(image, gdf_poly)
     assert image is not None
 
 def test_image_from_path_or_array():
@@ -208,8 +179,8 @@ def test_load_drop_alpha():
     image = visualize._load_image(image)
     assert image.shape == (100, 100, 3)
 
-def test_image_from_gdf(gdf):
-    image = visualize._load_image(df=gdf)
+def test_image_from_gdf(gdf_poly):
+    image = visualize._load_image(df=gdf_poly)
     assert image is not None
 
 def test_check_dtype_rescale():

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -153,12 +153,24 @@ def test_draw_points():
     points = np.array([[10, 10], [20, 20]])
 
     image = visualize.draw_points(image, points)
-    assert image is not None
+    assert image is not None and isinstance(image, np.ndarray)
 
-def test_draw_objects(gdf_poly):
+def test_draw_predictions(gdf_poly):
     image = visualize._load_image(get_data("OSBS_029.tif"))
     image = visualize.draw_predictions(image, gdf_poly)
-    assert image is not None
+    assert image is not None and isinstance(image, np.ndarray)
+
+def test_plot_points():
+    image = visualize._load_image(get_data("OSBS_029.tif"))
+    points = np.array([[10, 10], [20, 20]])
+
+    image = visualize.plot_points(image, points)
+    assert image is not None and isinstance(image, np.ndarray)
+
+def test_plot_predictions(gdf_poly):
+    image = visualize._load_image(get_data("OSBS_029.tif"))
+    image = visualize.plot_predictions(image, gdf_poly)
+    assert image is not None and isinstance(image, np.ndarray)
 
 def test_image_from_path_or_array():
     image_path = visualize._load_image(np.array(Image.open(get_data("OSBS_029.tif"))))
@@ -174,6 +186,11 @@ def test_load_chw_to_hwc():
     image = visualize._load_image(image)
     assert image.shape == (100, 100, 3)
 
+def test_load_chw_to_hwc_tiny_image():
+    image = np.random.randint(0, 255, size=(3, 3, 100), dtype=np.uint8)
+    image = visualize._load_image(image)
+    assert image.shape == (3, 100, 3)
+
 def test_load_drop_alpha():
     image = np.random.randint(0, 255, size=(100, 100, 4), dtype=np.uint8)
     image = visualize._load_image(image)
@@ -188,7 +205,13 @@ def test_check_dtype_rescale():
     assert image.dtype != np.uint8
     image = visualize._load_image(image)
     assert image.dtype == np.uint8
-    assert image.max() > 1 and image.max() <= 255
+    assert image.max() >=0 and image.max() <= 255
+
+def test_check_float_image_non_unitary():
+    # Shift distribution to [-1,1]
+    image = 2*np.random.random((100, 100, 3)) - 1
+    image = visualize._load_image(image)
+    assert image.max() >=0 and image.max() <= 255
 
 @pytest.mark.xfail
 def test_image_empty():


### PR DESCRIPTION
Some refactoring in `visualisation.py` to make image handling more consistent. Test coverage was a bit spotty, so added checks for the drawing functions as well.

- Renamed "plot" functions to "draw" to better indicate that they return arrays and do not invoke "show"
- Refactored image loading into a separate function that can be used in multiple places. This loader handles the various edge cases (array/str/dataframe, != 3 channels, channel ordering, etc) and returns an RGB image. Supports str, numpy array, PIL Image and dataframe.
- Simplified RGB/BGR concerns and use `cv2.cvtColor` to handle channel conversion (equivalent to rolling axes, but more explicit - and CV2 is usually fast)
- Test cases for drawing points + geometry (could be expanded)
- Test cases for loading in different guises.
- Removed unnecessary fixture calls to `m` in several test cases.
- Fixed point-no-label test which did not have empty labels 
- Aside from the plot->draw rename, user facing interfaces remain the same- 

The diff is a little funky. Suggest viewing the raw file.