### PR TITLE
Add rgb_path argument to read_file

### DIFF
--- a/docs/user_guide/01_Reading_data.md
+++ b/docs/user_guide/01_Reading_data.md
@@ -5,12 +5,25 @@ The most time-consuming part of many open-source projects is getting the data in
 You can also optionally provide:
   - `image_path`: A single image path to assign to all annotations in the input. This is useful when the input contains annotations for only one image.
   - `label`: A single label to apply to all rows. This is helpful when all annotations share the same label (e.g., "Tree").
+  - `rgb_path`: For shapefiles (`.shp`, `.gpkg`) that do not contain an `image_path` column, provide the path to the corresponding RGB image so that coordinate conversion can occur.
 
 Example:
 ```
 from deepforest import utilities
 
 df = utilities.read_file("annotations.csv", image_path="OSBS_029.tif", label="Tree")
+```
+
+For shapefiles that lack an `image_path` column, pass `rgb_path`:
+
+```python
+from deepforest import utilities
+
+gdf = utilities.read_file(
+    input="/path/to/annotations.shp",
+    rgb_path="/path/to/OSBS_029.tif",   # required if no image_path column
+    label="Tree"                        # optional: used if no 'label' column in the shapefile
+)
 ```
 
 **Note:** If your input file contains multiple image filenames and you do not provide the `image_path` argument, a warning may appear:
@@ -138,6 +151,29 @@ from deepforest import utilities
 
 shp = utilities.read_file(input="/path/to/boxes_shapefile.shp")
 shp.head()
+```
+
+If your shapefile does not include an `image_path` column, you must provide the raster path via `rgb_path`:
+
+```python
+from deepforest import utilities
+
+shp = utilities.read_file(
+    input="/path/to/boxes_shapefile.shp",
+    rgb_path="/path/to/OSBS_029.tif"
+)
+```
+
+If your shapefile also lacks a `label` column, you can assign one for all rows:
+
+```python
+from deepforest import utilities
+
+shp = utilities.read_file(
+    input="/path/to/boxes_shapefile.shp",
+    rgb_path="/path/to/OSBS_029.tif",
+    label="Tree"
+)
 ```
 
 Example output:

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -109,6 +109,22 @@ def test_shapefile_to_annotations_convert_unprojected_to_boxes(tmpdir):
     assert shp.shape[0] == 2
 
 
+def test_read_file_shapefile_with_rgb_path(tmpdir):
+    # Create a shapefile with no image_path or label columns
+    sample_geometry = [geometry.Point(10, 20), geometry.Point(20, 40)]
+    df = pd.DataFrame({"geometry": sample_geometry})
+    gdf = gpd.GeoDataFrame(df, geometry="geometry")
+    shp_path = "{}/annotations_no_image_label.shp".format(tmpdir)
+    gdf.to_file(shp_path)
+
+    # Provide rgb_path and label via read_file to fill missing columns
+    rgb = get_data("OSBS_029.png")
+    result = utilities.read_file(input=shp_path, rgb_path=rgb, label="Tree")
+
+    assert result.shape[0] == 2
+    # image_path should be taken from the provided rgb_path
+    assert os.path.basename(rgb) in result.image_path.unique()
+
 def test_shapefile_to_annotations_invalid_epsg(tmpdir):
     sample_geometry = [geometry.Point(404211.9 + 10, 3285102 + 20), geometry.Point(404211.9 + 20, 3285102 + 20)]
     labels = ["Tree", "Tree"]


### PR DESCRIPTION
Instead of needing to manually edit a .shp when reading in annotations to give it a image_path column, we should have an argument that allows this flexibility. 
