### PR TITLE
Fix broken "good first issues" link in README Developer Guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Get suggestions on how to improve a model by using the [discussion board](https:
 
 If you are a new contributor to DeepForest, welcome and thank you! Here are some suggestions that we hope will make the submission process more smooth:
 
-- Look out for [good first issues](https://github.com/weecology/DeepForest/pulls?q=is%3Aopen+is%3Apr+label%3A%22good+first+issue%22). These should be accessible to less experienced developers and will help you get oriented with the code.
+- Look out for [good first issues](https://github.com/weecology/DeepForest/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22). These should be accessible to less experienced developers and will help you get oriented with the code.
 - Check that the functionality you are suggesting doesn't already exist. Perhaps it does, but needs improved documentation.
 - Search for issues or discussions on Github already, before submitting a PR. Do check closed issues as well.
 - If you are submitting a trivial improvement (like a one-line bug fix), feel free to PR directly, following the template.


### PR DESCRIPTION
## Description

This fixes an incorrect "good first issues" link in the README.md Developer Guidelines section that was pointing to pull requests instead of issues.

**Previous link (broken):**
https://github.com/weecology/DeepForest/pulls?q=is%3Aopen+is%3Apr+label%3A%22good+first+issue%22

The previous link directed to pull requests, which returns no results since "good first issue" is a label applied to issues, not PRs.

**Updated link (fixed):**
https://github.com/weecology/DeepForest/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22

This correctly links to open issues labeled "good first issue" — helping new contributors find beginner-friendly tasks.

**Changes made:**
- `pulls` → `issues`
- `is%3Apr` → `is%3Aissue`

## Related Issue(s)

No related issue — this is a minor documentation fix discovered while reading the README.