### PR TITLE
Simplify evaluation and prediction to mirror training datasets and create tests to assert expected eval behavior

### DIFF
--- a/src/deepforest/datasets/prediction.py
+++ b/src/deepforest/datasets/prediction.py
@@ -1,8 +1,6 @@
 import os
 
-import cv2
 import numpy as np
-import numpy.typing as npt
 import pandas as pd
 import rasterio as rio
 import slidingwindow
@@ -10,10 +8,10 @@ import torch
 from PIL import Image
 from rasterio.windows import Window
 from torch.nn import functional as F
-from torch.utils.data import Dataset, default_collate
+from torch.utils.data import Dataset
 
 from deepforest import preprocess
-from deepforest.utilities import format_geometry
+from deepforest.utilities import format_geometry, read_file
 
 
 # Base prediction class
@@ -27,7 +25,6 @@ class PredictionDataset(Dataset):
         image (PIL.Image.Image): A single image.
         path (str): Path to a single image.
         images (List[PIL.Image.Image]): A list of images.
-        paths (List[str]): A list of image paths.
         patch_size (int): Size of the patches to extract.
         patch_overlap (float): Overlap between patches.
         size (int): Target size to resize images to. Optional; if not provided, no resizing is performed.
@@ -38,82 +35,45 @@ class PredictionDataset(Dataset):
         image=None,
         path=None,
         images=None,
-        paths=None,
         patch_size=400,
         patch_overlap=0,
-        size=None,
     ):
         self.image = image
         self.images = images
         self.path = path
-        self.paths = paths
         self.patch_size = patch_size
         self.patch_overlap = patch_overlap
-        self.size = size
         self.items = self.prepare_items()
 
