### PR TITLE
Check config_args override checkpoint config

### DIFF
--- a/src/deepforest/main.py
+++ b/src/deepforest/main.py
@@ -52,6 +52,8 @@ class deepforest(pl.LightningModule):
         # Checkpoint load
         elif isinstance(config, dict):
             config = utilities.load_config(overrides=config)
+            if config_args is not None:
+                config = OmegaConf.merge(config, config_args)
         # Hub overrides
         elif "config_args" in config:
             config = utilities.load_config(overrides=config["config_args"])


### PR DESCRIPTION
This PR fixes a bug where `config_args` provided to `load_from_checkpoint` were being ignored.

**The Issue**
When loading a model from a PyTorch Lightning checkpoint (e.g., `.pl` or `.ckpt`), the `__init__` method loads the configuration dictionary saved inside the checkpoint. However, it previously stopped there and did not merge the user-provided `config_args` into this loaded configuration. This caused the model to revert to its training-time settings (e.g., `score_thresh=0.1`) even if the user explicitly requested a change (e.g., `score_thresh=0.5`).
**The Fix**
* Modified `src/deepforest/main.py`: Added an explicit `OmegaConf.merge(config, config_args)` step in the `__init__` method to ensure user overrides take precedence over the saved checkpoint configuration.
 
**Verification**
* Added a new regression test `test_checkpoint_config_override` in `tests/test_main.py`.
* The test trains a model with `score_thresh=0.1`, saves it, and verifies that reloading it with `config_args={"score_thresh": 0.5}` correctly updates the model and config to `0.5`.
 
**Related Issue**
Fixes #1246 

### AI-Assisted Development
I utilized AI for sanity checking code logic and conducting an assisted review to identify potential missing resets and schema constraints.

- [x] I used AI tools (e.g., GitHub Copilot, ChatGPT, etc.) in developing this PR
- [x] I understand all the code I'm submitting