### PR TITLE
Disable build failures caused by Codecov patch coverage diffs, but re…

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,3 +4,6 @@ coverage:
       default:
         target: 85%
         threshold: 2%
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
…port the results

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Makes Codecov patch coverage checks non-blocking while keeping existing project coverage settings.
> 
> - Updates `codecov.yml` to set `coverage.status.patch.default.informational: true`
> - Retains project coverage target (`85%`) and threshold (`2%`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d013d7c0390e21d27e6515c5045295f38a9afd7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->