### PR TITLE
pin safetensors until patched

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -29,7 +29,7 @@ pyyaml>=5.1.0
 rasterio
 recommonmark
 rtree
-safetensors
+safetensors<0.6.0
 slidingwindow
 sphinx
 sphinx_markdown_tables

--- a/environment.yml
+++ b/environment.yml
@@ -50,5 +50,5 @@ dependencies:
     - Pygments
     - docformatter
     - opencv-python-headless
-    - safetensors
+    - safetensors<0.6.0
     - myst-parser

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ dependencies = [
     "rasterio",
     "recommonmark",
     "rtree",
-    "safetensors",
+    "safetensors<0.6.0",
     "scipy>1.5",
     "six",
     "slidingwindow",


### PR DESCRIPTION
Pin `safetensors` to < 0.6.0 until the issue is patched, then we can add a range to avoid the releases that cause trouble.