### PR TITLE
Fix DETR box coords during target preparation

### DIFF
--- a/src/deepforest/models/DeformableDetr.py
+++ b/src/deepforest/models/DeformableDetr.py
@@ -85,13 +85,18 @@ class DeformableDetrWrapper(nn.Module):
                 if isinstance(label, torch.Tensor):
                     label = label.item()
 
+                # Convert from [xmin, ymin, xmax, ymax] to COCO format [x, y, width, height]
+                xmin, ymin, xmax, ymax = box
+                coco_bbox = [xmin, ymin, xmax - xmin, ymax - ymin]
+                area = (xmax - xmin) * (ymax - ymin)
+
                 annotations_for_target.append(
                     {
                         "id": i,
                         "image_id": i,
                         "category_id": label,
-                        "bbox": box,
-                        "area": (box[3] - box[1]) * (box[2] - box[0]),
+                        "bbox": coco_bbox,
+                        "area": area,
                         "iscrowd": 0,
                     }
                 )


### PR DESCRIPTION
Fixes a small (but important) bug in DETR target preparation. The transformers implementation requires COCO [format](https://cocodataset.org/#format-data) annotations which are XYWH.

Box corners coming from the dataset were not converted, so training was using XYXY incorrectly. Added a unit test for all target entries (area, etc).