### PR TITLE
add torchmetrics wrapper for evaluate_boxes

### DIFF
--- a/src/deepforest/main.py
+++ b/src/deepforest/main.py
@@ -3,12 +3,10 @@ import importlib
 import os
 import warnings
 
-import geopandas as gpd
 import numpy as np
 import pandas as pd
 import pytorch_lightning as pl
 import torch
-from lightning_fabric.utilities.exceptions import MisconfigurationException
 from omegaconf import DictConfig, OmegaConf
 from PIL import Image
 from pytorch_lightning.callbacks import LearningRateMonitor
@@ -19,6 +17,7 @@ from torchmetrics.detection import IntersectionOverUnion, MeanAveragePrecision
 from deepforest import evaluate as evaluate_iou
 from deepforest import predict, utilities
 from deepforest.datasets import prediction, training
+from deepforest.metrics import RecallPrecision
 
 
 class deepforest(pl.LightningModule):
@@ -70,23 +69,14 @@ class deepforest(pl.LightningModule):
         self.existing_train_dataloader = existing_train_dataloader
         self.existing_val_dataloader = existing_val_dataloader
 
-        # Metrics
-        self.iou_metric = IntersectionOverUnion(
-            class_metrics=True, iou_threshold=self.config.validation.iou_threshold
-        )
-        self.mAP_metric = MeanAveragePrecision(backend="faster_coco_eval")
-
-        # Empty frame accuracy
-        self.empty_frame_accuracy = BinaryAccuracy()
-
-        # Create a default trainer.
-        self.create_trainer()
-
         self.model = model
         self.original_batch_structure = []
 
         if self.model is None:
             self.create_model()
+
+        # Create a default trainer.
+        self.create_trainer()
 
         # Add user supplied transforms
         if transforms is None:
@@ -96,6 +86,25 @@ class deepforest(pl.LightningModule):
 
         self.save_hyperparameters(
             {"config": OmegaConf.to_container(self.config, resolve=True)}
+        )
+
+    def setup_metrics(self):
+        # Guard against initialization before a validation csv_file is set
+        if not self.config.validation.csv_file:
+            return
+
+        # Metrics
+        self.iou_metric = IntersectionOverUnion(
+            class_metrics=True, iou_threshold=self.config.validation.iou_threshold
+        )
+        self.mAP_metric = MeanAveragePrecision(backend="faster_coco_eval")
+
+        # Empty frame accuracy
+        self.empty_frame_accuracy = BinaryAccuracy()
+
+        self.precision_recall_metric = RecallPrecision(
+            csv_file=self.config.validation.csv_file,
+            label_dict=self.label_dict,
         )
 
     def load_model(self, model_name=None, revision=None):
@@ -190,6 +199,10 @@ class deepforest(pl.LightningModule):
             callbacks: Optional list of callbacks
             **kwargs: Additional trainer arguments
         """
+
+        # Setup metrics which may have changed if the config was modified
+        self.setup_metrics()
+
         if callbacks is None:
             callbacks = []
         # If val data is passed, monitor learning rate and setup classification metrics
@@ -704,15 +717,10 @@ class deepforest(pl.LightningModule):
         losses = sum(loss_dict.values())
 
         # Log losses
-        try:
-            for key, value in loss_dict.items():
-                self.log(
-                    f"val_{key}", value.detach(), on_epoch=True, batch_size=len(images)
-                )
+        for key, value in loss_dict.items():
+            self.log(f"val_{key}", value.detach(), on_epoch=True, batch_size=len(images))
 
-            self.log("val_loss", losses.detach(), on_epoch=True, batch_size=len(images))
-        except MisconfigurationException:
-            pass
+        self.log("val_loss", losses.detach(), on_epoch=True, batch_size=len(images))
 
         # In eval model, return predictions to calculate prediction metrics
         self.model.eval()
@@ -723,13 +731,29 @@ class deepforest(pl.LightningModule):
             # Remove empty targets and corresponding predictions
             filtered_preds = []
             filtered_targets = []
+
             for i, target in enumerate(targets):
-                if target["boxes"].shape[0] > 0:
+                # Empty frame accuracy
+                is_empty_frame = target["boxes"].numel() == 0 or torch.all(
+                    target["boxes"] == 0
+                )
+                if is_empty_frame:
+                    # 0 indicates empty frame or predication
+                    device = target["boxes"].device
+                    self.empty_frame_accuracy.update(
+                        torch.tensor([min(len(preds[i]["boxes"]), 1)], device=device),
+                        torch.tensor([0.0], device=device),
+                    )
+                else:
+                    # Non-empty frames go to all metrics
                     filtered_preds.append(preds[i])
                     filtered_targets.append(target)
 
+            # IoU and mAP metrics need preds/targets to exist
             self.iou_metric.update(filtered_preds, filtered_targets)
             self.mAP_metric.update(filtered_preds, filtered_targets)
+            # Precision recall metric can handle empty frames internally
+            self.precision_recall_metric.update(preds, image_names)
 
         # Log the predictions if you want to use them for evaluation logs
         for i, result in enumerate(preds):
@@ -799,49 +823,38 @@ class deepforest(pl.LightningModule):
             # Calculate accuracy using metric
             self.empty_frame_accuracy.update(predictions, gt)
             empty_accuracy = self.empty_frame_accuracy.compute()
+            self.empty_frame_accuracy.reset()
 
         # Log empty frame accuracy
-        try:
-            self.log("empty_frame_accuracy", empty_accuracy)
-        except MisconfigurationException:
-            pass
+        self.log("empty_frame_accuracy", empty_accuracy)
 
         return empty_accuracy
 
-    def log_epoch_metrics(self):
-        if len(self.iou_metric.groundtruth_labels) > 0:
-            output = self.iou_metric.compute()
-            # Lightning bug: claims this is a warning but it's not. See issue #16218 in Lightning-AI/pytorch-lightning
-            try:
-                self.log_dict(output)
-            except Exception:
-                pass
+    def _compute_epoch_metrics(self) -> dict:
+        """Compute metrics and returns a Lightning-loggable dictionary.
 
