### PR TITLE
Allow user to expand cropmodel boxes for predict_tile

### DIFF
--- a/src/deepforest/conf/config.yaml
+++ b/src/deepforest/conf/config.yaml
@@ -113,3 +113,5 @@ cropmodel:
     resize:
         - 224
         - 224
+    # Number of pixels to expand bbox crop windows for better prediction context.
+    expand: 0

--- a/src/deepforest/conf/schema.py
+++ b/src/deepforest/conf/schema.py
@@ -107,6 +107,7 @@ class CropModelConfig:
     scheduler: SchedulerConfig = field(default_factory=SchedulerConfig)
     balance_classes: bool = False
     resize: list[int] = field(default_factory=lambda: [224, 224])
+    expand: int = 0
 
 
 @dataclass

--- a/src/deepforest/datasets/cropmodel.py
+++ b/src/deepforest/datasets/cropmodel.py
@@ -49,12 +49,23 @@ class BoundingBoxDataset(Dataset):
         transform: Optional transform function
         augmentations: Augmentation configuration
         resize: Optional list of [height, width] for resizing. Defaults to [224, 224]
+        expand: expand: number of context pixels to add to input bounding boxes
+
+    Note: Use the expand option to sample a larger area around the source bounding box. This may improve classification accuracy by providing the model with increased context. The sampling window is increased by `expand` pixels on all sides and then clamped to the image bounds.
 
     Returns:
         Tensor of shape (3, height, width)
     """
 
-    def __init__(self, df, root_dir, transform=None, augmentations=None, resize=None):
+    def __init__(
+        self,
+        df,
+        root_dir,
+        transform=None,
+        augmentations=None,
+        resize=None,
+        expand: int = 0,
+    ):
         self.df = df
 
         if transform is None:
@@ -64,6 +75,11 @@ class BoundingBoxDataset(Dataset):
         else:
             self.transform = transform
 
+        # Check that expand is non-negative
+        if expand < 0:
+            raise ValueError("expand must be >= 0")
+        self.expand = int(expand)
+
         unique_image = self.df["image_path"].unique()
         assert len(unique_image) == 1, (
             "There should be only one unique image for this class object"
@@ -71,6 +87,8 @@ class BoundingBoxDataset(Dataset):
 
         # Open the image using rasterio
         self.src = rio.open(os.path.join(root_dir, unique_image[0]))
+        self._image_width = self.src.width
+        self._image_height = self.src.height
 
     def __len__(self):
         """Return number of samples."""
@@ -86,13 +104,24 @@ class BoundingBoxDataset(Dataset):
             Transformed image tensor
         """
         row = self.df.iloc[idx]
-        xmin = row["xmin"]
-        xmax = row["xmax"]
-        ymin = row["ymin"]
-        ymax = row["ymax"]
+        xmin = float(row["xmin"])
+        xmax = float(row["xmax"])
+        ymin = float(row["ymin"])
+        ymax = float(row["ymax"])
+
+        # Expand the box equally on all sides by self.expand pixels (context window)
+        if self.expand > 0:
+            xmin = max(0, xmin - self.expand)
+            ymin = max(0, ymin - self.expand)
+            xmax = min(self._image_width, xmax + self.expand)
+            ymax = min(self._image_height, ymax + self.expand)
 
         # Read the RGB data
-        box = self.src.read(window=Window(xmin, ymin, xmax - xmin, ymax - ymin))
+        col_off = int(xmin)
+        row_off = int(ymin)
+        width = int(max(1, xmax - xmin))
+        height = int(max(1, ymax - ymin))
+        box = self.src.read(window=Window(col_off, row_off, width, height))
         box = np.rollaxis(box, 0, 3)
 
         if self.transform:

