### PR TITLE
Serialize and de-serialize configs as plain containers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     "pandas",
     "pillow>6.2.0",
     "psutil",
-    "pytorch-lightning>=2.1.0,<3.0.0",
+    "pytorch-lightning>=2.6.0,<3.0.0",
     "pyyaml>=5.1.0",
     "rasterio",
     "safetensors<0.6.0",

--- a/src/deepforest/conf/schema.py
+++ b/src/deepforest/conf/schema.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass, field
 
+from omegaconf import DictConfig, OmegaConf
+
 
 @dataclass
 class ModelConfig:
@@ -131,7 +133,7 @@ class Config:
 
     architecture: str = "retinanet"
     num_classes: int = 1
-    label_dict: dict[str, int] = field(default_factory=lambda: {"Tree": 0})
+    label_dict: DictConfig = field(default_factory=lambda: OmegaConf.create({"Tree": 0}))
 
     nms_thresh: float = 0.05
     score_thresh: float = 0.1

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,10 +1,12 @@
 from omegaconf import OmegaConf
 import os
 import pytest
+import torch
 import yaml
 
-from deepforest import main, get_data
+from deepforest import main, get_data, utilities
 from deepforest.conf import schema
+from deepforest.model import CropModel
 
 
 # Test that the default configuration can be correctly loaded into the schema template.
@@ -43,3 +45,74 @@ def test_custom_config_file(tmpdir):
     m = main.deepforest(config = config_path)
     assert 'foo' in m.config.label_dict
     assert 'Tree' not in m.config.label_dict
+
+
+def test_load_config_missing_field(m, tmpdir):
+    """Test that checkpoints load successfully when they're
+    missing fields added to the schema
+    """
+    # Calling fit/predict etc. is required before save_model
+    m.predict_tile(get_data("SOAP_061.png"))
+    checkpoint_path = tmpdir / "checkpoint.pl"
+    m.save_model(checkpoint_path)
+
+    # Load the checkpoint and remove "batch size"
+    checkpoint = torch.load(checkpoint_path)
+    saved_config = checkpoint['hyper_parameters']['config']
+    del saved_config['batch_size']
+    torch.save(checkpoint, checkpoint_path)
+
+    # Load the checkpoint
+    loaded = main.deepforest.load_from_checkpoint(checkpoint_path)
+    assert isinstance(loaded.config.batch_size, int)
+
+def test_config_additional_field(m, tmpdir):
+    """Test that checkpoints with extra fields not in schema still load successfully,
+    such as added config items in newer versions of DeepForest.
+    """
+    m.predict_tile(get_data("SOAP_061.png"))
+    checkpoint_path = tmpdir / "checkpoint.pl"
+    m.save_model(checkpoint_path)
+
+    # Load the checkpoint and add a field not in the current schema
+    checkpoint = torch.load(checkpoint_path)
+    saved_config = checkpoint['hyper_parameters']['config']
+    saved_config['new_flag'] = 'test_value'
+    torch.save(checkpoint, checkpoint_path)
+
+    # Load the checkpoint
+    loaded = main.deepforest.load_from_checkpoint(checkpoint_path)
+    assert loaded.config.new_flag == 'test_value'
+
+def test_strict_mode_rejects_unknown_fields():
+    """Test that strict mode rejects configs with unknown fields."""
+    from omegaconf import errors as omegaconf_errors
+
+    # Try to load a config with an unknown field in strict mode
+    config_with_unknown_field = {"unknown_field": "value"}
+
+    with pytest.raises(omegaconf_errors.ConfigKeyError):
+        utilities.load_config(overrides=config_with_unknown_field, strict=True)
+
+def test_load_checkpoint_with_dictconfig(m, tmpdir):
+    """Test that we can load an older checkpoint with a DictConfig in it.
+    """
+    m.predict_tile(get_data("SOAP_061.png"))
+    checkpoint_path = tmpdir / "checkpoint.pl"
+    m.save_model(checkpoint_path)
+
+    # Load the checkpoint and replace the config dict with a DictConfig
+    checkpoint = torch.load(checkpoint_path, weights_only=False)
+    saved_config = checkpoint['hyper_parameters']['config']
+    checkpoint['hyper_parameters']['config'] = OmegaConf.create(saved_config)
+    torch.save(checkpoint, checkpoint_path)
+
+    # Load the checkpoint with "unsafe" weights_only
+    loaded = main.deepforest.load_from_checkpoint(checkpoint_path, weights_only=False)
+    assert loaded.config == m.config
+
+    # Check if we save + reload, this gets fixed.
+    loaded.predict_tile(get_data("SOAP_061.png"))
+    loaded.save_model(checkpoint_path)
+    fixed = main.deepforest.load_from_checkpoint(checkpoint_path)
+    assert fixed.config == m.config


### PR DESCRIPTION
Fixes https://github.com/weecology/DeepForest/issues/1217 and https://github.com/weecology/DeepForest/issues/1219

- With recent changes to Pytorch and Lightning, model loading is stricter
- When you call `save_checkpoint` on a DeepForest instance and reload it, the stored arguments to the constructor are used.
- We save the config in the hyperparameters, but apparently there is no auto-conversion between DictConfig and dict. This worked before because pickle would load OmegaConf upon deserializing the checkpoint, and this behaviour is now considered unsafe.

Changes:

- `main`: converts the config to Plain Old Data, and adds an additional check during `on_save_checkpoint` to catch other fields that may have been modified since the instance was created.
- `main`: allow passing a `dict` to DeepForest. This gets loaded as an 'override' because currently `load_config` can't handle this directly. Doing it this way rather than blindly accepting what the user passes in allows us to take advantage of type checking via schema. I would prefer that `load_config` is the one source of truth for config parsing.
- `label_dict` is still a bit special because of how OmegaConf handles dictionaries in configs; each class is its own "key" so we handle it separately.
- `utilities`: some tweaks to `load_config` to be more explicit about what strict mode does, but no functional change.
- `test_config`: two additional tests for (1) configs with a missing parameter, for example back-compatibility with older checkpoints and (2) configs with an additional parameter, which can happen if something gets moved. Also tests the load/save/load fix below.

Strategy for older models:

`load_checkpoint` with `weights_only=False`, run train/evaluate/predict (a lightning requirement) and then re-save the checkpoint.

Tested with:

```python
uv lock --upgrade
uv run pytest tests -k checkpoint
```

Followup:

- Better documentation for the pathways users can take to save/load models
- Double check CropModel is also fine with these changes? Tests pass for now
- Move the config loading code to `utilities` in its entirety rather than having partial logic sitting in main?