-            self.iou_metric.reset()
+        This function is called automatically at the end of validation.
+        """
+        metrics = {}
+
+        # IoU and mAP
+        if len(self.iou_metric.groundtruth_labels) > 0:
+            metrics.update(self.iou_metric.compute())
+            # Lightning bug: claims this is a warning but it's not. See issue #16218 in Lightning-AI/pytorch-lightning
             output = self.mAP_metric.compute()
 
-            # Keep only overall mAP; drop extra map_* and classes clutter
-            if isinstance(output, dict):
-                # Remove classes entry if present
-                if "classes" in output:
-                    output.pop("classes", None)
-                # Reduce to only overall 'map' and map_50   if available
-                output = {k: v for k, v in output.items() if k in ["map", "map_50"]}
-            try:
-                self.log_dict(output)
-            except MisconfigurationException:
-                pass
-            self.mAP_metric.reset()
+            # Remove classes from output dict
+            output = {key: value for key, value in output.items() if not key == "classes"}
+            metrics.update(output)
 
-        # Log empty frame accuracy if it has been updated
-        if self.empty_frame_accuracy._update_called:
-            empty_accuracy = self.empty_frame_accuracy.compute()
+        # Box recall/precision
+        metrics.update(self.precision_recall_metric.compute())
 
-            # Log empty frame accuracy
-            try:
-                self.log("empty_frame_accuracy", empty_accuracy)
-            except MisconfigurationException:
-                pass
+        # Empty frame accuracy
+        if self.empty_frame_accuracy.update_called:
+            metrics["empty_frame_accuracy"] = self.empty_frame_accuracy.compute()
+
+        return metrics
 
     def on_validation_epoch_end(self):
         """Compute metrics and predictions at the end of the validation
@@ -850,23 +863,16 @@ class deepforest(pl.LightningModule):
             return
 
         # Log epoch metrics
-        self.log_epoch_metrics()
-
         if (self.current_epoch + 1) % self.config.validation.val_accuracy_interval == 0:
-            if len(self.predictions) > 0:
-                predictions = pd.concat(self.predictions)
-            else:
-                predictions = pd.DataFrame()
+            metrics = self._compute_epoch_metrics()
+            self.log_dict(metrics)
 