-    def _load_and_preprocess_image(
-        self,
-        image_path: str | None = None,
-        image: Image.Image | npt.NDArray | None = None,
-        size: int | None = None,
-        preprocess_image: bool = True,
+    def load_and_preprocess_image(
+        self, image_path: str = None, image: np.ndarray | Image.Image = None
     ):
-        """Load and preprocess an image. Either an image path or PIL image must
-        be provided.
+        if image is None:
+            if image_path is None:
+                raise ValueError("Either image_path or image must be provided")
+            image = np.array(Image.open(image_path).convert("RGB"))
+        else:
+            image = np.array(image)
+        # If dtype is not float32, convert to float32
+        if image.dtype != "float32":
+            image = image.astype("float32")
 
-        Datasets should load using PIL and transpose the image to
-        (C, H, W) before main.model.forward() is called.
+        # If image is not normalized, normalize to [0, 1]
+        if image.max() > 1 or image.min() < 0:
+            image = image / 255.0
 
-        Args:
-            image_path: (str) path to image, optional
-            image: (PIL image), optional
-            size: (int) output size
-            preprocess_image: (bool) Whether to convert the image to a float32 array between 0 and 1.
+        # If image is not in CHW format, convert to CHW
+        if image.shape[0] != 3:
+            if image.shape[-1] != 3:
+                raise ValueError(
+                    f"Expected 3 channel image, got image shape {image.shape}"
+                )
+            else:
+                image = np.rollaxis(image, 2, 0)
 
-        Returns:
-            CHW float32 numpy array, normalized to be in [0, 1]
-        """
-        if image is None and image_path is None:
-            raise ValueError("Either image or image_path must be provided")
-        elif image is None:
-            image = Image.open(image_path)
-
-        if isinstance(image, Image.Image) and image.mode != "RGB":
-            raise ValueError(
-                f"Expected 8-bit 3-channel RGB, got {image.mode}, {len(image.getbands())} channels and size: {image.size}."
-                "Check for transparent alpha channel and remove if present."
-            )
-        elif isinstance(image, np.ndarray) and (
-            image.ndim != 3 or image.shape[2] != 3 or image.dtype != np.uint8
-        ):
-            raise ValueError(
-                f"Expected 8-bit 3-channel RGB numpy array, got {image.ndim} dimensions and shape: {image.shape}."
-                "Check for transparent alpha channel and remove if present."
-            )
-
-        image = np.array(image)
-
-        if preprocess_image:
-            image = self.preprocess_image(image, size)
+        image = torch.from_numpy(image)
 
         return image
-
-    def preprocess_image(self, image: npt.NDArray, size=None) -> npt.NDArray:
-        """Preprocess an 8-bit image to a float32 array between 0 and 1."""
-        image = image.astype(np.float32)
-        image /= 255.0
-
-        if size is not None:
-            image = self.resize_image(image, size)
-
-        image = np.transpose(image, (2, 0, 1))
-
-        return image
-
-    def resize_image(self, image: npt.NDArray, size: int) -> npt.NDArray:
-        """Resize an image to a new (square) size."""
-        return cv2.resize(image, dsize=(size, size))
 
     def prepare_items(self):
         """Prepare the items for the dataset.
@@ -131,15 +91,9 @@ class PredictionDataset(Dataset):
         return self.get_crop(idx)
 
     def collate_fn(self, batch):
-        """Collate the batch into a single tensor."""
-        # Check if all images in batch have same dimensions
-        try:
-            return default_collate(batch)
-        except RuntimeError:
-            raise RuntimeError(
-                "Images in batch have different dimensions. "
-                "Set validation.size in config.yaml to resize all images to a common size."
-            ) from None
+        """Collate the batch into a list."""
+
+        return batch
 
     def get_crop_bounds(self, idx):
         """Get the crop bounds at the given index, needed to mosaic
@@ -171,12 +125,12 @@ class PredictionDataset(Dataset):
         return geom_type
 
     def format_batch(self, batch, idx, sub_idx=None):
-        """Format the batch into a single dataframe.
+        """Format a single prediction dict into a dataframe with metadata.
 
         Args:
-            batch (list): The batch to format.
-            idx (int): The index of the batch.
-            sub_idx (int): The index of the subbatch. If None, the index is the subbatch index.
+            batch: A single prediction dict (keys: boxes, labels, scores, etc.)
+            idx: The dataset index (image index for windowed datasets)
+            sub_idx: The sub-index (window index). If None, uses idx.
         """
         if sub_idx is None:
             sub_idx = idx
@@ -184,38 +138,26 @@ class PredictionDataset(Dataset):
         result = format_geometry(batch, geom_type=geom_type)
         if result is None:
             return None
-        result["window_xmin"] = self.get_crop_bounds(sub_idx)[0]
-        result["window_ymin"] = self.get_crop_bounds(sub_idx)[1]
+
+        crop_bounds = self.get_crop_bounds(sub_idx)
+        if crop_bounds is not None:
+            result["window_xmin"] = crop_bounds[0]
+            result["window_ymin"] = crop_bounds[1]
         result["image_path"] = self.get_image_basename(idx)
 
         return result
 
-    def postprocess(self, batched_result):
-        """Postprocess the batched result into a single dataframe.
+    def postprocess(self, batch, prediction_index):
+        """Postprocess a single prediction result into a dataframe.
 
-        In the case of sub-batches, the index is the sub-batch index.
+        Args:
+            batch: A single prediction dict (keys: boxes, labels, scores, etc.)
+            prediction_index: The index of this item in the dataset
         """
-        formatted_result = []
-        for idx, batch in enumerate(batched_result):
-            if isinstance(batch, list):
-                for sub_idx, sub_batch in enumerate(batch):
-                    result = self.format_batch(sub_batch, idx, sub_idx)
-                    if result is not None:
-                        formatted_result.append(result)
-            else:
-                result = self.format_batch(batch, idx)
-                if result is not None:
-                    formatted_result.append(result)
-
-        if len(formatted_result) > 0:
-            formatted_result = pd.concat(formatted_result)
-        else:
-            formatted_result = pd.DataFrame()
-
-        # reset index
-        formatted_result = formatted_result.reset_index(drop=True)
-
-        return formatted_result
+        result = self.format_batch(batch, prediction_index)
+        if result is None:
+            return pd.DataFrame()
+        return result.reset_index(drop=True)
 
 
 class SingleImage(PredictionDataset):
@@ -227,13 +169,7 @@ class SingleImage(PredictionDataset):
         )
 
     def prepare_items(self):
-        self.image = self._load_and_preprocess_image(
-            self.path, self.image, preprocess_image=False
-        )
-
-        # Seperately transpose the image to channels first
-        self.image = np.transpose(self.image, (2, 0, 1))
-
+        self.image = self.load_and_preprocess_image(self.path, image=self.image)
         self.windows = preprocess.compute_windows(
             self.image, self.patch_size, self.patch_overlap
         )
