### PR TITLE
Fix: Handle no-data values in TIF files during prediction

### DIFF
--- a/src/deepforest/datasets/cropmodel.py
+++ b/src/deepforest/datasets/cropmodel.py
@@ -12,6 +12,8 @@ from rasterio.windows import Window
 from torch.utils.data import Dataset
 from torchvision import transforms
 
+from deepforest.utilities import read_raster_window
+
 
 def bounding_box_transform(augmentations=None, resize=None):
     """Create transform pipeline for bounding box data.
@@ -122,6 +124,7 @@ class BoundingBoxDataset(Dataset):
         width = int(max(1, xmax - xmin))
         height = int(max(1, ymax - ymin))
         box = self.src.read(window=Window(col_off, row_off, width, height))
+        box = read_raster_window(box, nodata_value=self.src.nodata)
         box = np.rollaxis(box, 0, 3)
 
         if self.transform:

--- a/src/deepforest/datasets/cropmodel.py
+++ b/src/deepforest/datasets/cropmodel.py
@@ -123,7 +123,10 @@ class BoundingBoxDataset(Dataset):
         row_off = int(ymin)
         width = int(max(1, xmax - xmin))
         height = int(max(1, ymax - ymin))
-        box = apply_nodata_mask(self.src, Window(col_off, row_off, width, height))
+        # Clip window to image bounds to avoid out-of-bounds errors
+        window = Window(col_off, row_off, width, height)
+        window = window.intersection(Window(0, 0, self._image_width, self._image_height))
+        box = apply_nodata_mask(self.src, window)
         box = np.rollaxis(box, 0, 3)
 
         if self.transform:

--- a/src/deepforest/datasets/cropmodel.py
+++ b/src/deepforest/datasets/cropmodel.py
@@ -12,7 +12,7 @@ from rasterio.windows import Window
 from torch.utils.data import Dataset
 from torchvision import transforms
 
-from deepforest.utilities import read_raster_window
+from deepforest.utilities import apply_nodata_mask
 
 
 def bounding_box_transform(augmentations=None, resize=None):
@@ -123,8 +123,7 @@ class BoundingBoxDataset(Dataset):
         row_off = int(ymin)
         width = int(max(1, xmax - xmin))
         height = int(max(1, ymax - ymin))
-        box = self.src.read(window=Window(col_off, row_off, width, height))
-        box = read_raster_window(box, nodata_value=self.src.nodata)
+        box = apply_nodata_mask(self.src, Window(col_off, row_off, width, height))
         box = np.rollaxis(box, 0, 3)
 
         if self.transform:

--- a/src/deepforest/datasets/prediction.py
+++ b/src/deepforest/datasets/prediction.py
@@ -13,7 +13,7 @@ from torch.nn import functional as F
 from torch.utils.data import Dataset, default_collate
 
 from deepforest import preprocess
-from deepforest.utilities import format_geometry
+from deepforest.utilities import format_geometry, read_raster_window
 
 
 # Base prediction class
@@ -491,6 +491,7 @@ class TiledRaster(PredictionDataset):
         window = self.windows[idx]
         with rio.open(self.path) as src:
             window_data = src.read(window=Window(window.x, window.y, window.w, window.h))
+            window_data = read_raster_window(window_data, nodata_value=src.nodata)
 
         # Convert to torch tensor and rearrange dimensions
         window_data = torch.from_numpy(window_data).float()  # Convert to torch tensor

--- a/src/deepforest/datasets/prediction.py
+++ b/src/deepforest/datasets/prediction.py
@@ -13,7 +13,7 @@ from torch.nn import functional as F
 from torch.utils.data import Dataset, default_collate
 
 from deepforest import preprocess
-from deepforest.utilities import format_geometry, read_raster_window
+from deepforest.utilities import apply_nodata_mask, format_geometry
 
 
 # Base prediction class
@@ -490,8 +490,9 @@ class TiledRaster(PredictionDataset):
     def get_crop(self, idx):
         window = self.windows[idx]
         with rio.open(self.path) as src:
-            window_data = src.read(window=Window(window.x, window.y, window.w, window.h))
-            window_data = read_raster_window(window_data, nodata_value=src.nodata)
+            window_data = apply_nodata_mask(
+                src, Window(window.x, window.y, window.w, window.h)
+            )
 
         # Convert to torch tensor and rearrange dimensions
         window_data = torch.from_numpy(window_data).float()  # Convert to torch tensor

--- a/src/deepforest/model.py
+++ b/src/deepforest/model.py
@@ -297,6 +297,7 @@ class CropModel(LightningModule, PyTorchModelHubMixin):
 
                 # Crop the image using the square box coordinates
                 img = src.read(window=((int(ymin), int(ymax)), (int(xmin), int(xmax))))
+                img = utilities.read_raster_window(img, nodata_value=src.nodata)
                 # Save the cropped image as a PNG file using opencv
                 image_basename = os.path.splitext(os.path.basename(image))[0]
                 img_path = os.path.join(savedir, label, f"{image_basename}_{index}.png")

--- a/src/deepforest/model.py
+++ b/src/deepforest/model.py
@@ -296,8 +296,9 @@ class CropModel(LightningModule, PyTorchModelHubMixin):
                 xmin, ymin, xmax, ymax = square_box
 
                 # Crop the image using the square box coordinates
-                img = src.read(window=((int(ymin), int(ymax)), (int(xmin), int(xmax))))
-                img = utilities.read_raster_window(img, nodata_value=src.nodata)
+                img = utilities.apply_nodata_mask(
+                    src, ((int(ymin), int(ymax)), (int(xmin), int(xmax)))
+                )
                 # Save the cropped image as a PNG file using opencv
                 image_basename = os.path.splitext(os.path.basename(image))[0]
                 img_path = os.path.join(savedir, label, f"{image_basename}_{index}.png")

--- a/src/deepforest/utilities.py
+++ b/src/deepforest/utilities.py
@@ -87,8 +87,8 @@ def apply_nodata_mask(src, window):
     """Read raster window and apply no-data value masking.
 
     This function reads a window from a rasterio dataset and masks no-data
