### PR TITLE
Unpin transformers for v5.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ dependencies = [
     "torch>=2.2.0",
     "torchvision>=0.17.0",
     "tqdm",
-    "transformers<4.57.0",
+    "transformers",
     "xmltodict",
 ]
 


### PR DESCRIPTION
Checked if upstream fixes allow training DETR or if the CI is still breaking. Cause seems to be garbage weight initialisation by transformers, which caused extreme gradients that failed from-scratch training (nan boxes in output). This would then fail the low level tests in the CI, but shouldn't affect using pre-trained weights.

This seems to be fixed and released now, and the CI is pulling 5.0.0. This only affected a narrow use-case and should not matter to most users, so if someone hasn't updated, it shouldn't break other things.

I don't think it's necessary to restrict `transformers` versions in `pyproject` as everything else should work fine with 4.57, but we could include that (e.g. `transformers<4.57, transformers>=5.0.0`)