### PR TITLE
Test model predictions using predefined expected detection counts

### DIFF
--- a/tests/test_model_prediction.py
+++ b/tests/test_model_prediction.py
@@ -1,0 +1,31 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from deepforest import main
+
+
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        "weecology/deepforest-bird",
+        # "weecology/deepforest-everglades-bird-species-detector",
+        # "weecology/deepforest-tree",
+        # "weecology/deepforest-livestock",
+        # "weecology/cropmodel-deadtrees",
+    ],
+)
+def test_white_image_predict_tile_no_predictions_bird_model(model_name):
+    """All-white image should yield no detections with various models."""
+    m = main.deepforest()
+    m.create_trainer()
+    m.load_model(model_name)
+    # Create a white image (uint8 RGB)
+    white = np.full((2048, 2048, 3), 255, dtype=np.uint8)
+    res = m.predict_tile(
+        image=white,
+        patch_size=128,
+        patch_overlap=0.0,
+        iou_threshold=m.config.nms_thresh,
+    )
+    assert (res is None) or (isinstance(res, pd.DataFrame) and res.empty)


### PR DESCRIPTION
## Description
Add images with known detection counts
For example white images should return o counts for birds and trees.

Since we are trying to reduce the repo size, we shall not add images rather source them from zenodo.

<!-- Provide a clear and concise description of what this PR does -->

## Related Issue(s)

<!-- Link to related issues using: Closes #123, Fixes #456, Related to #789 -->
<!-- If no issue exists, explain why this change is needed -->


## AI-Assisted Development

<!-- Be transparent about AI tool usage -->

- [ ] I used AI tools (e.g., GitHub Copilot, ChatGPT, etc.) in developing this PR
- [ ] I understand all the code I'm submitting
- [ ] I have reviewed and validated all AI-generated code

**AI tools used (if applicable):**
<!-- List AI tools used, if any -->
