### PR TITLE
Better support for composable configs

### DIFF
--- a/src/deepforest/conf/schema.py
+++ b/src/deepforest/conf/schema.py
@@ -1,7 +1,5 @@
 from dataclasses import dataclass, field
 
-from omegaconf import MISSING
-
 
 @dataclass
 class ModelConfig:
@@ -60,8 +58,8 @@ class TrainConfig:
     sanity checking.
     """
 
-    csv_file: str | None = MISSING
-    root_dir: str | None = MISSING
+    csv_file: str | None = None
+    root_dir: str | None = None
     lr: float = 0.001
     scheduler: SchedulerConfig = field(default_factory=SchedulerConfig)
     epochs: int = 1
@@ -79,8 +77,8 @@ class ValidationConfig:
     converged or is overfitting.
     """
 
-    csv_file: str | None = MISSING
-    root_dir: str | None = MISSING
+    csv_file: str | None = None
+    root_dir: str | None = None
     preload_images: bool = False
     size: int | None = None
     iou_threshold: float = 0.4
@@ -140,12 +138,12 @@ class Config:
     model: ModelConfig = field(default_factory=ModelConfig)
 
     # Preprocessing
-    path_to_raster: str | None = MISSING
+    path_to_raster: str | None = None
     patch_size: int = 400
     patch_overlap: float = 0.05
-    annotations_xml: str | None = MISSING
-    rgb_dir: str | None = MISSING
-    path_to_rgb: str | None = MISSING
+    annotations_xml: str | None = None
+    rgb_dir: str | None = None
+    path_to_rgb: str | None = None
 
     train: TrainConfig = field(default_factory=TrainConfig)
     validation: ValidationConfig = field(default_factory=ValidationConfig)

--- a/src/deepforest/main.py
+++ b/src/deepforest/main.py
@@ -29,7 +29,7 @@ class deepforest(pl.LightningModule):
         model: DeepForest model object
         existing_train_dataloader: PyTorch dataloader for training data
         existing_val_dataloader: PyTorch dataloader for validation data
-        config: DeepForest configuration object
+        config: DeepForest configuration object or name
         config_args: Dictionary of config overrides
     """
 
@@ -39,14 +39,16 @@ class deepforest(pl.LightningModule):
         transforms=None,
         existing_train_dataloader=None,
         existing_val_dataloader=None,
-        config: DictConfig = None,
+        config: str | DictConfig | None = None,
         config_args: dict | None = None,
     ):
         super().__init__()
 
-        # If not provided, load default config via OmegaConf.
         if config is None:
             config = utilities.load_config(overrides=config_args)
+        # Default/string config name
+        elif isinstance(config, str):
+            config = utilities.load_config(config_name=config, overrides=config_args)
         # Hub overrides
         elif "config_args" in config:
             config = utilities.load_config(overrides=config["config_args"])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,9 @@
 from omegaconf import OmegaConf
+import os
+import pytest
+import yaml
 
-from deepforest import get_data
+from deepforest import main, get_data
 from deepforest.conf import schema
 
 
@@ -15,3 +18,28 @@ def test_default_config_schema():
     config = OmegaConf.merge(base, default_config)
 
     assert isinstance(config, type(base))
+
+def test_config_main_dictconfig():
+    base = OmegaConf.structured(schema.Config)
+    m = main.deepforest(config=base)
+    assert m.config.model.name == "weecology/deepforest-tree"
+
+def test_config_main_empty_config():
+    m = main.deepforest(config=None)
+    assert m.config.model.name == "weecology/deepforest-tree"
+
+def test_custom_config_file(tmpdir):
+    # Verify that we can use a custom config file which overrides the default
+    config = {
+        'label_dict': {
+            'foo': 0
+        }
+    }
+
+    config_path = os.path.join(tmpdir, "custom-config.yaml")
+    with open(config_path, 'w') as fp:
+        yaml.dump(config, fp)
+
+    m = main.deepforest(config = config_path)
+    assert 'foo' in m.config.label_dict
+    assert 'Tree' not in m.config.label_dict


### PR DESCRIPTION
This PR adds improved support for loading custom and named configs.

- Single level of inheritance for configs (i.e. derive from defaults/`config`). This was technically supported, but I think was not thoroughly tested.
~~- Add core "named" configs (tree, bird, livestock)~~
~~- main now clearly defaults to `config='tree'`~~
- Users can provide a config path directly to `deepforest.main`
- Removed `MISSING` from the schema as not necessary
~~- Adds a `task` key in preparation for keypoint/polygon modeling~~
- A few more tests.

Notes:

- Using `MISSING` indicates a required field that is likely custom, like a `csv_file`. However, this forces derived config files to set all of those fields. In practice it doesn't make a difference because we have error handling for missing paths.
- We discussed using Hydra throughout, but that gets messy when calling DeepForest from another pipeline that uses it. It's cleaner to keep Hydra purely for the CLI.
- However, Hydra can do more complicated things (like multiple layers of inheritance)
- OmegaConf doesn't actually support inheritance, it's managed by `.merge`. We do this by merging in the following order:
  - base (always)
  - supplied config (optional built-in yaml file or path)
  - overrides (optional)
- Handling label_dict is awkward because of how OmegaConf merges dictionaries, so there is still a hack to make sure that if the class list is updated, it's properly overriden.