### PR TITLE
add SAM2 box -> polygon script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ docs = [
 
 [project.scripts]
 deepforest = "deepforest.scripts.cli:main"
+deepforest-sam = "deepforest.scripts.sam:main"
 
 [build-system]
 requires = ["setuptools>=61.0", "wheel"]

--- a/src/deepforest/scripts/sam.py
+++ b/src/deepforest/scripts/sam.py
@@ -1,0 +1,299 @@
+"""Convert DeepForest bounding box predictions to polygons using SAM2."""
+
+import argparse
+import logging
+import os
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import torch
+from PIL import Image
+from shapely import wkt
+from shapely.geometry import Polygon
+from tqdm import tqdm
+from transformers import Sam2Model, Sam2Processor
+
+from deepforest.utilities import mask_to_polygon
+from deepforest.visualize import plot_results
+
+logger = logging.getLogger(__name__)
+
+
+def load_sam2_model(model_name: str, device: str):
+    """Load SAM2 model and processor from HuggingFace.
+
+    Args:
+        model_name: Name of the SAM2 model on HuggingFace
+        device: Device to load model on ('cuda', 'mps', or 'cpu')
+
+    Returns:
+        Tuple of (model, processor)
+    """
+    processor = Sam2Processor.from_pretrained(model_name)
+    model = Sam2Model.from_pretrained(model_name)
+    model = model.to(device)
+    return model, processor
+
+
+def process_image_group(
+    image_path: str,
+    detections: pd.DataFrame,
+    model,
+    processor,
+    device: str,
+    image_root: str = "",
+    box_batch_size: int = 32,
+    mask_threshold: float = 0.5,
+    iou_threshold: float = 0.5,
+    viz_output_dir: str = None,
+) -> list:
+    """Process all detections for a single image.
+
+    Args:
+        image_path: Path to the image file
+        detections: DataFrame of detections for this image
+        model: SAM2 model
+        processor: SAM2 processor
+        device: Device to run inference on
+        image_root: Root directory to prepend to image_path if needed
+        box_batch_size: Maximum number of boxes to process per forward pass
+        mask_threshold: Threshold for binarizing SAM2 mask outputs
+        iou_threshold: Minimum IoU score to accept a polygon
+        viz_output_dir: Directory to save visualizations (if not None)
+
+    Returns:
+        List of WKT polygon strings
+    """
+    full_path = os.path.join(image_root, image_path) if image_root else image_path
+    image = Image.open(full_path).convert("RGB")
+
+    boxes = detections[["xmin", "ymin", "xmax", "ymax"]].values.tolist()
+
+    all_polygons = []
+    for i in range(0, len(boxes), box_batch_size):
+        box_chunk = boxes[i : i + box_batch_size]
+        input_boxes = [box_chunk]
+
+        inputs = processor(images=image, input_boxes=input_boxes, return_tensors="pt").to(
+            device
+        )
+
+        with torch.no_grad():
+            outputs = model(**inputs)
+
+        masks = processor.post_process_masks(
+            outputs.pred_masks.cpu(),
+            inputs["original_sizes"],
+            binarize=False,
+            mask_interpolation_mode="nearest",
+        )[0]
+
+        iou_scores = outputs.iou_scores.cpu()
+
+        for i, mask_set in enumerate(masks):
+            best_idx = iou_scores[0, i].argmax().item()
+            best_iou = iou_scores[0, i, best_idx].item()
+
+            if best_iou < iou_threshold:
+                all_polygons.append(Polygon().wkt)
+                continue
+
+            best_mask = mask_set[best_idx]
+            mask_np = (best_mask.numpy() > mask_threshold).astype(np.uint8)
+            polygon = mask_to_polygon(mask_np)
+            all_polygons.append(polygon.wkt)
+
+    if viz_output_dir is not None:
+        viz_df = detections.copy()
+        viz_df["polygon_geometry"] = all_polygons
+        viz_df["geometry"] = viz_df["polygon_geometry"].apply(
+            lambda x: wkt.loads(x) if pd.notna(x) else None
+        )
+        viz_df = viz_df[
+            viz_df["geometry"].apply(lambda x: x is not None and not x.is_empty)
+        ]
+
+        if len(viz_df) > 0:
+            if "label" not in viz_df.columns:
+                viz_df["label"] = "Tree"
+            if "score" not in viz_df.columns:
+                viz_df["score"] = 1.0
+
+            full_path = os.path.join(image_root, image_path) if image_root else image_path
+            with Image.open(full_path) as img:
+                width, height = img.size
+
+            image_name = Path(image_path).stem
+            viz_path = os.path.join(viz_output_dir, f"{image_name}_polygons.png")
+            plot_results(
+                results=viz_df,
+                image=full_path,
+                savedir=os.path.dirname(viz_path),
+                basename=os.path.splitext(os.path.basename(viz_path))[0],
+                height=height,
+                width=width,
+                show=False,
+            )
+
+    return all_polygons
+
+
+def convert_boxes_to_polygons(
+    input_csv: str,
+    output_csv: str,
+    model_name: str = "facebook/sam2.1-hiera-small",
+    box_batch_size: int = 32,
+    image_root: str = "",
+    visualize: bool = False,
+    viz_output_dir: str = ".",
+    mask_threshold: float = 0.5,
+    iou_threshold: float = 0.5,
+    device: str = None,
+) -> None:
+    """Convert DeepForest bounding boxes to polygons using SAM2.
+
+    Args:
+        input_csv: Path to input CSV with DeepForest predictions
+        output_csv: Path to save output CSV with polygons
+        model_name: HuggingFace model name for SAM2
+        box_batch_size: Maximum number of boxes to process per forward pass
+        image_root: Root directory to prepend to image paths in CSV
+        visualize: Whether to create visualization images
+        viz_output_dir: Directory to save visualization images
+        mask_threshold: Threshold for binarizing SAM2 mask outputs
+        iou_threshold: Minimum IoU score to accept a polygon
+        device: Device to use ('cuda', 'mps', or 'cpu'). Auto-detects if None.
+    """
+    df = pd.read_csv(input_csv)
+
+    required_cols = ["xmin", "ymin", "xmax", "ymax", "image_path"]
+    missing_cols = [col for col in required_cols if col not in df.columns]
+    if missing_cols:
+        raise ValueError(f"Missing required columns: {missing_cols}")
+
+    if device is None:
+        if torch.backends.mps.is_available():
+            device = "mps"
+        elif torch.cuda.is_available():
+            device = "cuda"
+        else:
+            device = "cpu"
+
+    logger.info("Using device: %s", device)
+    logger.info("Loading SAM2 model: %s", model_name)
+    model, processor = load_sam2_model(model_name, device)
+
+    grouped = df.groupby("image_path")
+    total_images = len(grouped)
+
+    all_polygons = []
+
+    if visualize:
+        os.makedirs(viz_output_dir, exist_ok=True)
+
+    for image_path, group in tqdm(grouped, desc="Processing images", total=total_images):
+        polygons = process_image_group(
+            image_path,
+            group,
+            model,
+            processor,
+            device,
+            image_root,
+            box_batch_size,
+            mask_threshold,
+            iou_threshold,
+            viz_output_dir=viz_output_dir if visualize else None,
+        )
+        all_polygons.extend(polygons)
+
+    df["polygon_geometry"] = all_polygons
+
+    os.makedirs(os.path.dirname(output_csv), exist_ok=True)
+    df.to_csv(output_csv, index=False)
+    logger.info("Saved results to %s", output_csv)
+
+
+def main():
+    """CLI entrypoint for polygon conversion."""
+    parser = argparse.ArgumentParser(
+        description="Convert DeepForest bounding boxes to polygons using SAM2"
+    )
+    parser.add_argument("input", help="Path to input CSV with DeepForest predictions")
+    parser.add_argument(
+        "-o",
+        "--output",
+        help="Path to output CSV (default: input with '_polygons' suffix)",
+    )
+    parser.add_argument(
+        "--model",
+        default="facebook/sam2.1-hiera-small",
+        help="SAM2 model name from HuggingFace (default: facebook/sam2.1-hiera-small)",
+    )
+    parser.add_argument(
+        "--box-batch",
+        type=int,
+        default=32,
+        help="Maximum number of boxes to process per forward pass (default: 32)",
+    )
+    parser.add_argument(
+        "--image-root",
+        default="",
+        help="Root directory to prepend to image paths in CSV",
+    )
+    parser.add_argument(
+        "--visualize",
+        action="store_true",
+        help="Create visualization images with polygons overlaid",
+    )
+    parser.add_argument(
+        "--viz-output-dir",
+        default=".",
+        help="Directory to save visualization images (default: current directory)",
+    )
+    parser.add_argument(
+        "--mask-threshold",
+        type=float,
+        default=0.5,
+        help="Threshold for binarizing SAM2 mask outputs (default: 0.5)",
+    )
+    parser.add_argument(
+        "--iou-threshold",
+        type=float,
+        default=0.5,
+        help="Minimum IoU score to accept a polygon (default: 0.5)",
+    )
+    parser.add_argument(
+        "--device",
+        choices=["cuda", "mps", "cpu"],
+        default=None,
+        help="Device to use for inference (default: auto-detect mps > cuda > cpu)",
+    )
+
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    )
+
+    if args.output is None:
+        input_path = Path(args.input)
+        output_path = input_path.parent / f"{input_path.stem}_polygons{input_path.suffix}"
+        args.output = str(output_path)
+
+    convert_boxes_to_polygons(
+        args.input,
+        args.output,
+        model_name=args.model,
+        box_batch_size=args.box_batch,
+        image_root=args.image_root,
+        visualize=args.visualize,
+        viz_output_dir=args.viz_output_dir,
+        mask_threshold=args.mask_threshold,
+        iou_threshold=args.iou_threshold,
+        device=args.device,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/deepforest/scripts/sam.py
+++ b/src/deepforest/scripts/sam.py
@@ -20,7 +20,7 @@ from deepforest.visualize import plot_results
 logger = logging.getLogger(__name__)
 
 
-def load_sam2_model(model_name: str, device: str):
+def load_sam2_model(model_name: str, device: str) -> tuple[Sam2Model, Sam2Processor]:
     """Load SAM2 model and processor from HuggingFace.
 
     Args:
@@ -39,15 +39,15 @@ def load_sam2_model(model_name: str, device: str):
 def process_image_group(
     image_path: str,
     detections: pd.DataFrame,
-    model,
-    processor,
+    model: Sam2Model,
+    processor: Sam2Processor,
     device: str,
     image_root: str = "",
     box_batch_size: int = 32,
     mask_threshold: float = 0.5,
     iou_threshold: float = 0.5,
-    viz_output_dir: str = None,
-) -> list:
+    viz_output_dir: str | None = None,
+) -> list[str]:
     """Process all detections for a single image.
 
     Args:
@@ -149,7 +149,7 @@ def convert_boxes_to_polygons(
     viz_output_dir: str = ".",
     mask_threshold: float = 0.5,
     iou_threshold: float = 0.5,
-    device: str = None,
+    device: str | None = None,
 ) -> None:
     """Convert DeepForest bounding boxes to polygons using SAM2.
 
@@ -214,7 +214,7 @@ def convert_boxes_to_polygons(
     logger.info("Saved results to %s", output_csv)
 
 
-def main():
+def main() -> None:
     """CLI entrypoint for polygon conversion."""
     parser = argparse.ArgumentParser(
         description="Convert DeepForest bounding boxes to polygons using SAM2"

--- a/tests/test_sam.py
+++ b/tests/test_sam.py
@@ -1,0 +1,183 @@
+"""Tests for SAM polygon generation CLI tool."""
+import os
+import subprocess
+import sys
+from importlib.resources import files
+
+import pandas as pd
+from shapely import wkt
+from shapely.geometry import box
+
+from deepforest import get_data
+from deepforest.scripts.sam import (
+    convert_boxes_to_polygons,
+    load_sam2_model,
+    process_image_group,
+)
+
+SAM_SCRIPT = files("deepforest.scripts").joinpath("sam.py")
+
+
+def test_load_sam2_model():
+    """Test SAM2 model sucessfully loads."""
+    from transformers import Sam2Model, Sam2Processor
+
+    model, processor = load_sam2_model("facebook/sam2.1-hiera-small", device="cpu")
+
+    assert isinstance(model, Sam2Model)
+    assert isinstance(processor, Sam2Processor)
+
+
+def test_process_image_group():
+    """Test processing a single image with detections."""
+    test_csv = get_data("OSBS_029.csv")
+    test_image_dir = os.path.dirname(get_data("OSBS_029.tif"))
+
+    df = pd.read_csv(test_csv)
+
+    model, processor = load_sam2_model("facebook/sam2.1-hiera-small", device="cpu")
+
+    polygons = process_image_group(
+        image_path="OSBS_029.tif",
+        detections=df,
+        model=model,
+        processor=processor,
+        device="cpu",
+        image_root=test_image_dir,
+        box_batch_size=2
+    )
+
+    assert len(polygons) == len(df)
+
+    # Verify all are valid WKT strings
+    for poly_wkt in polygons:
+        poly = wkt.loads(poly_wkt)
+        assert poly is not None
+
+
+def test_convert_boxes_to_polygons(tmp_path):
+    """Test the main conversion function directly."""
+    test_csv = get_data("OSBS_029.csv")
+    test_image_dir = os.path.dirname(get_data("OSBS_029.tif"))
+    output_csv = tmp_path / "polygons.csv"
+    viz_dir = tmp_path / "viz"
+
+    input_df = pd.read_csv(test_csv)
+
+    convert_boxes_to_polygons(
+        input_csv=test_csv,
+        output_csv=str(output_csv),
+        image_root=test_image_dir,
+        box_batch_size=2,
+        visualize=True,
+        viz_output_dir=viz_dir
+    )
+
+    assert output_csv.exists()
+
+    result_df = pd.read_csv(output_csv)
+    assert "polygon_geometry" in result_df.columns
+    assert len(result_df) == len(input_df)
+
+    # Validate all polygons are valid WKT
+    for poly_wkt in result_df["polygon_geometry"]:
+        poly = wkt.loads(poly_wkt)
+        assert poly is not None
+
+    assert viz_dir.exists()
+    viz_files = list(viz_dir.glob("*.png"))
+    assert len(viz_files) > 0, "No visualization files were created"
+
+
+def test_polygon_box_overlap():
+    """Test that output polygons overlap with input bounding boxes."""
+    test_csv = get_data("OSBS_029.csv")
+    test_image_dir = os.path.dirname(get_data("OSBS_029.tif"))
+
+    df = pd.read_csv(test_csv)
+
+    model, processor = load_sam2_model("facebook/sam2.1-hiera-small", device="cpu")
+
+    polygons = process_image_group(
+        image_path="OSBS_029.tif",
+        detections=df,
+        model=model,
+        processor=processor,
+        device="cpu",
+        image_root=test_image_dir,
+        box_batch_size=2
+    )
+
+    # Check that each polygon overlaps with its corresponding box
+    for idx, (_, row) in enumerate(df.iterrows()):
+        poly = wkt.loads(polygons[idx])
+
+        # Skip empty polygons
+        if poly.is_empty:
+            continue
+
+        # Create box polygon from detection
+        bbox = box(row["xmin"], row["ymin"], row["xmax"], row["ymax"])
+
+        # Calculate intersection
+        intersection = poly.intersection(bbox)
+
+        # Assert there is overlap
+        assert intersection.area > 0, f"Polygon {idx} has no overlap with its bounding box"
+
+
+def test_sam_cli_end_to_end(tmp_path):
+    """Test complete CLI workflow with visualization."""
+    test_csv = get_data("OSBS_029.csv")
+    test_image_dir = os.path.dirname(get_data("OSBS_029.tif"))
+
+    df = pd.read_csv(test_csv)
+
+    output_csv = tmp_path / "polygons.csv"
+    viz_dir = tmp_path / "viz"
+
+    args = [
+        sys.executable,
+        str(SAM_SCRIPT),
+        test_csv,
+        "-o", str(output_csv),
+        "--image-root", test_image_dir,
+        "--box-batch", "2",
+        "--device", "cpu",
+        "--mask-threshold", "0.5",
+        "--iou-threshold", "0.5",
+        "--visualize",
+        "--viz-output-dir", str(viz_dir)
+    ]
+
+    result = subprocess.run(
+        args,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        timeout=300  # 5 minute timeout for model loading
+    )
+
+    assert result.returncode == 0, f"stderr:\n{result.stderr}\nstdout:\n{result.stdout}"
+    assert output_csv.exists(), f"Expected output file not found: {output_csv}"
+
+    # Check output CSV
+    df_out = pd.read_csv(output_csv)
+    assert "polygon_geometry" in df_out.columns
+    assert len(df_out) == len(df)
+
+    # Verify polygons are valid WKT
+    valid_polygons = 0
+    for poly_wkt in df_out["polygon_geometry"]:
+        poly = wkt.loads(poly_wkt)
+        assert poly is not None
+        if not poly.is_empty:
+            valid_polygons += 1
+
+    # At least one polygon should be non-empty
+    assert valid_polygons > 0, "All polygons are empty"
+
+    # Check visualization created
+    assert viz_dir.exists()
+    viz_files = list(viz_dir.glob("*.png"))
+    assert len(viz_files) > 0, "No visualization files were created"

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -652,3 +652,13 @@ def test_format_geometry_polygon():
     # Format geometry should raise ValueError since polygon predictions are not supported
     with pytest.raises(ValueError, match="Polygon predictions are not yet supported for formatting"):
         utilities.format_geometry(prediction, geom_type="polygon")
+
+def test_empty_mask_to_poly():
+    """Test handling of empty masks."""
+
+    empty_mask = np.zeros((100, 100), dtype=np.uint8)
+
+    polygon = utilities.mask_to_polygon(empty_mask)
+
+    assert isinstance(polygon, shapely.geometry.Polygon)
+    assert polygon.is_empty


### PR DESCRIPTION
Implements https://github.com/weecology/DeepForest/issues/460

I've added this as a standalone script that processes prediction outputs, rather than integrated into the pipeline. Uses box prompts rather than points, but we can experiment with other strategies. I played with an option that uses OAM-TCD masks as a refinement step which worked pretty well, but needs more experimentation to see if it's actually worth doing.

Takes a few seconds per 1024 image on my laptop which I think is pretty decent. I haven't tested on an NVIDIA GPU.

I haven't done/added any evaluation beyond unit tests. Will write docs once we agree on where the best place to put this is.

Some results from LIDAR labels:

<img width="1785" height="1785" alt="2019_BLAN_3_751000_4330000_image_tile_70_polygons" src="https://github.com/user-attachments/assets/c0243c0e-b95b-41bd-90ff-111806c5f715" />

<img width="1785" height="1785" alt="2019_BLAN_3_751000_4330000_image_tile_14_polygons" src="https://github.com/user-attachments/assets/ce836528-13ab-4522-a297-8df54422516d" />

Works fine for isolated trees and _somewhat_ well for trees in groups. Here is an output from the script which uses the built-in polygon viz:

<img width="400" height="400" alt="OSBS_029_polygons" src="https://github.com/user-attachments/assets/a7e1e4ff-ae1f-41d8-a606-c737249a8957" />
