### PR TITLE
More consistent checkpoint handling.

### DIFF
--- a/docs/user_guide/09_configuration_file.md
+++ b/docs/user_guide/09_configuration_file.md
@@ -18,7 +18,6 @@ batch_size: 1
 
 # Model Architecture
 architecture: 'retinanet'
-num_classes: 1
 nms_thresh: 0.05
 score_thresh: 0.1
 
@@ -29,9 +28,16 @@ model:
 
 # If this label dict is specified, and it differs
 # from the model downloaded from the hub, the model
-# will be updated to reflect the new class list.
+# will be updated to reflect the new class list. By
+# default, this is blank and is populated when the
+# model is loaded.
+#
+# label_dict:
+#   Tree: 0
+# num_classes: 1
+#
 label_dict:
-    Tree: 0
+num_classes:
 
 # Pre-processing parameters
 path_to_raster:

--- a/docs/user_guide/13_annotation.md
+++ b/docs/user_guide/13_annotation.md
@@ -129,7 +129,7 @@ from deepforest.visualize import plot_results
 
 PATH_TO_DIR = "/path/to/directory"
 files = glob(f"{PATH_TO_DIR}/*.JPG")
-m = main.deepforest(config_args={"label_dict": {"Bird": 0}})
+m = main.deepforest(config_args={"label_dict": {"Bird": 0}, "num_classes": 1})
 m.load_model(model_name="weecology/deepforest-bird", revision="main")
 
 for path in files:

--- a/docs/user_guide/examples/nest_detection.ipynb
+++ b/docs/user_guide/examples/nest_detection.ipynb
@@ -361,7 +361,7 @@
    "outputs": [],
    "source": [
     "# initialize the model and change the corresponding config file\n",
-    "m = main.deepforest(config_args={\"label_dict\": {\"Nest\": 0}})\n",
+    "m = main.deepforest(config_args={\"label_dict\": {\"Nest\": 0}, \"num_classes\": 1})\n",
     "\n",
     "# move to GPU and use all the GPU resources\n",
     "m.config[\"gpus\"] = \"-1\"\n",

--- a/src/deepforest/conf/config.yaml
+++ b/src/deepforest/conf/config.yaml
@@ -9,7 +9,6 @@ batch_size: 1
 
 # Model Architecture
 architecture: 'retinanet'
-num_classes: 1
 nms_thresh: 0.05
 score_thresh: 0.1
 
@@ -18,8 +17,11 @@ model:
     name: 'weecology/deepforest-tree'
     revision: 'main'
 
+# Specify a label_dict to override model settings.
+# By default, this will be populated from the model
+# checkpoint that is selected in model.name/revision.
 label_dict:
-    Tree: 0
+num_classes:
 
 # Pre-processing parameters
 path_to_raster:

--- a/src/deepforest/conf/schema.py
+++ b/src/deepforest/conf/schema.py
@@ -133,8 +133,8 @@ class Config:
     batch_size: int = 1
 
     architecture: str = "retinanet"
-    num_classes: int = 1
-    label_dict: DictConfig = field(default_factory=lambda: OmegaConf.create({"Tree": 0}))
+    num_classes: int | None = None
+    label_dict: DictConfig | None = field(default_factory=lambda: OmegaConf.create({}))
 
     nms_thresh: float = 0.05
     score_thresh: float = 0.1

--- a/src/deepforest/main.py
+++ b/src/deepforest/main.py
@@ -51,6 +51,7 @@ class deepforest(pl.LightningModule):
             config = utilities.load_config(config_name=config, overrides=config_args)
         # Checkpoint load
         elif isinstance(config, dict):
+            config = OmegaConf.merge(config, config_args or {})
             config = utilities.load_config(overrides=config)
         # Hub overrides
         elif "config_args" in config:
@@ -128,22 +129,8 @@ class deepforest(pl.LightningModule):
             pretrained=model_name, revision=revision
         )
 