-            results = self.__evaluate__(
-                self.config.validation.csv_file,
-                root_dir=self.config.validation.root_dir,
-                predictions=predictions,
-            )
-
-            self.__evaluation_logs__(results)
-
-            return results
+        # Manual reset. Lightning does not do this automatically
+        # unless we log the metric objects directly
+        self.precision_recall_metric.reset()
+        self.iou_metric.reset()
+        self.mAP_metric.reset()
+        self.empty_frame_accuracy.reset()
 
     def predict_step(self, batch, batch_idx):
         """Predict a batch of images with the deepforest model. If batch is a
@@ -1040,8 +1046,6 @@ class deepforest(pl.LightningModule):
         empty_accuracy = self.calculate_empty_frame_accuracy(ground_df, predictions)
         results["empty_frame_accuracy"] = empty_accuracy
 
-        self.__evaluation_logs__(results)
-
         return results
 
     def evaluate(
@@ -1079,52 +1083,3 @@ class deepforest(pl.LightningModule):
             root_dir=root_dir,
             predictions=predictions,
         )
-
-    def __evaluation_logs__(self, results):
-        """Log metrics from evaluation results."""
-        # Log metrics
-        for key, value in results.items():
-            if type(value) in [
-                pd.DataFrame,
-                gpd.GeoDataFrame,
-                utilities.DeepForest_DataFrame,
-            ]:
-                pass
-            elif value is None:
-                pass
-            else:
-                try:
-                    self.log(key, value)
-                except MisconfigurationException:
-                    pass
-
-        # Log each key value pair of the results dict
-        if results["class_recall"] is not None and self.config.num_classes > 1:
-            for key, value in results.items():
-                if key in ["class_recall"]:
-                    for _, row in value.iterrows():
-                        try:
-                            self.log(
-                                "{}_Recall".format(
-                                    self.numeric_to_label_dict[row["label"]]
-                                ),
-                                row["recall"],
-                            )
-                            self.log(
-                                "{}_Precision".format(
-                                    self.numeric_to_label_dict[row["label"]]
-                                ),
-                                row["precision"],
-                            )
-                        except MisconfigurationException:
-                            pass
-                elif key in ["predictions", "results", "ground_df"]:
-                    # Don't log dataframes of predictions or IoU results per epoch
-                    pass
-                elif value is None:
-                    pass
-                else:
-                    try:
-                        self.log(key, value)
-                    except MisconfigurationException:
-                        pass

--- a/src/deepforest/metrics.py
+++ b/src/deepforest/metrics.py
@@ -1,0 +1,150 @@
+import warnings
+
+import geopandas as gpd
+import pandas as pd
+import torch
+from torch import Tensor
+from torchmetrics import Metric
+
+from deepforest import utilities
+from deepforest.evaluate import __evaluate_wrapper__
+
+
+class RecallPrecision(Metric):
+    """DeepForest box recall and precision metric.
+
+    This class is a thin wrapper around evaluate_boxes to compute box
+    recall and precision during validation. In multi-GPU environments,
+    each rank runs evaluation on the full (gathered) dataset.
+    """
+
+    boxes: list[Tensor]
+    labels: list[Tensor]
+    scores: list[Tensor]
+    image_indices: list[Tensor]
+
+    def __init__(
+        self,
+        csv_file: str,
+        label_dict: dict,
+        task="box",
+        iou_threshold: float = 0.4,
+        **kwargs,
+    ) -> None:
+        """This metric performs DeepForest's box recall and precision
+        evaluation.
+
+        Args:
+            csv_file (str): Path to CSV file with ground truth boxes.
+            label_dict (dict): Dictionary mapping string labels to numeric labels.
+            iou_threshold (float, optional): IOU threshold for evaluation. Defaults to 0.4.
+        """
+        super().__init__(**kwargs)
+
+        self.csv_file = csv_file
+        self.iou_threshold = iou_threshold
+        self.label_dict = label_dict
+
+        if task != "box":
+            raise NotImplementedError("Only 'box' task is currently supported.")
+
+        # Create image path index mappings. This is necessary
+        # as we can't sync strings across multiple GPUs by default.
+        ground_df = utilities.read_file(csv_file)
+        unique_paths = sorted(ground_df["image_path"].unique())
+        self.path_to_index = {path: idx for idx, path in enumerate(unique_paths)}
+        self.index_to_path = {idx: path for path, idx in self.path_to_index.items()}
+
+        self.add_state("boxes", default=[], dist_reduce_fx=None)
+        self.add_state("labels", default=[], dist_reduce_fx=None)
+        self.add_state("scores", default=[], dist_reduce_fx=None)
+        self.add_state("image_indices", default=[], dist_reduce_fx=None)
+
+    def update(self, preds: list[dict[str, Tensor]], image_names: list[str]) -> None:
+        """Update the metric with new predictions.
+
+        Args:
+            preds (list[dict[str, Tensor]]): List of prediction dictionaries from the model.
+            image_names (list): List of image names corresponding to the predictions.
+        """
+        for pred, image_name in zip(preds, image_names, strict=True):
+            # Look up image index; skip if not in ground truth
+            if image_name not in self.path_to_index:
+                warnings.warn(
+                    f"Image '{image_name}' not found in ground truth CSV. Skipping.",
+                    stacklevel=2,
+                )
+                continue
+
+            image_idx = self.path_to_index[image_name]
+            num_boxes = len(pred["boxes"])
+
+            # Store predictions and image indices as tensors
+            self.boxes.append(pred["boxes"].detach())
+            self.labels.append(pred["labels"].detach())
+            self.scores.append(pred["scores"].detach())
+            # Create a 1D tensor with one index per box
+            self.image_indices.append(
+                torch.full((num_boxes,), image_idx, dtype=torch.long).to(
+                    pred["boxes"].device
+                )
+            )
+
+    def compute(self) -> dict[str, float]:
+        """Computes the recall/precision metrics."""
+
+        ground_df = utilities.read_file(self.csv_file)
+        numeric_to_label_dict = {v: k for k, v in self.label_dict.items()}
+        ground_df["label"] = ground_df.label.apply(lambda x: self.label_dict[x])
+
+        predictions = pd.DataFrame()
+        if self.boxes:
+            combined = {
+                "boxes": torch.cat(self.boxes),
+                "labels": torch.cat(self.labels),
+                "scores": torch.cat(self.scores),
+            }
+            predictions = utilities.format_geometry(combined)
+            if predictions is None:
+                predictions = pd.DataFrame()  # Reset to empty DataFrame
+            else:
+                # Expand image names to one entry per box
+                predictions["image_path"] = [
+                    self.index_to_path[int(idx.item())]
+                    for idx in torch.cat(self.image_indices)
+                ]
+
+        results = __evaluate_wrapper__(
+            predictions=predictions,
+            ground_df=ground_df,
+            iou_threshold=self.iou_threshold,
+            numeric_to_label_dict=numeric_to_label_dict,
+        )
+
+        filtered_results = {}
+
+        # Extract per-class recall/precision for multi class prediction only.
+        if len(self.label_dict) > 1:
+            if "class_recall" in results and results["class_recall"] is not None:
+                for _, row in results["class_recall"].iterrows():
+                    filtered_results[
+                        "{}_Recall".format(numeric_to_label_dict[row["label"]])
+                    ] = row["recall"]
+                    filtered_results[
+                        "{}_Precision".format(numeric_to_label_dict[row["label"]])
+                    ] = row["precision"]
+
+        # Filter out values that cannot be logged
+        for key, value in results.items():
+            if isinstance(value, (pd.DataFrame, gpd.GeoDataFrame)):
+                pass
+            elif value is None:
+                pass
+            else:
+                filtered_results[key] = value
+
+        return filtered_results
+
+    def reset(self) -> None:
+        """Reset metric state."""
+        super().reset()


### PR DESCRIPTION
## Description

- Use `torchmetrics` to collect results and call `evaluate_boxes` during validation
- All metrics now respect `validate_on_epoch`, but should be fast enough even with large datasets to run with `n=1`. Metrics are always reset regardless.
- Simpler empty frame tracking during `validation_step`
- Much cleaner logging in `main`. Non-loggable metrics are dropped in the torchmetric class.
- Metric set up is delegated to when the trainer is created. See next point.
- If the user changes anything like validation data etc after initialization, we need to also re-init the metrics because precision/recall needs to know about label_dict and the annotation file when it calls `evaluate` under the hood. There are some guards in the code to check this (e.g. reload metrics in create_trainer and on model load).
- There is also a guard to not init metrics unless a validation set is defined, which is required for our internal metric (since it needs to know about the gt dataframe to run). Case when the user sets validation csv/root after init, instead of a config arg. I would suggest we think about decoupling this in evaluate for training (ie the core eval methods should only care about pairs of pred/target and not worry about image paths.
- The metric has a `task` arg which is set to `box` for now, as I anticipate that we will modify it to support different prediction types.
 
## Related Issue(s)

https://github.com/weecology/DeepForest/issues/901 (step towards this)
https://github.com/weecology/DeepForest/pull/1254 
https://github.com/weecology/DeepForest/issues/1245
Supports https://github.com/weecology/DeepForest/pull/1253

## AI-Assisted Development

<!-- Be transparent about AI tool usage -->

- [X] I used AI tools (e.g., GitHub Copilot, ChatGPT, etc.) in developing this PR
- [X] I understand all the code I'm submitting
- [X] I have reviewed and validated all AI-generated code

**AI tools used (if applicable):**
Claude Code to do some bug hunting and experiments with gpu sync that turned out to be not required.
