### PR TITLE
update config path in manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 
-include src/deepforest/conf/config.yml
+include src/deepforest/conf/config.yaml
 include src/deepforest/data/testfile_deepforest.csv
 include src/deepforest/data/testfile_multi.csv
 include src/deepforest/data/classes.csv


### PR DESCRIPTION
This PR updates the manifest file to correctly include `config.yaml`, which had a minor extension change  (`yml` -> `yaml`) when we moved to OmegaConf/Hydra.

@martibosch let us know if this fixes your issue, but either way the manifest is outdated.