--- a/src/deepforest/predict.py
+++ b/src/deepforest/predict.py
@@ -269,8 +269,10 @@ def _predict_crop_model_(
 
     # Get resize dimensions from crop_model config if not using custom transform
     resize = None
+    expand = 0
     if transform is None and hasattr(crop_model, "config"):
         resize = crop_model.config.get("cropmodel", {}).get("resize", [224, 224])
+        expand = crop_model.config.get("cropmodel", {}).get("expand", 0)
 
     # Create dataset
     bounding_box_dataset = cropmodel.BoundingBoxDataset(
@@ -279,6 +281,7 @@ def _predict_crop_model_(
         transform=transform,
         augmentations=augmentations,
         resize=resize,
+        expand=expand,
     )
 
     # Create dataloader

--- a/tests/test_datasets_cropmodel.py
+++ b/tests/test_datasets_cropmodel.py
@@ -1,6 +1,7 @@
 import os
 
 import pandas as pd
+from PIL import Image
 
 from deepforest import get_data
 from deepforest.datasets.cropmodel import BoundingBoxDataset
@@ -21,3 +22,68 @@ def test_bounding_box_dataset():
 
     # Check the shape of the RGB tensor
     assert item.shape == (3, 224, 224)
+
+
+def test_bounding_box_dataset_expand_increases_window():
+    # Load annotations and corresponding image
+    df = pd.read_csv(get_data("OSBS_029.csv"))
+    img_path = get_data("OSBS_029.png")
+    root_dir = os.path.dirname(img_path)
+
+    # Read image size
+    width, height = Image.open(img_path).size
+
+    # Select a box well inside the image to avoid clipping during expansion
+    margin = 30
+    safe = df[
+        (df["xmin"] > margin)
+        & (df["ymin"] > margin)
+        & (df["xmax"] < (width - margin))
+        & (df["ymax"] < (height - margin))
+    ]
+    # Use a single-row dataframe for deterministic comparison
+    row = safe.iloc[0:1].copy()
+
+    # Use a no-op transform so we can compare raw window sizes directly (H, W, 3)
+    noop = lambda x: x
+    ds_no_expand = BoundingBoxDataset(row, root_dir=root_dir, transform=noop, expand=0)
+    ds_expand_10 = BoundingBoxDataset(row, root_dir=root_dir, transform=noop, expand=10)
+
+    crop_no_expand = ds_no_expand[0]
+    crop_expand_10 = ds_expand_10[0]
+
+    # Expansion adds 10 pixels to each side -> +20 px in both height and width
+    assert crop_expand_10.shape[0] == crop_no_expand.shape[0] + 20
+    assert crop_expand_10.shape[1] == crop_no_expand.shape[1] + 20
+
+def test_bounding_box_dataset_expand_clips_at_image_bounds():
+    # Load annotations and corresponding image
+    df = pd.read_csv(get_data("OSBS_029.csv"))
+    img_path = get_data("OSBS_029.png")
+    root_dir = os.path.dirname(img_path)
+
+    # Read image size
+    width, height = Image.open(img_path).size
+
+    # Build a single-row dataframe with a box near the bottom-right corner
+    # so that expanding by 10px would exceed the image bounds (and thus must clip)
+    row = df.iloc[0:1].copy()
+    box_w, box_h = 20, 20
+    row.loc[row.index[0], "xmax"] = width - 2
+    row.loc[row.index[0], "ymax"] = height - 2
+    row.loc[row.index[0], "xmin"] = max(0, width - 2 - box_w)
+    row.loc[row.index[0], "ymin"] = max(0, height - 2 - box_h)
+
+    # Use a no-op transform to compare raw window sizes (H, W, 3)
+    noop = lambda x: x
+    ds_no_expand = BoundingBoxDataset(row, root_dir=root_dir, transform=noop, expand=0)
+    ds_expand_10 = BoundingBoxDataset(row, root_dir=root_dir, transform=noop, expand=10)
+
+    crop_no_expand = ds_no_expand[0]
+    crop_expand_10 = ds_expand_10[0]
+
+    # Expansion should increase size but be clipped at image bounds (< 20px increase)
+    dh = crop_expand_10.shape[0] - crop_no_expand.shape[0]
+    dw = crop_expand_10.shape[1] - crop_no_expand.shape[1]
+    assert dh > 0 and dw > 0
+    assert dh < 20 and dw < 20


### PR DESCRIPTION
While working on the BOEM pipeline I noticed a strong performance difference between how annotators make detections and the deepforest detection models, leading to weaker cropmodel classification performance. This PR allows the user to specify in config to expand the detection both by x pixels on all sides to capture a wider extent. 

Agent statement: I conceived of the change and wrote the initial function. Cursor wrote the test which I then showed failed and that my fix improved. Cursor added the edge cases that the bounding box expansion goes off the side of the image. 