### PR TITLE
account for current_epoch being zero indexed when triggering evaluate

### DIFF
--- a/src/deepforest/main.py
+++ b/src/deepforest/main.py
@@ -957,7 +957,7 @@ class deepforest(pl.LightningModule):
         if self.trainer.sanity_checking:  # optional skip
             return
 
-        if self.current_epoch % self.config.validation.val_accuracy_interval == 0:
+        if (self.current_epoch + 1) % self.config.validation.val_accuracy_interval == 0:
             if len(self.predictions) > 0:
                 self.predictions = pd.concat(self.predictions)
             else:


### PR DESCRIPTION
This small change adjusts when we `evaluate` during training. Current behavior is:

```python
if self.current_epoch % self.config.validation.val_accuracy_interval == 0:
    evaluate()
```

which will always fire for `current_epoch = 0`, because epochs are 0-indexed. If you set `val_accuracy_interval == max_epochs` (with the intention to do a single eval at the end of training), it also won't fire, because last epoch is `max_epochs - 1`.

I propose changing to:

```python
if (self.current_epoch + 1) % self.config.validation.val_accuracy_interval == 0:
```

which should fix both issues and is more intuitive to me.

EDIT: In case there are concerns, this is also Lightning's interpretation: https://github.com/Lightning-AI/pytorch-lightning/blob/b7ca4d365978512ae053d7d8a8c2ddc99894e813/src/lightning/pytorch/loops/training_epoch_loop.py#L519