### PR TITLE
move preprocess to the crop level to avoid memory usage

### DIFF
--- a/src/deepforest/datasets/prediction.py
+++ b/src/deepforest/datasets/prediction.py
@@ -247,6 +247,8 @@ class SingleImage(PredictionDataset):
     def get_crop(self, idx):
         crop = self.image[self.windows[idx].indices()]
         crop = self.preprocess_image(crop)
+        if crop.shape[0] != 3:
+            crop = np.transpose(crop, (1, 2, 0))
 
         return crop
 


### PR DESCRIPTION
I have checked each of the dataloaders, only in SingleImage were we loading the entire tile and processing. Its unavoidable in MultiImage, since the entire image is going into the GPU, there are no crops. In all others, we were already preprocessing on the crop level. 

We were testing this example and found this to be a much better strategy for memory usage with a 8GB array.

```
from deepforest import main
from deepforest.utilities import image_to_geo_coordinates

import PIL.Image

PIL.Image.MAX_IMAGE_PIXELS = 3000145511

tile_path = "/blue/ewhite/everglades/projected_mosaics/2022/Joule/Joule_02_11_2022_projected.tif"
model = main.deepforest()
model.load_model("weecology/deepforest-bird")

boxes = model.predict_tile(path=tile_path, patch_overlap=0, patch_size=1500)
print(boxes.head())
```

I also took the chance to clarify the docstring in MultiImage.