-    values to 0, ensuring consistent handling across all DeepForest components.
-    Uses rasterio's built-in dataset mask for efficient masking.
+    values to 0 for more consistent predictions. If no nodata value is set,
+    the data are returned unmodified.
 
     Args:
         src: rasterio.DatasetReader opened in 'r' mode

--- a/src/deepforest/utilities.py
+++ b/src/deepforest/utilities.py
@@ -82,6 +82,28 @@ def load_config(
     return config
 
 
+def read_raster_window(data, nodata_value=None, masked=True):
+    """Apply no-data value masking to raster data.
+
+    This function masks no-data values to 0, ensuring consistent handling
+    across all DeepForest components.
+
+    Args:
+        data: numpy.ndarray with shape (bands, height, width) containing raster data
+        nodata_value: The no-data value to mask. If None, no masking is applied.
+        masked: If True, mask no-data values to 0. Default True.
+
+    Returns:
+        numpy.ndarray: Raster data with shape (bands, height, width). No-data values
+            are set to 0 if masked=True and nodata_value is not None.
+    """
+    if masked and nodata_value is not None:
+        nodata_mask = np.any(data == nodata_value, axis=0)
+        data[:, nodata_mask] = 0
+
+    return data
+
+
 class DownloadProgressBar(tqdm):
     """Download progress bar class."""
 
@@ -587,6 +609,7 @@ def crop_raster(bounds, rgb_path=None, savedir=None, filename=None, driver="GTif
                 left, bottom, right, top, transform=src.transform
             )
         )
+        img = read_raster_window(img, nodata_value=src.nodata)
         cropped_transform = rasterio.windows.transform(
             rasterio.windows.from_bounds(
                 left, bottom, right, top, transform=src.transform


### PR DESCRIPTION
Previously, when reading TIF files with rasterio, no-data values were not masked before normalization. This caused invalid values (e.g., -9999 normalized to -39.2) to be passed to the model, potentially affecting prediction accuracy.

## Description

<!-- Provide a clear and concise description of what this PR does -->

## Related Issue(s)

<!-- Link to related issues using: Closes #123, Fixes #456, Related to #789 -->
<!-- If no issue exists, explain why this change is needed -->


## AI-Assisted Development

<!-- Be transparent about AI tool usage -->

- [x] I used AI tools (e.g., GitHub Copilot, ChatGPT, etc.) in developing this PR
- [x] I understand all the code I'm submitting
- [x] I have reviewed and validated all AI-generated code

**AI tools used (if applicable):**
<!-- List AI tools used, if any -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements consistent no-data handling across raster reads and tightens window bounds to prevent out-of-range access.
> 
> - Adds `utilities.apply_nodata_mask` to read raster windows, clip to bounds, and set no-data pixels to 0 using `dataset_mask`
> - Replaces direct `src.read(...)` with `apply_nodata_mask` in `datasets/cropmodel.py`, `datasets/prediction.py` (TiledRaster), `model.py` (crop writing), and `utilities.crop_raster`
> - Clamps crop windows to image bounds in `BoundingBoxDataset.__getitem__` to avoid out-of-bounds errors
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8df58ebcbec74c1d1dfa2c384fe9c4c479977513. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->