### PR TITLE
Add tests for point annotations split_raster

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Project Overview
 
-DeepForest is a Python library for object detection in aerial images, primarily trees, but also supporting models for livestock and other objects of interest. It uses pytorch throughout and the Lightning framework for model training, prediction and evaluation.
+DeepForest is a Python library for object detection in aerial images for biodiversity applications such as tree detection and wildlife observation. It uses pytorch and Pytorch Lightning framework for model training, prediction and evaluation.
 
 Imagery is of a relatively high resolution and is generally not satellite data.
 
@@ -8,7 +8,7 @@ Imagery is of a relatively high resolution and is generally not satellite data.
 
 - We use `uv` for package management
 - NEVER edit dependencies in pyproject.toml directly, ALWAYS use `uv add`
-- To set up, use `uv sync --all-extras --dev`. You can reference the CI workflow in .github
+- To set up and run tests, use `uv sync --all-extras --dev`. You can reference the CI workflow in .github
 - Use the `deepforest` command line interface with Hydra overrides for simple tests
 - When you've finished, run `uv run pre-commit` with appropriate arguments to run formatting and linters on your work.
 

--- a/src/deepforest/preprocess.py
+++ b/src/deepforest/preprocess.py
@@ -84,9 +84,18 @@ def select_annotations(annotations, window):
     if clipped_annotations.empty:
         return clipped_annotations
 
-    # For points, keep all annotations.
+    # For points, keep all annotations but translate to window origin
     if selected_annotations.iloc[0].geometry.geom_type == "Point":
-        return selected_annotations
+        if clipped_annotations.empty:
+            return clipped_annotations
+        # Translate point coordinates to be relative to the top-left of the window
+        clipped_annotations.geometry = clipped_annotations.geometry.translate(
+            xoff=-window_xmin, yoff=-window_ymin
+        )
+        # Update convenience x/y columns if they exist or create them
+        clipped_annotations["x"] = clipped_annotations.geometry.x
+        clipped_annotations["y"] = clipped_annotations.geometry.y
+        return clipped_annotations
 
     else:
         # Keep clipped boxes if they're more than 50% of original size

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,13 +1,14 @@
 ## Testing
 
-- Tests will be run via pytest
-- Keep tests short and focused, with a clear contract
-- You can find data for testing in src/deepforest/data. Prefer to use existing files with utilities.get_data over generating data at test time.
-- Do not use print statements in tests, document failure with assertions
-- Use fixtures for repeated code sections, with appropriate scoping
-- Run models instead of mocking them. Use existing fixtures if suitable and set config options to be more efficient if necessary (such as fast_dev_run, low numbers of epochs)
-- Tests should check for behaviour, not duplicate logic from the library
-- Avoid excessive testing for initialization
+- When proposing code changes that require new tests:
+  - First add the minimal failing test(s) that reproduce the issue or specify the expected new behavior.
+  - Run those specific tests and show their failing output (red) before suggesting or implementing a fix.
+  - After implementing the fix, re-run the same tests and show they pass (green).
+- Keep tests short and focused, with a clear contract.
+- Prefer using existing data via `deepforest.get_data(...)` over generating new data at runtime.
+- Do not use print statements in tests; document failure with assertions.
+- Use fixtures for repeated setup; keep scope appropriate.
+- Test behavior, not implementation details.
 
 ## Running tests
 


### PR DESCRIPTION
This PR was motivated by testing in MillionTrees where I noticed that when using a point geometry, preprocess.split_raster was not re-normalizing the annotations to the tiled output, making them offset. I added a test, which failed, and then a fix, which passed. 

I also played with adding to agents.md to make it clear that when interacting with cursor we expect it to run and show failing tests before it just goes makes a solution. Its quite annoying to revert part of the automation to show it failed beforehand and then was fixed.

I think when we work on the polygon model, this function might need to be refactored into tile_raster -> determine geometry -> select_*_annotations for points, boxes and polygons, but I think we should leave that to another time since we don't quite yet have polygons ready. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Translate point annotations to patch-local coordinates during tiling and add a focused test plus testing guidelines doc.
> 
> - **Preprocessing**:
>   - Update `select_annotations` in `src/deepforest/preprocess.py` for point geometry:
>     - Translate `Point` annotations to window-origin coordinates.
>     - Populate/refresh `x` and `y` columns from translated geometry.
> - **Tests**:
>   - Add `test_split_raster_points_translate_and_bounds` in `tests/test_preprocess.py` to verify point translation, count preservation, and in-window bounds when `patch_overlap=0`.
> - **Docs**:
>   - Add `tests/AGENTS.md` with concise testing and `uv`-based test-running guidelines.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c970f2152d023bb1c85f3a06b6e24edd7df868ad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->