@@ -246,9 +182,6 @@ class SingleImage(PredictionDataset):
 
     def get_crop(self, idx):
         crop = self.image[self.windows[idx].indices()]
-        crop = self.preprocess_image(crop)
-        if crop.shape[0] != 3:
-            crop = np.transpose(crop, (1, 2, 0))
 
         return crop
 
@@ -266,14 +199,15 @@ class FromCSVFile(PredictionDataset):
     """Take in a csv file with image paths and preprocess and batch
     together."""
 
-    def __init__(self, csv_file: str, root_dir: str, size: int = None):
+    def __init__(self, csv_file: str, root_dir: str):
         self.csv_file = csv_file
         self.root_dir = root_dir
-        super().__init__(size=size)
-        self.prepare_items()
+        super().__init__()
 
     def prepare_items(self):
-        self.annotations = pd.read_csv(self.csv_file)
+        self.annotations = read_file(self.csv_file)
+        if self.root_dir is None:
+            self.root_dir = self.annotations.root_dir
         self.image_names = self.annotations.image_path.unique()
         self.image_paths = [os.path.join(self.root_dir, x) for x in self.image_names]
 
@@ -281,7 +215,7 @@ class FromCSVFile(PredictionDataset):
         return len(self.image_paths)
 
     def get_crop(self, idx):
-        image = self._load_and_preprocess_image(self.image_paths[idx], size=self.size)
+        image = self.load_and_preprocess_image(image_path=self.image_paths[idx])
         return image
 
     def get_image_basename(self, idx):
@@ -291,19 +225,20 @@ class FromCSVFile(PredictionDataset):
         return None
 
     def format_batch(self, batch, idx, sub_idx=None):
-        """Format the batch into a single dataframe.
+        """Format a single prediction dict into a dataframe with metadata.
+        Override of base class to skip window coordinates (not applicable for
+        full images).
 
         Args:
-            batch (list): The batch to format.
-            idx (int): The index of the batch.
-            sub_idx (int): The index of the subbatch. If None, the index is the subbatch index.
+            batch: A single prediction dict (keys: boxes, labels, scores, etc.)
+            idx: The dataset index (image index)
+            sub_idx: Unused (kept for compatibility with base class signature)
         """
-        if sub_idx is None:
-            sub_idx = idx
         geom_type = self.determine_geometry_type(batch)
         result = format_geometry(batch, geom_type=geom_type)
         if result is None:
             return None
+
         result["image_path"] = self.get_image_basename(idx)
 
         return result
@@ -312,7 +247,7 @@ class FromCSVFile(PredictionDataset):
 class MultiImage(PredictionDataset):
     """Take in a list of image paths, preprocess and batch together.
 
-    Note: This dataset will load the first image to determine the image dimensions.
+    Note: This dataset will load the first image to determine the image dimensions. Images are expected to be the same size. For variable sized images, write a csv file and use the FromCSVFile dataset.
     """
 
     def __init__(self, paths: list[str], patch_size: int, patch_overlap: float):
@@ -322,15 +257,12 @@ class MultiImage(PredictionDataset):
             patch_size (int): Size of the patches to extract.
             patch_overlap (float): Overlap between patches.
         """
-        # Runtime type checking
-        if not isinstance(paths, list):
-            raise TypeError(f"paths must be a list, got {type(paths)}")
-
         self.paths = paths
         self.patch_size = patch_size
         self.patch_overlap = patch_overlap
+        self.sublist_lengths = []
 
-        image = self._load_and_preprocess_image(self.paths[0])
+        image = self.load_and_preprocess_image(image_path=self.paths[0])
         self.image_height = image.shape[1]
         self.image_width = image.shape[2]
 
@@ -379,7 +311,7 @@ class MultiImage(PredictionDataset):
         return output
 
     def _create_patches(self, image):