-        # Handle label override
-        cfg_labels = self.config.label_dict
-        model_labels = self.model.label_dict
-
-        # If user specified labels, and they differ from the model:
-        if cfg_labels != model_labels:
-            warnings.warn(
-                "Your supplied label dict differs from the model. "
-                "This is expected if you plan to fine-tune this model on your own data.",
-                stacklevel=2,
-            )
-            label_dict = cfg_labels
-        else:
-            label_dict = model_labels
-
-        self.set_labels(label_dict)
+        self.config.num_classes = self.model.num_classes
+        self.set_labels(self.model.label_dict)
 
         return
 
@@ -159,8 +146,7 @@ class deepforest(pl.LightningModule):
                 "Label dictionary not found. Check it was set in your config file or config_args."
             )
 
-        # Label encoder and decoder
-        if not len(label_dict) == self.config.num_classes:
+        if len(label_dict) != self.config.num_classes:
             raise ValueError(
                 f"label_dict {label_dict} does not match requested number of "
                 f"classes {self.config.num_classes}, please supply a label_dict argument "

--- a/src/deepforest/utilities.py
+++ b/src/deepforest/utilities.py
@@ -56,9 +56,15 @@ def load_config(
     base = OmegaConf.structured(StructuredConfig)
     OmegaConf.set_struct(base, strict)
 
-    # Label dict has model-specific keys, so needs to be mutable.
-    # Validated elsewhere
-    OmegaConf.set_struct(base.label_dict, False)
+    # Disable struct mode on nested configs to allow extra fields
+    if not strict:
+        for key in base:
+            value = base[key]
+            if OmegaConf.is_dict(value):
+                OmegaConf.set_struct(value, False)
+    else:
+        # Label dict has model-specific keys, so needs to be mutable even in strict mode
+        OmegaConf.set_struct(base.label_dict, False)
 
     # Load target (potentially derived) config
     yaml_cfg = OmegaConf.load(yaml_path)

--- a/tests/test_detr.py
+++ b/tests/test_detr.py
@@ -52,10 +52,7 @@ def test_check_model(config):
     model.check_model()
 
 
-# The test case "2" currently fails due to a bug in transformers
-# which is fixed in transformers-4.53.0, related to the
-# from_pretrained logic.
-@pytest.mark.parametrize("num_classes", [1, 5, 10])
+@pytest.mark.parametrize("num_classes", [1, 2, 5, 10])
 def test_create_model(config, num_classes):
     """
     Test that we can instantiate a model with differing numbers

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -77,7 +77,8 @@ def test_evaluate_boxes_save_images():
 def test_evaluate_empty(m, tmp_path):
     # Evaluate with an empty model which should return no predictions.
     m = main.deepforest(config_args={"model": {"name": None},
-                                     "log_root": str(tmp_path)})
+                                     "label_dict": {"Tree": 0},
+                                     "num_classes": 1})
     csv_file = get_data("OSBS_029.csv")
     results = m.evaluate(csv_file, iou_threshold=0.4)
 

--- a/tests/test_main_checkpointing.py
+++ b/tests/test_main_checkpointing.py
@@ -1,0 +1,375 @@
+import os
+
+import math
+import pandas as pd
+import pytest
+import shutil
+import torch
+
+from deepforest import get_data, main, utilities
+
+
+@pytest.fixture
+def config(architecture, tmp_path):
+    # Basic from-scratch config for fast tests
+    config = {
+        "architecture": architecture,
+        "model": {"name": None},
+        "num_classes": 1,
+        "label_dict": {"Tree": 0},
+        "train": {
+            "csv_file": get_data("OSBS_029.csv"),
+            "root_dir": os.path.dirname(get_data("OSBS_029.csv")),
+            "epochs": 1,
+            "fast_dev_run": False,  # Required for multi-epoch testing
+            "log_root": str(tmp_path / "logs"),
+        },
+        "validation": {
+            "csv_file": get_data("OSBS_029.csv"),
+            "root_dir": os.path.dirname(get_data("OSBS_029.csv")),
+        },
+    }
+
+    return config
+
+
+def state_dicts_equal(model_a, model_b):
+    """Helper function to compare model state dicts"""
+    state_dict_a = model_a.state_dict()
+    state_dict_b = model_b.state_dict()
+
+    assert state_dict_a.keys() == state_dict_b.keys(), "State dict keys do not match"
+
+    for key in state_dict_a:
+        tensor_a = state_dict_a[key]
+        tensor_b = state_dict_b[key]
+
+        assert torch.equal(tensor_a, tensor_b), f"Mismatch found in key: {key}"
+
+    return True
+
+
+@pytest.mark.parametrize("architecture", ["retinanet", "DeformableDetr"])
+def test_train_reload_checkpoint(config):
+    """Test train and reload checkpoint"""
+
+    m = main.deepforest(config=config)
+
+    # Train and save model
+    m.trainer.fit(m)
+    checkpoint_path = f"{m.config.train.log_root}/pretrain.ckpt"
+    m.save_model(checkpoint_path)
+
+    # Load checkpoint
+    loaded = main.deepforest.load_from_checkpoint(checkpoint_path)
+
+    assert loaded.config.architecture == config["architecture"]
+    os.remove(checkpoint_path)
+
+
+@pytest.mark.parametrize("architecture", ["retinanet", "DeformableDetr"])
+def test_train_and_resume(config):
+    """Test resume training from checkpoint with modified config (typically for continuing training)"""
+
+    m = main.deepforest(config=config)
+
+    # Train and save model
+    m.trainer.fit(m)
+    assert m.trainer.current_epoch == 1
+    checkpoint_path = f"{m.config.train.log_root}/pretrain.ckpt"
+    m.save_model(checkpoint_path)
+
+    # Load checkpoint
+    loaded = main.deepforest.load_from_checkpoint(
+        checkpoint_path, config_args={"train": {"epochs": 3}}
+    )
+    assert loaded.config.train.epochs == 3
+    assert loaded.trainer.max_epochs == 3
+    loaded.trainer.fit(loaded)
+    assert loaded.trainer.current_epoch == 3
+    os.remove(checkpoint_path)
+
+@pytest.mark.parametrize("architecture", ["retinanet", "DeformableDetr"])
+def test_train_fit_ckpt(config):
+    """Test resume directly via fit (typically for interrupted training)"""
+
+    m = main.deepforest(config=config)
+
+    # Train and save model
+    m.trainer.fit(m)
+    assert m.trainer.current_epoch == 1
+    checkpoint_path = f"{m.config.train.log_root}/pretrain.ckpt"
+    m.save_model(checkpoint_path)
+
+    # Load checkpoint
+    m_resume = main.deepforest(config=config, config_args={"train": {"epochs": 3}})
+
+    m_resume.trainer.fit(m_resume, ckpt_path=checkpoint_path)
+    assert m_resume.trainer.current_epoch == 3
+    os.remove(checkpoint_path)
+
+
+@pytest.mark.parametrize("architecture", ["retinanet", "DeformableDetr"])
+def test_pretrain_finetune(config):
+    # Pretrain model
+    pretrain = main.deepforest(config=config)
+    pretrain.trainer.fit(pretrain)
+
+    # Save checkpoint
+    pretrain_checkpoint = f"{pretrain.config.train.log_root}/pretrain.ckpt"
+    pretrain.save_model(pretrain_checkpoint)
+
+    # Fine-tune on "new" data (same data for test)
+    log_dir = str(config["train"]["log_root"]) + "_finetune"
+    finetune = main.deepforest.load_from_checkpoint(
+        pretrain_checkpoint,
+        config_args={
+            "train": {
+                "log_root": log_dir,
+                "epochs": 1,
+            }
+        },
+    )
+    finetune.trainer.fit(finetune)
+    finetune.save_model(f"{log_dir}/finetune.ckpt")
+    assert finetune.config.train.log_root == log_dir
+
+    os.remove(pretrain_checkpoint)
+    os.remove(f"{log_dir}/finetune.ckpt")
+
+
+@pytest.mark.parametrize("architecture", ["retinanet", "DeformableDetr"])
+def test_local_hf_checkpoint(config):
+    """Test loading model.name from local checkpoint path"""
+
+    # Pretrain model
+    pretrain = main.deepforest(config=config)
+    pretrain.trainer.fit(pretrain)
+
+    # Save HF compatible checkpoints
+    pretrain_checkpoint = f"{pretrain.config.train.log_root}/pretrain_ckpt"
+    pretrain.model.save_pretrained(pretrain_checkpoint)
+
+    # Load via model.name
+    config_load = pretrain.config.copy()
+    config_load.model.name = pretrain_checkpoint
+
+    loaded = main.deepforest(config=config_load)
+
+    assert loaded.config.architecture == config["architecture"]
+    assert loaded.config.model.name == pretrain_checkpoint
+
+    shutil.rmtree(pretrain_checkpoint)
+
+@pytest.mark.parametrize("architecture", ["retinanet", "DeformableDetr"])
+def test_checkpoint_label_dict(config, tmp_path, architecture):
+    """Test that the label dict is saved and loaded correctly from a checkpoint"""
+    # Modify config to use a custom label
+    csv_file = get_data("example.csv")
+    df = pd.read_csv(csv_file)
+    df["label"] = "Object"
+    df.to_csv(os.path.join(tmp_path, "example.csv"), index=False)
+
+    config["train"]["csv_file"] = os.path.join(tmp_path, "example.csv")
+    config["train"]["root_dir"] = os.path.dirname(csv_file)
+    config["train"]["fast_dev_run"] = True
+    config["validation"]["csv_file"] = os.path.join(tmp_path, "example.csv")
+    config["validation"]["root_dir"] = os.path.dirname(csv_file)
+    config["label_dict"] = {"Object": 0}
+
+    m = main.deepforest(config=config)
+    m.trainer.fit(m)
+
+    checkpoint_path = f"{tmp_path}/checkpoint.ckpt"
+    m.trainer.save_checkpoint(checkpoint_path)
+    m.model.save_pretrained(os.path.join(tmp_path, "hf_weights"))
+
+    # Load and verify label dicts are preserved
+    loaded = main.deepforest.load_from_checkpoint(checkpoint_path)
+    assert loaded.label_dict == {"Object": 0}
+    del loaded
+
+    loaded_hf = main.deepforest(
+        config={"model": {"name": os.path.join(tmp_path, "hf_weights")},
+                "architecture": architecture}
+    )
+    assert loaded_hf.label_dict == {"Object": 0}
+
+    os.remove(checkpoint_path)
+    shutil.rmtree(os.path.join(tmp_path, "hf_weights"))
+
+# This test requires "good' weights for tree detection
+@pytest.mark.parametrize("architecture", ["retinanet"])
+def test_save_and_reload_checkpoint(config):
+    """Test that predictions are identical after saving and reloading checkpoint"""
+    img_path = get_data(path="2019_YELL_2_528000_4978000_image_crop2.png")
+
+    # Train model
+    config["model"]["name"] = "weecology/deepforest-tree"
+    m = main.deepforest(config=config)
+    m.create_trainer()
+    m.trainer.fit(m)
+    pred_after_train = m.predict_image(path=img_path)
+
+    # Save checkpoint
+    checkpoint_path = f"{m.config.train.log_root}/checkpoint.ckpt"
+    m.save_model(checkpoint_path)
+
+    # Reload and predict
+    loaded = main.deepforest.load_from_checkpoint(
+        checkpoint_path,
+        config_args={
+            "train": {
+                "csv_file": config["train"]["csv_file"],
+                "root_dir": config["train"]["root_dir"],
+            },
+            "validation": {
+                "csv_file": config["validation"]["csv_file"],
+                "root_dir": config["validation"]["root_dir"],
+            },
+        },
+    )
+    pred_after_reload = loaded.predict_image(path=img_path)
+
+    # Verify predictions match
+    assert not pred_after_train.empty
+    assert not pred_after_reload.empty
+    assert m.config == loaded.config
+    assert state_dicts_equal(m.model, loaded.model)
+    pd.testing.assert_frame_equal(pred_after_train, pred_after_reload)
+
+    os.remove(checkpoint_path)
+
+@pytest.mark.parametrize("architecture", ["retinanet", "DeformableDetr"])
+def test_load_from_checkpoint_with_overrides(config):
+    """Test that config_args can override saved config when loading from checkpoint"""
+    # Train and save model
+    m = main.deepforest(config=config)
+    m.trainer.fit(m)
+
+    checkpoint_path = f"{m.config.train.log_root}/pretrain.ckpt"
+    m.save_model(checkpoint_path)
+
+    # Load with config_args overrides
+    new_batch_size = 4
+    new_epochs = 15
+    loaded = main.deepforest.load_from_checkpoint(
+        checkpoint_path,
+        weights_only=True,
+        config_args={"batch_size": new_batch_size,
+                     "score_thresh": 0.9,
+                     "train": {"epochs": new_epochs}},
+    )
+
+    # Verify the overrides were applied
+    assert loaded.config.batch_size == new_batch_size
+    assert loaded.config.train.epochs == new_epochs
+    assert loaded.config.score_thresh != m.config.score_thresh
+    assert loaded.config.score_thresh == 0.9
+    # Verify other config values from checkpoint are preserved
+    assert loaded.config.architecture == config["architecture"]
+
+    os.remove(checkpoint_path)
+
+@pytest.mark.parametrize("architecture", ["retinanet", "DeformableDetr"])
+def test_load_from_checkpoint_with_config_dict(config):
+    """Test that a full config dict can be passed directly when loading from checkpoint"""
+    # Train and save model
+    m = main.deepforest(config=config)
+    m.trainer.fit(m)
+
+    checkpoint_path = f"{m.config.train.log_root}/pretrain.ckpt"
+    m.save_model(checkpoint_path)
+
+    # Create a modified config with different training parameters
+    modified_config = utilities.load_config(
+        overrides={
+            "architecture": config["architecture"],
+            "batch_size": 8,
+            "train": {"epochs": 20},
+            "model": {"name": None},
+            "label_dict": config["label_dict"],
+            "num_classes": config["num_classes"],
+        }
+    )
+
+    # Load with full config dict (as done in CLI)
+    loaded = main.deepforest.load_from_checkpoint(
+        checkpoint_path, weights_only=True, config=modified_config
+    )
+
+    # Verify the config overrides were applied
+    assert loaded.config.batch_size == 8
+    assert loaded.config.train.epochs == 20
+    # Verify architecture is preserved
+    assert loaded.config.architecture == config["architecture"]
+    # Verify label_dict is preserved
+    assert loaded.label_dict == m.label_dict
+    assert loaded.numeric_to_label_dict == m.numeric_to_label_dict
+
+    os.remove(checkpoint_path)
+
+# This test requires "good' weights for tree detection
+@pytest.mark.parametrize("architecture", ["retinanet"])
+def test_save_and_reload_weights(config, tmp_path):
+    """Test saving and loading raw PyTorch state dict"""
+    img_path = get_data(path="2019_YELL_2_528000_4978000_image_crop2.png")
+
+    # Train model
+    config["train"]["fast_dev_run"] = True
+    config["model"]["name"] = "weecology/deepforest-tree"
+    m = main.deepforest(config=config)
+    m.create_trainer()
+    m.trainer.fit(m)
+    pred_after_train = m.predict_image(path=img_path)
+
+    # Save raw state dict
+    weights_path = f"{tmp_path}/weights.pt"
+    torch.save(m.model.state_dict(), weights_path)
+
+    # Create new model and load state dict
+    loaded = main.deepforest(config=config)
+    loaded.model.load_state_dict(torch.load(weights_path, weights_only=True))
+    pred_after_reload = loaded.predict_image(path=img_path)
+
+    # Verify predictions match
+    assert not pred_after_train.empty
+    assert not pred_after_reload.empty
+    pd.testing.assert_frame_equal(pred_after_train, pred_after_reload)
+
+    os.remove(weights_path)
+
+
+@pytest.mark.parametrize("architecture", ["retinanet"])
+def test_reload_multi_class(config, tmp_path):
+    """Test reloading a multi-class model checkpoint"""
+    # Configure for 2 classes with matching data
+    csv_file = get_data("testfile_multi.csv")
+    config["num_classes"] = 2
+    config["label_dict"] = {"Alive": 0, "Dead": 1}
+    config["batch_size"] = 2
+    config["train"]["csv_file"] = csv_file
+    config["train"]["root_dir"] = os.path.dirname(csv_file)
+    config["train"]["fast_dev_run"] = True
+    config["validation"]["csv_file"] = csv_file
+    config["validation"]["root_dir"] = os.path.dirname(csv_file)
+
+    # Train and save
+    m = main.deepforest(config=config)
+    m.trainer.fit(m)
+    checkpoint_path = f"{tmp_path}/checkpoint.ckpt"
+    m.save_model(checkpoint_path)
+    before = m.trainer.validate(m)
+
+    # Reload and validate
+    loaded = main.deepforest.load_from_checkpoint(
+        checkpoint_path,
+        weights_only=True,
+    )
+    assert loaded.config.num_classes == 2
+    loaded.create_trainer()
+    after = loaded.trainer.validate(loaded)
+
+    assert math.isclose(after[0]["val_loss"], before[0]["val_loss"], rel_tol=5e-2, abs_tol=5e-2)
+
+    os.remove(checkpoint_path)

--- a/tests/test_retinanet.py
+++ b/tests/test_retinanet.py
@@ -68,3 +68,20 @@ def test_maintain_parameters(config):
     x = [torch.rand(3, 300, 400), torch.rand(3, 500, 400)]
     predictions = retinanet_model(x)
     assert retinanet_model.score_thresh == 0.9
+
+def test_retinanet_override_class(tmpdir):
+    # Check we correctly override num_classes and label_dict
+    model = retinanet.RetinaNetHub.from_pretrained("weecology/deepforest-tree", num_classes=2, label_dict={"Tree": 0, "Shrub": 1})
+    assert model.label_dict == {"Tree": 0, "Shrub": 1}
+    assert model.head.classification_head.num_classes == 2
+
+    # Confirm it persists when reloading
+    model.save_pretrained(tmpdir)
+    model2 = retinanet.RetinaNetHub.from_pretrained(tmpdir)
+    assert model2.label_dict == {"Tree": 0, "Shrub": 1}
+    assert model2.head.classification_head.num_classes == 2
+
+def test_retinanet_override_class_error():
+    # Mismatch between label_dict and class count
+    with pytest.raises(ValueError):
+        retinanet.RetinaNetHub.from_pretrained("weecology/deepforest-tree", num_classes=1, label_dict={"Tree": 0, "Shrub": 1})


### PR DESCRIPTION
## Description

This PR fixes a some usability issues in config and checkpoint loading.

It adds a more thorough test suite for training, checkpoints, resuming/continuing and pretain/fine-tune workflows. The tests are parametrized over Retinanet and DeformableDETR and I've moved them into a separate file as `test_main` is getting quite long. This is the bulk of the PR in terms of line count, the logic changes are pretty small.

The main changes are:

- `label_dict` and `num_classes` are undefined by default. The model classes will obtain label mappings on load and will populate the config.
- If the user supplies a label_dict, it will override the model if it differs. This is expected for fine-tuning (e.g. tree -> bird). If the label dict matches the loaded model, nothing happens.
- If nothing is passed and the user tries to create a from-scratch model, this will fail. And there are some basic checks for mismatches between num_classes/label_dict. We can probably plan to deprecate num_classes from the config as it's fully defined by label_dict anyway.
- Exposes `save_pretrained` on DeformableDetr. Note that this is the expected way to store models for re-use/distribution as it's a different format to Lightning and is what goes in `model.name` (works locally too). TODO update docs on this.
- The tests include usage of checkpoints (`save_checkpoint()`), HF weights (`save_pretrained`) and check that the correct modified labels are recovered after training. We also have tests for `ckpt_path` on `fit` (resuming interrupted training) and continuing training from `load_checkpoint` which is roughly equivalent.
- Fixes the bug where config_args aren't respected by `load_checkpoint`.

TODO: update docs on best practices for checkpoints.

## Related Issue(s)

https://github.com/weecology/DeepForest/issues/1260
https://github.com/weecology/DeepForest/issues/1246

## AI-Assisted Development

<!-- Be transparent about AI tool usage -->

Claude + GitHub Copilot assisted writing tests and figuring out some of the more obscure features in HuggingFace (e.g. that we need to store model config as `_hub_mixin_config`). The test suite was largely written by hand to try and mimic the kinds of workflows we actually use.

- [X] I used AI tools (e.g., GitHub Copilot, ChatGPT, etc.) in developing this PR
- [X] I understand all the code I'm submitting
- [X] I have reviewed and validated all AI-generated code
