### PR TITLE
constrain transformers to < 4.57 due to DETR loading

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ dependencies = [
     "torch>=2.2.0",
     "torchvision>=0.17.0",
     "tqdm",
-    "transformers",
+    "transformers<4.57.0",
     "xmltodict",
 ]
 


### PR DESCRIPTION
As description, only difference we can identify in failing CI is a recent `transformers` release. We were running 4.56.2 and the 4.57.0 release breaks DETR tests for some reason. I am unable to replicate on OS X.

If this passes, we should probably merge it for now until we figure out if there's some additional work we need to do to maintain compatibility with > 4.57.