-        image_tensor = torch.tensor(image).unsqueeze(0)  # Convert to (N, C, H, W)
+        image_tensor = image.unsqueeze(0)  # Convert to (N, C, H, W)
         patch_overlap_size = int(self.patch_size * self.patch_overlap)
         patches = self.create_overlapping_views(
             image_tensor, self.patch_size, patch_overlap_size
@@ -416,21 +348,73 @@ class MultiImage(PredictionDataset):
         return windows
 
     def collate_fn(self, batch):
-        # Comes pre-batched
-        return batch
+        """Collate the batch into a single list of crops.
+
+        Keep track of the lengths of each sublist.
+        """
+        # Create a list of lengths of each sublist
+        sub_list_length = [
+            [idx, sub_idx]
+            for idx, sublist in enumerate(batch)
+            for sub_idx in range(len(sublist))
+        ]
+        self.sublist_lengths.append(sub_list_length)
+
+        # Flatten list of lists of crops
+        flattened_batch = [crop for sublist in batch for crop in sublist]
+        sublist_lengths = [
+            [idx, sub_idx]
+            for idx, sublist in enumerate(batch)
+            for sub_idx in range(len(sublist))
+        ]
+
+        return {"images": flattened_batch, "sublist_lengths": sublist_lengths}
 
     def __len__(self):
         return len(self.paths)
 
     def get_crop(self, idx):
-        image = self._load_and_preprocess_image(self.paths[idx])
-        return self._create_patches(image)
+        image = self.load_and_preprocess_image(image_path=self.paths[idx])
+        crops = self._create_patches(image)
+
+        # Return as a list of crops, each with shape (3, 300, 300)
+        return [crops[i] for i in range(crops.shape[0])]
 
     def get_image_basename(self, idx):
         return os.path.basename(self.paths[idx])
 
     def get_crop_bounds(self, idx):
         return self.window_list()[idx]
+
+    def postprocess(self, batch, prediction_index, original_batch_structure):
+        """Postprocess flattened batch of predictions from multiple images.
+
+        Args:
+            batch: List of prediction dicts (all windows from all images in batch)
+            prediction_index: Index of this batch from trainer.predict
+        """
+        if prediction_index >= len(original_batch_structure):
+            raise ValueError(
+                f"prediction_index {prediction_index} exceeds sublist_lengths length {len(original_batch_structure)}. "
+                "This may indicate a mismatch between collate_fn calls and postprocess calls."
+            )
+
+        batch_sublist_lengths = original_batch_structure[prediction_index]
+        formatted_results = []
+
+        # batch_sublist_lengths[i] = [image_idx, window_idx] corresponds to batch[i]
+        for batch_position, (image_idx, window_idx) in enumerate(batch_sublist_lengths):
+            prediction = batch[batch_position]
+
+            # Format with correct image index and window index
+            result = self.format_batch(prediction, image_idx, window_idx)
+            if result is not None:
+                formatted_results.append(result)
+
+        if len(formatted_results) > 0:
+            return pd.concat(formatted_results).reset_index(drop=True)
+        else:
+            return pd.DataFrame()
 
 
 class TiledRaster(PredictionDataset):
@@ -447,13 +431,9 @@ class TiledRaster(PredictionDataset):
     """
 
     def __init__(self, path, patch_size, patch_overlap):
-        self.path = path
-        self.patch_size = patch_size
-        self.patch_overlap = patch_overlap
-        self.prepare_items()
-
         if path is None:
             raise ValueError("path is required for a memory raster dataset")
+        super().__init__(path=path, patch_size=patch_size, patch_overlap=patch_overlap)
 
     def prepare_items(self):
         # Get raster shape without keeping file open
@@ -492,9 +472,13 @@ class TiledRaster(PredictionDataset):
         with rio.open(self.path) as src:
             window_data = src.read(window=Window(window.x, window.y, window.w, window.h))
 
-        # Convert to torch tensor and rearrange dimensions
-        window_data = torch.from_numpy(window_data).float()  # Convert to torch tensor
-        window_data = window_data / 255.0  # Normalize
+        # Rasterio already returns (C, H, W), just normalize and convert
+        window_data = window_data.astype("float32") / 255.0
+        window_data = torch.from_numpy(window_data).float()
+        if window_data.shape[0] != 3:
+            raise ValueError(
+                f"Expected 3 channel image, got {window_data.shape[0]} channels"
+            )
 
         return window_data
 

--- a/src/deepforest/model.py
+++ b/src/deepforest/model.py
@@ -407,10 +407,12 @@ class CropModel(LightningModule, PyTorchModelHubMixin):
 
     def on_validation_epoch_end(self):
         metric_dict = self.metrics.compute()
-        for index, value in enumerate(metric_dict["Class Accuracy"]):
-            key = self.numeric_to_label_dict[index]
-            metric_name = f"Class Accuracy_{key}"
-            self.log(metric_name, value, on_step=False, on_epoch=True)
+        # Only log per-class metrics when there are multiple classes
+        if len(self.numeric_to_label_dict) > 1:
+            for index, value in enumerate(metric_dict["Class Accuracy"]):
+                key = self.numeric_to_label_dict[index]
+                metric_name = f"Class Accuracy_{key}"
+                self.log(metric_name, value, on_step=False, on_epoch=True)
 
         self.log(
             "Micro-Average Accuracy",

--- a/src/deepforest/predict.py
+++ b/src/deepforest/predict.py
@@ -201,12 +201,20 @@ def _dataloader_wrapper_(model, trainer, dataloader, root_dir, crop_model):
 
     # Flatten list from batched prediction
     prediction_list = []
-    for batch in batched_results:
-        for images in batch:
-            prediction_list.append(images)
+    global_image_idx = 0
+    for _idx, batch in enumerate(batched_results):
+        for _image_idx, image_result in enumerate(batch):
+            formatted_result = dataloader.dataset.postprocess(
+                image_result, global_image_idx
+            )
+            global_image_idx += 1
+            prediction_list.append(formatted_result)
 
-    # Postprocess predictions
-    results = dataloader.dataset.postprocess(prediction_list)
+    # Postprocess predictions, return empty dataframe if no predictions
+    if not prediction_list:
+        return pd.DataFrame()
+
+    results = pd.concat(prediction_list)
 
     if results.empty:
         return results

--- a/tests/test_datasets_prediction.py
+++ b/tests/test_datasets_prediction.py
@@ -31,33 +31,11 @@ def test_SingleImage_path():
     for i in range(len(ds)):
         assert ds.get_crop(i).shape == (3, 300, 300)
 
-def test_invalid_array_dtype():
-    # Not explicitly 8-bit
-    test_data = np.random.random((300,300, 3))
-    with pytest.raises(ValueError):
-        SingleImage(image=test_data)
-
-def test_invalid_image_dtype():
-    # Not explicitly 8-bit
-    test_data = (np.random.random((300,300)) * 255).astype(np.float32)
-    with pytest.raises(ValueError):
-        SingleImage(image=Image.fromarray(test_data))
-
-def test_invalid_array_shape():
-    # Not HWC
-    test_data = np.random.random((3,300,300))
-    with pytest.raises(ValueError):
-        SingleImage(image=test_data)
-
 def test_invalid_image_shape():
     # Not 3 channels
     test_data = (np.random.rand(300, 300, 4) * 255).astype(np.uint8)
-    with pytest.raises(ValueError, match="4 channels"):
+    with pytest.raises(ValueError):
         SingleImage(image=Image.fromarray(test_data))
-
-def test_no_image_or_path():
-    with pytest.raises(ValueError, match="image or image_path"):
-        SingleImage()
 
 def test_valid_image():
     # 8-bit, HWC
@@ -69,19 +47,13 @@ def test_valid_array():
     test_data = np.random.randint(0, 256, (300,300,3)).astype(np.uint8)
     SingleImage(image=test_data)
 
-def test_image_resize():
-    # Resize + transpose
-    test_data = np.random.randint(0, 256, (300,300,3)).astype(np.uint8)
-    ds = SingleImage(image=test_data)
-    assert ds._load_and_preprocess_image(image=test_data, size=200).shape == (3, 200, 200)
-
 def test_MultiImage():
     ds = MultiImage(paths=[get_data("OSBS_029.png"), get_data("OSBS_029.png")],
                     patch_size=300,
                     patch_overlap=0)
-    assert len(ds) == 2
     # 2 windows each image 2 * 2 = 4
-    assert ds[0].shape == (4, 3, 300, 300)
+    assert len(ds) == 2
+    assert ds[0][0].shape == (3, 300, 300)
 
 def test_FromCSVFile():
     ds = FromCSVFile(csv_file=get_data("example.csv"),

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -12,6 +12,7 @@ from deepforest import get_data
 from deepforest import main
 from deepforest.utilities import read_file
 
+from PIL import Image
 from shapely.geometry import box
 
 
@@ -79,7 +80,7 @@ def test_evaluate_empty(m, tmp_path):
     m = main.deepforest(config_args={"model": {"name": None},
                                      "log_root": str(tmp_path)})
     csv_file = get_data("OSBS_029.csv")
-    results = m.evaluate(csv_file, iou_threshold=0.4)
+    results = m.evaluate(csv_file, iou_threshold=0.4, root_dir=os.path.dirname(csv_file))
 
     # Does this make reasonable predictions, we know the model works.
     assert np.isnan(results["box_precision"])
@@ -202,3 +203,103 @@ def test_evaluate_boxes_no_predictions_for_image():
     assert results["box_recall"] == 0  # No predictions for image1.jpg
     assert all(results["results"].match == False)  # No matches
     assert all(results["results"].prediction_id.isna())  # No prediction IDs
+
+
+def test_validate_predictions_match_predict_file(m):
+    """trainer.validate should populate predictions equivalent to main.predict_file."""
+    csv_file = get_data("example.csv")
+    root_dir = os.path.dirname(csv_file)
+
+    # Run validation to populate m.predictions
+    m.create_trainer()
+    m.trainer.validate(m)
+
+    # Concatenate predictions collected during validation
+    if len(m.predictions) > 0:
+        val_preds = pd.concat(m.predictions, ignore_index=True)
+    else:
+        val_preds = pd.DataFrame(
+            columns=["image_path", "xmin", "ymin", "xmax", "ymax", "label"])
+
+    # Predict through inference path
+    infer_preds = m.predict_file(csv_file=csv_file, root_dir=root_dir)
+
+    assert infer_preds.empty == val_preds.empty
+    assert infer_preds.shape == val_preds.shape
+
+    # Compare the first row of the predictions
+    assert infer_preds.iloc[0].xmin == val_preds.iloc[0].xmin
+    assert infer_preds.iloc[0].ymin == val_preds.iloc[0].ymin
+    assert infer_preds.iloc[0].xmax == val_preds.iloc[0].xmax
+    assert infer_preds.iloc[0].ymax == val_preds.iloc[0].ymax
+    assert infer_preds.iloc[0].label == val_preds.iloc[0].label
+
+
+def test_validate_predictions_match_predict_file_mixed_sizes(m, tmp_path):
+    """trainer.validate should populate predictions equivalent to main.predict_file for mixed-size images."""
+    # Prepare two images at different sizes
+    src_path = get_data("OSBS_029.tif")
+    img = Image.open(src_path).convert("RGB")
+
+    # Create a smaller and a larger variant (bounded to avoid extreme sizes)
+    w, h = img.size
+    small = img.resize((max(64, w // 2), max(64, h // 2)))
+    large = img.resize((min(w * 2, 2 * w), min(h * 2, 2 * h)))
+
+    # Save both to tmp directory as PNGs
+    small_name = "mixed_small.png"
+    large_name = "mixed_large.png"
+    small_path = os.path.join(tmp_path, small_name)
+    large_path = os.path.join(tmp_path, large_name)
+    small.save(small_path)
+    large.save(large_path)
+
+    # Build a CSV with empty annotations (0,0,0,0) for validation compatibility
+    # predict_file only needs image_path, but validation requires full annotation format
+    csv_path = os.path.join(tmp_path, "mixed_images.csv")
+    df = pd.DataFrame({
+        "image_path": [small_name, large_name],
+        "xmin": [0, 0],
+        "ymin": [0, 0],
+        "xmax": [0, 0],
+        "ymax": [0, 0],
+        "label": ["Tree", "Tree"]
+    })
+    df.to_csv(csv_path, index=False)
+
+    # Configure validation to use the mixed-size images
+    m.config.validation.csv_file = csv_path
+    m.config.validation.root_dir = str(tmp_path)
+    # Don't set validation.size to avoid resizing - use batch_size=1 to handle mixed sizes
+    m.config.batch_size = 1
+
+    # Run validation to populate m.predictions
+    m.create_trainer()
+    m.trainer.validate(m)
+
+    # Concatenate predictions collected during validation
+    if len(m.predictions) > 0:
+        val_preds = pd.concat(m.predictions, ignore_index=True)
+    else:
+        val_preds = pd.DataFrame(
+            columns=["image_path", "xmin", "ymin", "xmax", "ymax", "label"])
+
+    # Predict through inference path
+    # Don't pass size to avoid resizing - coordinates should be in original image space
+    infer_preds = m.predict_file(csv_file=csv_path, root_dir=str(tmp_path))
+
+    assert infer_preds.empty == val_preds.empty
+    assert infer_preds.shape == val_preds.shape
+
+    # Compare predictions by image_path to ensure matching
+    # Sort both dataframes for comparison
+    val_preds_sorted = val_preds.sort_values(by=["image_path", "xmin", "ymin"]).reset_index(drop=True)
+    infer_preds_sorted = infer_preds.sort_values(by=["image_path", "xmin", "ymin"]).reset_index(drop=True)
+
+    # Compare the first row of the predictions if both are non-empty
+    if not val_preds_sorted.empty and not infer_preds_sorted.empty:
+        assert infer_preds_sorted.iloc[0].xmin == val_preds_sorted.iloc[0].xmin
+        assert infer_preds_sorted.iloc[0].ymin == val_preds_sorted.iloc[0].ymin
+        assert infer_preds_sorted.iloc[0].xmax == val_preds_sorted.iloc[0].xmax
+        assert infer_preds_sorted.iloc[0].ymax == val_preds_sorted.iloc[0].ymax
+        assert infer_preds_sorted.iloc[0].label == val_preds_sorted.iloc[0].label


### PR DESCRIPTION
* This PR favors trainer.validate over main.evaluate since it closely matches pytorch lightning. I considered renaming main.evaluate to main.__evaluate__ or deprecating it to hide it from users, I welcome input on that.
*  We want one standard evaluation path and then assert the behavior of this matches the inference path. I started on this road by adding tests to check parity between main.evaluate and trainer.validate. 
* I also simplified the outputs of trainer.validate since if this is going to be primary evaluation vehicle, it has too many map products for the average user.
* I removed the size and batch size argument from main.evaluate and had it routed through the config, in general we want to config to control as much as possible #1240 as we discussed here. 
* I simplified the prediction dataset workflow to just accept lists instead of tensors. This is faster, cleaner and easier to read. There is one additional complication for the MultiImage dataset since the batch comes from several images and we need to keep track of which in order to put it all back together.
* I wrote several tests to assert constancy of actions between evaluate and predict making the whole system more cohesive.

## AI-Assisted Development

<!-- Be transparent about AI tool usage -->

- [x ] I used AI tools (e.g., GitHub Copilot, ChatGPT, etc.) in developing this PR
- [ x] I understand all the code I'm submitting
- [ x] I have reviewed and validated all AI-generated code

**AI tools used (if applicable):**
<!-- List AI tools used, if any -->

I used cursor planning mode to help structure the tests, which i then edited and simplified. 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Major refactor to streamline augmentation, evaluation, prediction, and I/O with extensive tests.
> 
> - Migrate augmentations to `kornia` (remove `albumentations`), add `ZoomBlur` and `RandomPadTo`, and switch dataset transforms to `AugmentationSequential`
> - Standardize evaluation via `trainer.validate` with simplified mAP logging; deprecate `main.evaluate` (internal `__evaluate__` retained)
> - Simplify prediction datasets: use list-based batches, track sub-batch/window indices for `MultiImage` and tiled rasters, and update `predict`/`predict_tile` postprocessing
> - Overhaul `utilities.read_file` and geospatial handling with `DeepForest_DataFrame`, explicit `image_path`/`label`/`root_dir` assignment, and improved COCO/shape conversions
> - Update visualization to infer dimensions from `image`/`root_dir` (remove explicit `width`/`height`), and harden callbacks for empty annotations
> - Config/schema: add `log_root`; crop model: add bbox `expand` and dataset support
> - Adjust datasets (`training`, `prediction`, `cropmodel`) for new transforms, normalization, and box filtering; ensure 3-channel checks
> - Update docs (user guide, HISTORY), README link fix, and add `kornia` dependency; tweak `codecov.yml` to mark patch status informational
> - Add comprehensive tests for augmentations, datasets, callbacks, CLI, evaluation parity, crop model, DETR, and prediction batching
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 71728ea351b46f9ce28adeaac9cefe1b26b1a0c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->