### PR TITLE
move image logging to callback

### DIFF
--- a/src/deepforest/callbacks.py
+++ b/src/deepforest/callbacks.py
@@ -4,20 +4,28 @@ Callbacks must implement on_epoch_begin, on_epoch_end, on_fit_end,
 on_fit_begin methods and inject model and epoch kwargs.
 """
 
-import glob
+import json
+import os
+import warnings
+from pathlib import Path
 
+import matplotlib.pyplot as plt
 import numpy as np
+import pandas as pd
 import supervision as sv
+import torch
+from PIL import Image
 from pytorch_lightning import Callback
 
-from deepforest import visualize
+from deepforest import utilities, visualize
+from deepforest.datasets.training import BoxDataset
 
 
-class images_callback(Callback):
+class ImagesCallback(Callback):
     """Log evaluation images during training.
 
     Args:
-        savedir: Directory to save predicted images
+        save_dir: Directory to save predicted images
         n: Number of images to process
         every_n_epochs: Run interval in epochs
         select_random: Whether to select random images
@@ -26,61 +34,225 @@ class images_callback(Callback):
     """
 
     def __init__(
-        self, savedir, n=2, every_n_epochs=5, select_random=False, color=None, thickness=1
+        self,
+        save_dir,
+        prediction_samples=2,
+        dataset_samples=5,
+        every_n_epochs=5,
+        select_random=False,
+        color=None,
+        thickness=2,
     ):
-        self.savedir = savedir
-        self.n = n
+        self.savedir = save_dir
+        self.prediction_samples = prediction_samples
+        self.dataset_samples = dataset_samples
         self.color = color
         self.thickness = thickness
         self.select_random = select_random
         self.every_n_epochs = every_n_epochs
 
-    def log_images(self, pl_module):
-        """Log images to the logger."""
-        df = pl_module.predictions
+    def on_train_start(self, trainer, pl_module):
+        """Log sample images from training and validation datasets at training
+        start."""
 
-        # Limit to n images, potentially randomly selected
-        if self.select_random:
-            selected_images = np.random.choice(df.image_path.unique(), self.n)
-        else:
-            selected_images = df.image_path.unique()[: self.n]
-        df = df[df.image_path.isin(selected_images)]
+        if trainer.fast_dev_run:
+            return
 
-        # Add root_dir to the dataframe
-        if "root_dir" not in df.columns:
-            df["root_dir"] = pl_module.config.validation.root_dir
+        self.trainer = trainer
+        self.pl_module = pl_module
 
-        # Ensure color is correctly assigned
-        if self.color is None:
-            num_classes = len(df["label"].unique())
-            results_color = sv.ColorPalette.from_matplotlib("viridis", num_classes)
-        else:
-            results_color = self.color
+        # Training samples
+        pl_module.print("Logging training dataset samples.")
+        train_ds = trainer.train_dataloader.dataset
+        self._log_dataset_sample(train_ds, split="train")
 
-        # Plot results
-        visualize.plot_results(
-            results=df,
-            savedir=self.savedir,
-            results_color=results_color,
-            thickness=self.thickness,
-        )
-
-        try:
-            saved_plots = glob.glob(f"{self.savedir}/*.png")
-            for x in saved_plots:
-                pl_module.logger.experiment.log_image(x)
-        except Exception as e:
-            print(
-                "Could not find comet logger in lightning module, "
-                f"skipping upload, images were saved to {self.savedir}, "
-                f"error was raised {e}"
-            )
+        # Validation samples
+        if trainer.val_dataloaders:
+            pl_module.print("Logging validation dataset samples.")
+            val_ds = trainer.val_dataloaders.dataset
+            self._log_dataset_sample(val_ds, split="validation")
 
     def on_validation_end(self, trainer, pl_module):
         """Run callback at validation end."""
-        if trainer.sanity_checking:
+        if trainer.sanity_checking or trainer.fast_dev_run:
             return
 
-        if trainer.current_epoch % self.every_n_epochs == 0:
-            print("Running image callback")
-            self.log_images(pl_module)
+        if (trainer.current_epoch + 1) % self.every_n_epochs == 0:
+            pl_module.print("Logging prediction samples")
+            self._log_last_predictions(trainer, pl_module)
+
+    def _log_dataset_sample(self, dataset: BoxDataset, split: str):
+        """Log random samples from a DeepForest BoxDataset."""
+
+        if self.dataset_samples == 0:
+            return
+
+        out_dir = os.path.join(self.savedir, split + "_sample")
+        os.makedirs(out_dir, exist_ok=True)
+        n_samples = min(self.dataset_samples, len(dataset))
+        sample_indices = torch.randperm(len(dataset))[:n_samples]
+
+        sample_data = [dataset[idx] for idx in sample_indices]
+        sample_images = [data[0] for data in sample_data]
+        sample_targets = [data[1] for data in sample_data]
+        sample_paths = [data[2] for data in sample_data]
+
+        for image, target, path in zip(
+            sample_images, sample_targets, sample_paths, strict=False
+        ):
+            image_annotations = target.copy()
+            image_annotations = utilities.format_geometry(image_annotations, scores=False)
+            image_annotations.root_dir = dataset.root_dir
+            image_annotations["image_path"] = path
+
+            # Plot transformed image
+            basename = Path(path).stem
+            image = (255 * image.cpu().numpy().transpose((1, 2, 0))).astype(np.uint8)
+            fig = visualize.plot_annotations(
+                image=image,
+                annotations=image_annotations,
+                savedir=out_dir,
+                basename=basename,
+                thickness=self.thickness,
+                show=False,
+            )
+            plt.close(fig)
+
+            self._log_to_all(
+                image=os.path.join(out_dir, basename + ".png"),
+                trainer=self.trainer,
+                tag=f"{split} dataset sample",
+            )
+
+    def _log_last_predictions(self, trainer, pl_module):
+        """Log sample of predictions + targets from last validation."""
+        if self.prediction_samples == 0:
+            return
+
+        if len(pl_module.predictions) > 0:
+            df = pd.concat(pl_module.predictions)
+        else:
+            df = pd.DataFrame()
+
+        out_dir = os.path.join(self.savedir, "predictions")
+        os.makedirs(out_dir, exist_ok=True)
+
+        dataset = trainer.val_dataloaders.dataset
+
+        # Add root_dir to the dataframe
+        if "root_dir" not in df.columns:
+            df["root_dir"] = dataset.root_dir
+
+        # Limit to n images, potentially randomly selected
+        if self.select_random:
+            selected_images = np.random.choice(
+                df.image_path.unique(), self.prediction_samples
+            )
+        else:
+            selected_images = df.image_path.unique()[: self.prediction_samples]
+
+            # Ensure color is correctly assigned
+            if self.color is None:
+                num_classes = len(df["label"].unique())
+                results_color = sv.ColorPalette.from_matplotlib("viridis", num_classes)
+            else:
+                results_color = self.color
+
+        for image_name in selected_images:
+            pred_df = df[df.image_path == image_name]
+
+            targets = utilities.format_geometry(
+                dataset.annotations_for_path(image_name, return_tensor=True), scores=False
+            )
+
+            # Assume that validation images are un-augmented
+            basename = Path(image_name).stem + f"_{trainer.global_step}"
+            fig = visualize.plot_results(
+                basename=basename,
+                results=pred_df,
+                ground_truth=targets,
+                savedir=out_dir,
+                results_color=results_color,
+                thickness=self.thickness,
+                show=False,
+            )
+            plt.close(fig)
+
+            # Pred metadata, if supported.
+            stats = (
+                pred_df["score"]
+                .agg(
+                    mean_confidence="mean",
+                    max_confidence="max",
+                    min_confidence="min",
+                    std_confidence="std",
+                )
+                .to_dict()
+            )
+
+            metadata = {"pred_count": len(pred_df), "gt_count": len(targets)}
+            metadata.update(stats)
+
+            with open(os.path.join(out_dir, basename + ".json"), "w") as fp:
+                json.dump(metadata, fp, indent=1)
+
+            self._log_to_all(
+                image=os.path.join(out_dir, basename + ".png"),
+                trainer=trainer,
+                tag="prediction sample",
+                metadata=metadata,
+            )
+
+    def _log_to_all(self, image: str, trainer, tag, metadata: dict | None = None):
+        """Log to all connected loggers.
+
+        Since Comet will pickup image logs to Tensorboard by default, we
+        add a check to log images preferentially to Tensorboard if both
+        are enabled.
+        """
+        try:
+            img = np.array(Image.open(image).convert("RGB"))
+
+            loggers = [lg for lg in trainer.loggers if hasattr(lg, "experiment")]
+
+            tb = next((lg for lg in loggers if hasattr(lg.experiment, "add_image")), None)
+            if tb is not None:
+                tb.experiment.add_image(
+                    tag=f"{tag}/{os.path.basename(image)}",
+                    img_tensor=img,
+                    global_step=trainer.global_step,
+                    dataformats="HWC",
+                )
+                return
+
+            comet = next(
+                (lg for lg in loggers if hasattr(lg.experiment, "log_image")),
+                None,
+            )
+            if comet is not None:
+                meta = {
+                    "image_name": os.path.basename(image),
+                    "context": tag,
+                    "step": trainer.global_step,
+                }
+
+                if metadata:
+                    meta.update(metadata)
+
+                comet.experiment.log_image(
+                    img,
+                    name=tag,
+                    step=trainer.global_step,
+                    metadata=meta,
+                )
+
+        except Exception as e:
+            warnings.warn(f"Tried to log {image} exception raised: {e}", stacklevel=2)
+
+
+class images_callback(ImagesCallback):
+    def __init__(self, savedir, **kwargs):
+        warnings.warn(
+            "Please use ImagesCallback instead.", DeprecationWarning, stacklevel=2
+        )
+        super().__init__(save_dir=savedir, **kwargs)

--- a/src/deepforest/main.py
+++ b/src/deepforest/main.py
@@ -1,7 +1,6 @@
 # entry point for deepforest model
 import importlib
 import os
-import tempfile
 import warnings
 
 import geopandas as gpd
@@ -18,7 +17,7 @@ from torchmetrics.classification import BinaryAccuracy
 from torchmetrics.detection import IntersectionOverUnion, MeanAveragePrecision
 
 from deepforest import evaluate as evaluate_iou
-from deepforest import predict, utilities, visualize
+from deepforest import predict, utilities
 from deepforest.datasets import prediction, training
 
 
@@ -296,94 +295,6 @@ class deepforest(pl.LightningModule):
                 "please set 'config['train']['csv_file'] before "
                 "calling deepforest.create_trainer()'"
             )
-
-    def on_train_start(self):
-        """Log sample images from training and validation datasets at training
-        start."""
-
-        if self.trainer.fast_dev_run:
-            return
-
-        # Get training dataset
-        train_ds = self.train_dataloader().dataset
-
-        # Sample up to 5 indices from training dataset
-        n_samples = min(5, len(train_ds))
-        sample_indices = torch.randperm(len(train_ds))[:n_samples]
-
-        # Create temporary directory for images
-        tmpdir = tempfile.mkdtemp()
-
-        # Get images, targets and paths for sampled indices
-        sample_data = [train_ds[idx] for idx in sample_indices]
-        sample_images = [data[0] for data in sample_data]
-        sample_targets = [data[1] for data in sample_data]
-        sample_paths = [data[2] for data in sample_data]
-
-        for image, target, path in zip(
-            sample_images, sample_targets, sample_paths, strict=False
-        ):
-            # Get annotations for this image
-            image_annotations = target.copy()
-            image_annotations = utilities.format_geometry(image_annotations, scores=False)
-            image_annotations.root_dir = self.config.train.root_dir
-            image_annotations["image_path"] = path
-
-            # Plot and save
-            save_path = os.path.join(tmpdir, f"train_{os.path.basename(path)}")
-            visualize.plot_annotations(
-                image_annotations, savedir=tmpdir, image=image.numpy(), basename=path
-            )
-
-            # Log to available loggers
-            for logger in self.trainer.loggers:
-                if hasattr(logger.experiment, "log_image"):
-                    logger.experiment.log_image(
-                        save_path,
-                        metadata={
-                            "name": path,
-                            "context": "detection_train",
-                            "step": self.global_step,
-                        },
-                    )
-
-        # Also log validation images if available
-        if self.config.validation.csv_file is not None:
-            val_ds = self.val_dataloader().dataset
-
-            n_samples = min(5, len(val_ds))
-            sample_indices = torch.randperm(len(val_ds))[:n_samples]
-
-            sample_data = [val_ds[idx] for idx in sample_indices]
-            sample_images = [data[0] for data in sample_data]
-            sample_targets = [data[1] for data in sample_data]
-            sample_paths = [data[2] for data in sample_data]
-
-            for image, target, path in zip(
-                sample_images, sample_targets, sample_paths, strict=False
-            ):
-                image_annotations = target.copy()
-                image_annotations = utilities.format_geometry(
-                    image_annotations, scores=False
-                )
-                image_annotations.root_dir = self.config.validation.root_dir
-                image_annotations["image_path"] = path
-
-                save_path = os.path.join(tmpdir, f"val_{os.path.basename(path)}")
-                visualize.plot_annotations(
-                    image_annotations, savedir=tmpdir, image=image.numpy(), basename=path
-                )
-
-                for logger in self.trainer.loggers:
-                    if hasattr(logger.experiment, "log_image"):
-                        logger.experiment.log_image(
-                            save_path,
-                            metadata={
-                                "name": path,
-                                "context": "detection_val",
-                                "step": self.global_step,
-                            },
-                        )
 
     def on_save_checkpoint(self, checkpoint):
         checkpoint["label_dict"] = self.label_dict
@@ -959,15 +870,15 @@ class deepforest(pl.LightningModule):
 
         if self.current_epoch % self.config.validation.val_accuracy_interval == 0:
             if len(self.predictions) > 0:
-                self.predictions = pd.concat(self.predictions)
+                predictions = pd.concat(self.predictions)
             else:
-                self.predictions = pd.DataFrame()
+                predictions = pd.DataFrame()
 
             results = self.evaluate(
                 self.config.validation.csv_file,
                 root_dir=self.config.validation.root_dir,
                 size=self.config.validation.size,
-                predictions=self.predictions,
+                predictions=predictions,
             )
 
             # Log epoch metrics

--- a/src/deepforest/visualize.py
+++ b/src/deepforest/visualize.py
@@ -21,7 +21,8 @@ def _load_image(
     root_dir: str | None = None,
 ) -> np.typing.NDArray:
     """Utility function to load an image from either a path or a
