### PR TITLE
detach losses when logging

### DIFF
--- a/src/deepforest/main.py
+++ b/src/deepforest/main.py
@@ -676,10 +676,12 @@ class deepforest(pl.LightningModule):
 
         # Log loss
         for key, value in loss_dict.items():
-            self.log(f"train_{key}", value, on_epoch=True, batch_size=len(images))
+            self.log(
+                f"train_{key}", value.detach(), on_epoch=True, batch_size=len(images)
+            )
 
         # Log sum of losses
-        self.log("train_loss", losses, on_epoch=True, batch_size=len(images))
+        self.log("train_loss", losses.detach(), on_epoch=True, batch_size=len(images))
 
         return losses
 
@@ -699,9 +701,11 @@ class deepforest(pl.LightningModule):
         # Log losses
         try:
             for key, value in loss_dict.items():
-                self.log(f"val_{key}", value, on_epoch=True, batch_size=len(images))
+                self.log(
+                    f"val_{key}", value.detach(), on_epoch=True, batch_size=len(images)
+                )
 
-            self.log("val_loss", losses, on_epoch=True, batch_size=len(images))
+            self.log("val_loss", losses.detach(), on_epoch=True, batch_size=len(images))
         except MisconfigurationException:
             pass
 


### PR DESCRIPTION
## Description

`detach` losses when logging. It's probable that `lightning` does this for us under the hood, but good to be clear.

@bw4sz want to try these fixes with your bird model branch? 

I have also tried garbage collection, but I'm not sure it's necessary. Better to identify where we might be leaking.

## Related Issue(s)

https://github.com/weecology/DeepForest/pull/1247

## AI-Assisted Development

Some sanity checking with Claude Code, and an assisted review of where we might be missing resets etc.

- [X] I used AI tools (e.g., GitHub Copilot, ChatGPT, etc.) in developing this PR
- [X] I understand all the code I'm submitting
