### PR TITLE
Transform bounding box coordinate columns along with geometry

### DIFF
--- a/src/deepforest/utilities.py
+++ b/src/deepforest/utilities.py
@@ -783,6 +783,15 @@ def image_to_geo_coordinates(gdf, root_dir=None, flip_y_axis=False):
             projected_geometry.append(geom)
 
     transformed_gdf.geometry = projected_geometry
+
+    # Update xmin, xmax, ymin, ymax columns to match transformed geometry
+    if geom_type == "box":
+        bounds = transformed_gdf.geometry.bounds
+        transformed_gdf["xmin"] = bounds.minx
+        transformed_gdf["xmax"] = bounds.maxx
+        transformed_gdf["ymin"] = bounds.miny
+        transformed_gdf["ymax"] = bounds.maxy
+
     if flip_y_axis:
         # Numpy uses top-left origin, flip y-axis for QGIS compatibility
         # See GIS StackExchange for details on negative y-spacing

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -402,6 +402,13 @@ def test_image_to_geo_coordinates(tmpdir):
     # show(src, ax=ax)
     # plt.show()
 
+    # Check that geo coordiates are also reflected in box coordinate columns
+    bounds = geo_coords.geometry.bounds
+    assert (geo_coords["xmin"] == bounds.minx).all()
+    assert (geo_coords["xmax"] == bounds.maxx).all()
+    assert (geo_coords["ymin"] == bounds.miny).all()
+    assert (geo_coords["ymax"] == bounds.maxy).all()
+
 
 def test_image_to_geo_coordinates_boxes(tmpdir):
     annotations = get_data("2018_SJER_3_252000_4107000_image_477.csv")


### PR DESCRIPTION
`predict_tile()` returns bounding box data in two formats:

1. a geometry column in the gdf
2. bounding box position columns (xmin, xmax, ymin, ymax)

`image_to_geo_coordinates()` correctly updates the geometry, but the bounding box position columns aren't touched leaving them in image coordinates. This change extracts these position columns from the geometry after transformation so that the two versions of the position data are consistent.

Fixes #1193 