### PR TITLE
improve error handling for image loading

### DIFF
--- a/src/deepforest/__init__.py
+++ b/src/deepforest/__init__.py
@@ -15,8 +15,10 @@ _ROOT = os.path.abspath(os.path.dirname(__file__))
 disable_possible_user_warnings()
 
 
-def get_data(path):
+def get_data(path: str):
     """Get package sample data path.
+
+    Intended for locating files packaged with DeepForest, like test data. DeepForest functions normally accept a relative or absolute path directly.
 
     Args:
         path: Data file name
@@ -25,9 +27,16 @@ def get_data(path):
         Full path to data file
     """
     if path == "config.yaml":
-        return os.path.join(_ROOT, "conf", "config.yaml")
+        rel_path = os.path.join(_ROOT, "conf", "config.yaml")
     else:
-        return os.path.join(_ROOT, "data", path)
+        rel_path = os.path.join(_ROOT, "data", path)
+
+    if os.path.exists(rel_path):
+        return rel_path
+    else:
+        raise FileNotFoundError(
+            "The file {rel_path} was not found relative to the DeepForest package. Note: this function should only be used for accessing test/demonstration data packaged with DeepForest, instead you can pass a path directly to most DeepForest functions."
+        )
 
 
 __all__ = ["__version__"]

--- a/src/deepforest/datasets/prediction.py
+++ b/src/deepforest/datasets/prediction.py
@@ -1,6 +1,8 @@
 import os
 
+import cv2
 import numpy as np
+import numpy.typing as npt
 import pandas as pd
 import rasterio as rio
 import slidingwindow
@@ -50,33 +52,45 @@ class PredictionDataset(Dataset):
         self.size = size
         self.items = self.prepare_items()
 
-    def _load_and_preprocess_image(self, image_path, image=None, size=None):
-        """Load and preprocess an image.
+    def _load_and_preprocess_image(
+        self,
+        image_path: str | None = None,
+        image: Image.Image | None = None,
+        size: int | None = None,
+    ):
+        """Load and preprocess an image. Either an image path or PIL image must
+        be provided.
 
-        Datasets should load using PIL and transpose the image to (C, H,
-        W) before main.model.forward() is called.
+        Datasets should load using PIL and transpose the image to
+        (C, H, W) before main.model.forward() is called.
+
+        Args:
+            image_path: (str) path to image, optional
+            image: (PIL image), optional
+            size: (int) output size
+
+        Returns:
+            CHW float32 numpy array, normalized to be in [0, 1]
         """
         if image is None:
             image = Image.open(image_path)
-        else:
-            image = image
-        image = np.array(image)
-        if not image.shape[2] == 3:
+
+        if image.mode != "RGB":
             raise ValueError(
-                f"Only three band raster are accepted. Input tile has shape {image.shape}. "
-                "Check for transparent alpha channel and remove if present"
+                f"Expected 8-bit 3-channel RGB, got {image.mode}, {len(image.getbands())} channels and size: {image.size}."
+                "Check for transparent alpha channel and remove if present."
             )
 
+        image = np.array(image)
         image = np.transpose(image, (2, 0, 1))
-        image = self.preprocess_crop(image, size)
+        image = self.preprocess_image(image, size)
 
         return image
 
-    def preprocess_crop(self, image, size=None):
+    def preprocess_image(self, image: npt.NDArray, size=None):
         """Preprocess a crop to a float32 tensor between 0 and 1."""
-        image = np.array(image)
-        image = image / 255.0
         image = image.astype(np.float32)
+        image /= 255.0
 
         if size is not None:
             image = self.resize_image(image, size)
@@ -84,9 +98,8 @@ class PredictionDataset(Dataset):
         return image
 
     def resize_image(self, image, size):
-        """Resize an image to a new size."""
-        image = np.resize(image, (image.shape[0], size, size))
-        return image
+        """Resize an image to a new (square) size."""
+        return cv2.resize(image, dsize=(size, size))
 
     def prepare_items(self):
         """Prepare the items for the dataset.

--- a/src/deepforest/visualize.py
+++ b/src/deepforest/visualize.py
@@ -59,6 +59,8 @@ def _load_image(
         elif root_dir is None:
             raise ValueError(
                 "Neither root_dir nor a dataframe with the root_dir attribute was provided."
+                "This can happen if your dataframe contains predictions that aren't associated with a file."
+                "If you called plot_results, try providing an image (array or path) alongside the dataframe."
             )
 
         image_path = os.path.join(root_dir, df.image_path.unique()[0])

--- a/tests/test_datasets_prediction.py
+++ b/tests/test_datasets_prediction.py
@@ -1,6 +1,10 @@
 # test dataset model
 import os
 
+import numpy as np
+from PIL import Image
+import pytest
+
 from deepforest import get_data
 from deepforest.datasets.prediction import TiledRaster, SingleImage, MultiImage, FromCSVFile
 
@@ -26,6 +30,23 @@ def test_SingleImage_path():
 
     for i in range(len(ds)):
         assert ds.get_crop(i).shape == (3, 300, 300)
+
+@pytest.mark.xfail
+def test_invalid_image_dtype():
+    # Not explicitly 8-bit
+    test_data = np.random.random((300,300, 3))
+    SingleImage(image=Image.fromarray(test_data))
+
+@pytest.mark.xfail
+def test_invalid_image_shape():
+    # Not 3 channels
+    test_data = np.random.random((300,300, 5))
+    SingleImage(image=Image.fromarray(test_data))
+
+def test_valid_image():
+    # 8-bit, HWC
+    test_data = np.random.randint(0, 256, (300,300,3)).astype(np.uint8)
+    SingleImage(image=Image.fromarray(test_data))
 
 def test_MultiImage():
     ds = MultiImage(paths=[get_data("OSBS_029.png"), get_data("OSBS_029.png")],

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -21,6 +21,9 @@ def config():
     config = utilities.load_config()
     return config
 
+@pytest.mark.xfail
+def test_nonexistant_data():
+    get_data("does_not_exist.png")
 
 def test_read_pascal_voc():
     annotations = utilities.read_pascal_voc(xml_path=get_data("OSBS_029.xml"))


### PR DESCRIPTION
Fixes some issues raised in #1134:

- `get_data` will raise an informative error if the path it generates doesn't exist + test for this
- `prediction` dataset should catch non-RGB 3-channel images + tests. Also use OpenCV for resize (we could use PIL earlier on?)
- more informative `visualization` error if the image can't be located.