-    prediction/annotation dataframe.
+    prediction/annotation dataframe. If both are passed, image takes
+    precedence.
 
     Returns an image in RGB format with HWC channel ordering.
 
@@ -34,12 +35,20 @@ def _load_image(
         image: Numpy array
     """
 
-    if image is None and df is None:
-        raise ValueError(
-            "Either an image or a valid dataframe must be provided for plotting."
-        )
+    if image is not None:
+        if isinstance(image, str):
+            if root_dir is not None:
+                image_path = os.path.join(root_dir, image)
+            else:
+                image_path = image
 
-    if df is not None:
+            image = np.array(Image.open(image_path))
+        elif isinstance(image, Image.Image):
+            image = np.array(image)
+        elif not isinstance(image, np.ndarray):
+            raise ValueError("Image should be a numpy array, path or PIL Image.")
+
+    elif df is not None:
         # Resolve image root
         if hasattr(df, "root_dir") and root_dir is None:
             root_dir = df.root_dir
@@ -54,17 +63,10 @@ def _load_image(
 
         image_path = os.path.join(root_dir, df.image_path.unique()[0])
         image = np.array(Image.open(image_path))
-    elif isinstance(image, str):
-        if root_dir is not None:
-            image_path = os.path.join(root_dir, image)
-        else:
-            image_path = image
-
-        image = np.array(Image.open(image_path))
-    elif isinstance(image, Image.Image):
-        image = np.array(image)
-    elif not isinstance(image, np.ndarray):
-        raise ValueError("Image should be a numpy array, path or PIL Image.")
+    else:
+        raise ValueError(
+            "Either an image or a valid dataframe must be provided for plotting."
+        )
 
     # Fix channel ordering
     if image.ndim == 3 and image.shape[0] == 3 and image.shape[2] != 3:
@@ -511,9 +513,10 @@ def plot_annotations(
             basename = os.path.splitext(
                 os.path.basename(annotations.image_path.unique()[0])
             )[0]
+        os.makedirs(savedir, exist_ok=True)
         image_name = f"{basename}.png"
         image_path = os.path.join(savedir, image_name)
-        cv2.imwrite(image_path, annotated_scene)
+        Image.fromarray(annotated_scene).save(image_path)
     else:
         # Display the image using Matplotlib
         ax.imshow(annotated_scene)
@@ -602,9 +605,11 @@ def plot_results(
             basename = os.path.splitext(os.path.basename(results.image_path.unique()[0]))[
                 0
             ]
+
+        os.makedirs(savedir, exist_ok=True)
         image_name = f"{basename}.png"
         image_path = os.path.join(savedir, image_name)
-        cv2.imwrite(image_path, annotated_scene)
+        Image.fromarray(annotated_scene).save(image_path)
     else:
         # Display the image using Matplotlib
         ax.imshow(annotated_scene)

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -1,21 +1,158 @@
 # test callbacks
 import glob
+import os
+from unittest.mock import MagicMock, Mock
 
+import pytest
 from pytorch_lightning.callbacks import ModelCheckpoint
+from pytorch_lightning.loggers.logger import DummyLogger
 
-from deepforest import callbacks
+from deepforest import get_data
+from deepforest import callbacks, main
+
+class MockCometLogger(DummyLogger):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.setup()
+
+    def setup(self):
+        probe = Mock(spec_set=("log_image",))
+        probe.log_image = MagicMock(name="log_image")
+        self._experiment = probe
+
+    @property
+    def experiment(self):
+        return self._experiment
 
 
-def test_log_images(m, tmpdir):
-    im_callback = callbacks.images_callback(savedir=tmpdir, every_n_epochs=2)
-    m.create_trainer(callbacks=[im_callback])
+class MockTBLogger(MockCometLogger):
+    def setup(self):
+        probe = Mock(spec_set=("add_image",))
+        probe.add_image = MagicMock(name="add_image")
+        self._experiment = probe
+
+@pytest.fixture(scope="module")
+def m(download_release):
+    m = main.deepforest()
+    m.config.train.csv_file = get_data("example.csv")
+    m.config.train.root_dir = os.path.dirname(get_data("example.csv"))
+    m.config.train.fast_dev_run = True
+    m.config.batch_size = 2
+    m.config.validation.csv_file = get_data("example.csv")
+    m.config.validation.root_dir = os.path.dirname(get_data("example.csv"))
+    m.config.workers = 0
+    m.config.validation.val_accuracy_interval = 1
+    m.config.train.epochs = 2
+
+    m.create_trainer()
+    m.load_model("weecology/deepforest-tree")
+
+    return m
+
+
+def test_log_images_dummy_comet(m, tmpdir):
+    """Test for Comet-style loggers with log_image method"""
+    logger = MockCometLogger()
+    im_callback = callbacks.ImagesCallback(save_dir=tmpdir,
+                                           every_n_epochs=1,
+                                           prediction_samples=1,
+                                           dataset_samples=1)
+
+    m.create_trainer(callbacks=[im_callback], logger=logger, fast_dev_run=False)
     m.trainer.fit(m)
-    saved_images = glob.glob("{}/*.png".format(tmpdir))
-    assert len(saved_images) == 1
 
+    # Expect 1 from each dataset, 1 from prediction
+    assert logger.experiment.log_image.call_count >= 3
+
+def test_log_images_dummy_tb(m, tmpdir):
+    """Test for Tensorboard-style loggers with add_image method"""
+    logger = MockTBLogger()
+    im_callback = callbacks.ImagesCallback(save_dir=tmpdir,
+                                           every_n_epochs=1,
+                                           prediction_samples=1,
+                                           dataset_samples=1)
+
+    m.create_trainer(callbacks=[im_callback], logger=logger, fast_dev_run = False)
+    m.trainer.fit(m)
+
+    # Expect 1 from each dataset, 1 from prediction
+    assert logger.experiment.add_image.call_count >= 3
+
+
+def test_log_images_dummy_both(m, tmpdir):
+    """Test for the correct logger precedence is respected (TB > Comet)."""
+    comet = MockCometLogger()
+    tensorboard = MockTBLogger()
+    loggers = [comet, tensorboard]
+    im_callback = callbacks.ImagesCallback(save_dir=tmpdir,
+                                           every_n_epochs=1,
+                                           prediction_samples=1,
+                                           dataset_samples=1)
+
+    m.create_trainer(callbacks=[im_callback], logger=loggers, fast_dev_run = False)
+    m.trainer.fit(m)
+
+    # Expect 1 from each dataset, 1 from prediction
+    assert tensorboard.experiment.add_image.call_count >= 3
+    assert comet.experiment.log_image.call_count == 0
+
+def test_log_images_file(m, tmpdir):
+    im_callback = callbacks.ImagesCallback(save_dir=tmpdir, every_n_epochs=1, prediction_samples=5)
+
+    m.create_trainer(callbacks=[im_callback], fast_dev_run = False)
+    m.trainer.fit(m)
+
+    assert os.path.exists(os.path.join(tmpdir, "predictions"))
+    saved_images = glob.glob("{}/predictions/*.png".format(tmpdir))
+    assert len(saved_images) == m.current_epoch*min(len(m.val_dataloader().dataset), im_callback.prediction_samples)
+    saved_meta = glob.glob("{}/predictions/*.json".format(tmpdir))
+    assert len(saved_meta) == m.current_epoch*min(len(m.val_dataloader().dataset), im_callback.prediction_samples)
+
+    assert os.path.exists(os.path.join(tmpdir, "train_sample"))
+    train_images = glob.glob("{}/train_sample/*".format(tmpdir))
+    assert len(train_images) == min(len(m.train_dataloader().dataset), im_callback.dataset_samples)
+
+    assert os.path.exists(os.path.join(tmpdir, "validation_sample"))
+    val_images = glob.glob("{}/validation_sample/*".format(tmpdir))
+    assert len(val_images) == min(len(m.val_dataloader().dataset), im_callback.dataset_samples)
+
+def test_log_images_fast(m, tmpdir):
+    """Test that no images are logged if fast_dev_run is active"""
+    im_callback = callbacks.ImagesCallback(save_dir=tmpdir, every_n_epochs=1)
+
+    m.create_trainer(callbacks=[im_callback], fast_dev_run=True)
+    m.trainer.fit(m)
+
+    assert not os.path.exists(os.path.join(tmpdir, "predictions"))
+    assert not os.path.exists(os.path.join(tmpdir, "train_sample"))
+    assert not os.path.exists(os.path.join(tmpdir, "validation_sample"))
+
+def test_log_images_no_pred(m, tmpdir):
+    """Test disabling prediction logging"""
+    im_callback = callbacks.ImagesCallback(save_dir=tmpdir, prediction_samples=0, every_n_epochs=1)
+
+    m.create_trainer(callbacks=[im_callback], fast_dev_run=False)
+    m.trainer.fit(m)
+
+    assert not os.path.exists(os.path.join(tmpdir, "predictions"))
+    assert os.path.exists(os.path.join(tmpdir, "train_sample"))
+    assert os.path.exists(os.path.join(tmpdir, "validation_sample"))
+
+def test_log_images_no_dataset(m, tmpdir):
+    """Test disabling dataset sample logging"""
+    im_callback = callbacks.ImagesCallback(save_dir=tmpdir, dataset_samples=0, every_n_epochs=1)
+
+    m.create_trainer(callbacks=[im_callback], fast_dev_run=False)
+    m.trainer.fit(m)
+
+    assert os.path.exists(os.path.join(tmpdir, "predictions"))
+    assert not os.path.exists(os.path.join(tmpdir, "train_sample"))
+    assert not os.path.exists(os.path.join(tmpdir, "validation_sample"))
 
 def test_create_checkpoint(m, tmpdir):
+    """Test checkpoint creation"""
     checkpoint_callback = ModelCheckpoint(
+        filename='model',
         dirpath=tmpdir,
         save_top_k=1,
         monitor="val_classification",
@@ -23,5 +160,7 @@ def test_create_checkpoint(m, tmpdir):
         every_n_epochs=1,
     )
     m.load_model("weecology/deepforest-tree")
-    m.create_trainer(callbacks=[checkpoint_callback])
+    m.create_trainer(callbacks=[checkpoint_callback], fast_dev_run=False)
     m.trainer.fit(m)
+
+    assert os.path.exists(os.path.join(tmpdir, 'model.ckpt'))

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -208,6 +208,7 @@ def test_validation_step(m):
     val_dataloader = m.val_dataloader()
     batch = next(iter(val_dataloader))
     m.predictions = []
+    m.targets = {}
     val_loss = m.validation_step(batch, 0)
     assert val_loss != 0
 
@@ -221,6 +222,7 @@ def test_validation_step_empty(m_without_release):
     val_dataloader = m.val_dataloader()
     batch = next(iter(val_dataloader))
     m.predictions = []
+    m.targets = {}
     val_predictions = m.validation_step(batch, 0)
     assert m.iou_metric.compute()["iou"] == 0
 
@@ -1108,20 +1110,3 @@ def test_set_labels_invalid_length(m): # Expect a ValueError when setting an inv
     invalid_mapping = {"Object": 0, "Extra": 1}
     with pytest.raises(ValueError):
         m.set_labels(invalid_mapping)
-
-def test_on_train_start_basic(m):
-    """Test that on_train_start runs without error and logs images using the default logger."""
-    # Create a mock logger
-    class MockLogger:
-        def __init__(self):
-            self.experiment = Mock()
-            self.experiment.log_image = self.log_image
-            self.images = []
-
-        def log_image(self, image, metadata):
-            self.images.append(image)
-
-    m.create_trainer(fast_dev_run=False, limit_train_batches=2, limit_val_batches=2, logger=MockLogger())
-    m.on_train_start()
-
-    assert len(m.logger.images) == 2


### PR DESCRIPTION
This PR improves image visualization during training. It also includes some minor logic changes to `main.py` and `visualize.py` to support.

- Pre-train sample plotting has been moved to the same callback that plots sample images during training. This is IMO a logical place for this code to go, but does mean that the callback should be set up separately and won't be added by default.
- Images can be logged pre-train (dataset samples) and during training after the validation loop (predictions with ground truth).

Changes to `callbacks.py`
- Images are logged in `save_dir` with subdirectories for specific image categories (e.g. train_sample, val_sample and predictions). You can pass a tmpdir if you don't want anything to persist on disk, however the intent is that users will set up training to log to a specific and well-organized folder that replicates their experiment (see dinov3 CLI for example).
- Image logging during training now includes ground truth as well as the predictions. Metadata is also logged + saved to disk. This can definitely be expanded in future (e.g. plot scores/labels).
- Supports Tensorboard and/or Comet. Images are tagged so that Tensorboard will group them appropriately. Comet doesn't do this very well, but it's not a disaster as they're still sorted by step (+ group in the web UI). If both loggers are present, Tensorboard is favored so that Comet doesn't double-log. Tensorboard is an explicit dependency of DeepForest currently, so we can assume it's installed.
- One idea I had was to have the callback specifically take a logger in its constructor so that it will _only_ send to a specific one. We set up loggers + callbacks at the same time anyway. However, it wouldn't avoid double-logging unless Comet is set to not auto-detect metrics (I don't know what else this disables?). This could also be used to take advantage of things like the [Comet annotation API](https://www.comet.com/docs/v2/guides/experiment-management/log-data/images/#log-image-with-bounding-boxes). Could be a demo script so we don't need to add the dependency.

Changes to `visualization.py`:
- To plot the image, we call `plot_annotations`/`plot_results` which save the image to disk.
- Since we're plotting dataset samples, images are assumed to be transformed. It's important that we plot the transformed image.
- If you pass both an image and a dataframe to `_load_image`, the dataframe would take precedence. This would cause weird behaviour where we would take annotations from the dataset and the non-transformed image from disk.
- Refactored so that if you pass an image, it takes precedence. The plotting functions pass both to the loader, as they don't check which of image/df was provided.
- Use PIL for image saving outside of places where we're using OpenCV to avoid extra conversion between color formats.

Changes to `main.py`:
- ~~Cache `targets` as well as predictions on validation rounds. I suspect this is a bad idea.~~ I'm going to index the dataset directly instead, less ram (forgot it's a dataframe).
- I think the callback here actually is off-by-one. It should compute evaluation on `self.current_epochs + 1`. Will submit that separately.

Tests:
- Re-jigged the existing mock test to confirm that logging is called.
- Added other tests to confirm files are saved to disk.
- Added an assertion to the Checkpoint callback to confirm it fires

I've also deprecated `images_callback` in favour of `ImageCallback` and moved `savedir` to `save_dir` to align better with Lightning logger patterns (though ModelCheckpoint uses `dirpath`, go figure).

<img width="1659" height="845" alt="image" src="https://github.com/user-attachments/assets/7b2e6827-71bc-495c-aa6b-8bb466e01023" />

<img width="1848" height="725" alt="image" src="https://github.com/user-attachments/assets/1a0df93c-7f16-4534-920b-a21b93a8021f" />

<img width="1500" height="758" alt="image" src="https://github.com/user-attachments/assets/f75a2440-4518-434b-8164-18251f0549f4" />


Fixes https://github.com/weecology/DeepForest/issues/1109
