### PR TITLE
build: use ruff to replace yapf, flake8 nbqa and docformatter

### DIFF
--- a/.github/workflows/Conda-app.yml
+++ b/.github/workflows/Conda-app.yml
@@ -63,16 +63,10 @@ jobs:
         run: uv run deepforest train train.csv_file=src/deepforest/data/OSBS_029.csv train.root_dir=src/deepforest/data train.fast_dev_run=True
 
       - name: Check style
-        run: uv run yapf -d --recursive src/deepforest/ --style=.style.yapf
-
-      - name: Check notebook style
-        run: uv run nbqa yapf --in-place docs/user_guide/examples/*.ipynb --style=.style.yapf
+        uses: pre-commit/action@v3.0.1
 
       - name: Check notebook build
         run: uv run pytest --nbmake docs/**/*_test.ipynb
-
-      - name: Run docformatter
-        run: uv run docformatter --check --recursive src/deepforest/
 
       - name: Test Docs
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,28 +9,9 @@ repos:
     - id: check-json
       files: citation_count.json
 
-- repo: https://github.com/google/yapf
-  rev: v0.40.1
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.12.0
   hooks:
-    - id: yapf
-      language: python
-      additional_dependencies: [toml]
-      args: ['-i', '--style', '.style.yapf']
-      files: |
-        (?x)^(
-          src/deepforest.*\.py|
-          fetch_google_scholar\.py
-        )$
-
-- repo: local
-  hooks:
-    - id: docformatter
-      name: docformatter
-      entry: docformatter
-      language: system
-      types: [python]
-      args: ['--in-place']
-      files: |
-        (?x)^(
-          src/deepforest.*\.py
-        )$
+    - id: ruff
+      args: ["--fix"]
+    - id: ruff-format

--- a/.style.yapf
+++ b/.style.yapf
@@ -1,4 +1,0 @@
-[style]
-# YAPF uses the chromium style
-based_on_style = google
-COLUMN_LIMIT=90

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,12 +43,10 @@ dependencies = [
     "albumentations>=2.0.0",
     "aiolimiter",
     "aiohttp",
-    "docformatter",
     "huggingface_hub>=0.25.0",
     "hydra-core",
     "geopandas",
     "matplotlib",
-    "nbqa",
     "numpy",
     "opencv-python-headless>=4.5.4",
     "pandas",
@@ -75,28 +73,27 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "black",
     "bump-my-version",
-    "docformatter",
-    "flake8",
     "mypy",
     "nbmake",
     "nbsphinx",
-    "nbqa",
     "pytest",
     "pytest-cov",
     "pytest-mock",
     "pytest-xdist",
+    "ruff",
     "sphinx_design",
     "sphinx_markdown_tables",
     "sphinx_rtd_theme",
     "twine",
-    "yapf",
     "myst-parser",
 ]
 
 [project.scripts]
 deepforest = "deepforest.scripts.cli:main"
+
+[tool.ruff]
+line-length = 90
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,0 @@
-[flake8]
-exclude = docs
-
-[aliases]
-test = pytest


### PR DESCRIPTION
As mentioned in #1078, I think it would be a great idea to use a deterministic formatter such as ruff (which includes almost all the features of yapf, flake8, nbqa and docformatter).

I would further suggest to set up [pre-commit.ci](https://pre-commit.ci) so that pre-commit runs within pull requests. This would result in clearer diffs (I also encountered some import order differences in #901). Of course this would require first running `pre-commit run --all-files` to apply the rules to all files, which will result in a huge commit, but I think it will be benefitial on the long run.

PS: Running it locally, I found several "optional" corrections, e.g. "E712 Avoid equality comparisons to `True`; use `results.match:` for truth checks" or "E402 Module level import not at top of cell", but also more important ones such as "F841 Local variable `bounds` is assigned to but never used`" or "F821 Undefined name `plot_name`". We could further [configure ruff](https://docs.astral.sh/ruff/formatter/#configuration) to see which rules we want to apply.



