### PR TITLE
WIP: Refactor weight loading from deepforest:main to models

### DIFF
--- a/src/deepforest/conf/config.yaml
+++ b/src/deepforest/conf/config.yaml
@@ -13,8 +13,11 @@ num_classes: 1
 nms_thresh: 0.05
 
 model:
-    name: 'weecology/deepforest-tree'
-    revision: 'main'
+    name: 'joshvm/deepforest-tree'
+    revision: 'v2'
+
+label_dict:
+    Tree: 0
 
 # Pre-processing parameters
 path_to_raster:

--- a/src/deepforest/model.py
+++ b/src/deepforest/model.py
@@ -13,7 +13,7 @@ import cv2
 from PIL import Image
 
 
-class Model():
+class BaseModel():
     """A architecture agnostic class that controls the basic train, eval and
     predict functions. A model should optionally allow a backbone for
     pretraining. To add new architectures, simply create a new module in


### PR DESCRIPTION
This has come out of https://github.com/weecology/DeepForest/pull/1078 and some musings about how to handle checkpoints when we add new model variants to the package.

We currently store weights for trained models on HuggingFace. Models are instantiated two ways:

- `deepforest.main` calls `create_model()` on construction. This returns an instance of the desired architecture that's initialised to whatever the object returns by default, assuming no model was passed to the constructor directly.
- Alternatively/additionally we then call `load_model()` to pull in pre-trained weights.

There are a couple of issues here that I've run into when trying to add another model to the package:

- `load_model()` calls `deepforest.main.from_pretrained` which is a class method provided from the `PyTorchModelHubMixin` mixin. We attempt to set the return value to `self.model` and overwrite a few settings such as the instance label_dict, model and numeric_to_label_dict. This is an unusual way of using this function, because it builds an entirely new deepforest instance and then copies those three items from it. Whereas you'd normally do something like this to begin with:

```python
m = deepforest.from_pretrained(model_name, revision)
```

- We don't need to call `create_model` on construction unless we're training, because `load_model` will override it. This doesn't save much time, but it's a bit more efficient.
- Some parameters are hardcoded (e.g. the bird model class names) in the library, when they would be better off in the hub checkpoint.

Given what `load_model` is doing, I suggest we move the weight loading logic to the models directly.

This has an advantage that the weights stored on HF are (mostly) decoupled from the library and minimally contain the weights + label dict. I suspect there is currently a bug in the constructor at the moment where all models will open as retinanets, because of the way the config system is loaded (and the unnecessary extra call to `create_model` when you call `load_pretrained` as it calls the constructor again). Investigating that.

This PR proposes that models subclass `PyTorchModelHubMixin` where necessary. This has no effect on Lightning checkpointing as far as I'm aware, as those are separate (and store a lot more information to resume training state). This does not need to be done for transformers models as they already support the hub methods, but it would require adding the mixin to RetinaNet.

We would need re-publish weights to HF with a suitable revision (e.g. v2) and deprecate the old ones as v1. As long as the repository is updated in step with this change, this should be transparent. Otherwise we can keep a pathway to load the older weights but I've not found a clean way to get rid of the call to `create_model` this way.

```python
config = utilities.load_config(overrides= {"model": {"name": "joshvm/deepforest-tree",
                                                     "revision": "v2"}})
m = deepforest(config=config)
m.load_model()
results = m.predict_image(path="../src/deepforest/data/2018_SJER_3_252000_4107000_image_477.tif")
assert len(results) > 0
plot_results(results)
```

Config is overridden for now with test weights on HF, but we should revert that and make sure weights are under the weecology namespace.

