### PR TITLE
Add log root to config and use tmp_path for test logging

### DIFF
--- a/src/deepforest/conf/config.yaml
+++ b/src/deepforest/conf/config.yaml
@@ -29,6 +29,8 @@ annotations_xml:
 rgb_dir:
 path_to_rgb:
 
+log_root: ./
+
 train:
     csv_file:
     root_dir:

--- a/src/deepforest/conf/schema.py
+++ b/src/deepforest/conf/schema.py
@@ -140,6 +140,8 @@ class Config:
     score_thresh: float = 0.1
     model: ModelConfig = field(default_factory=ModelConfig)
 
+    log_root: str = "./"
+
     # Preprocessing
     path_to_raster: str | None = None
     patch_size: int = 400

--- a/src/deepforest/main.py
+++ b/src/deepforest/main.py
@@ -234,6 +234,7 @@ class deepforest(pl.LightningModule):
             "callbacks": callbacks,
             "limit_val_batches": limit_val_batches,
             "num_sanity_val_steps": num_sanity_val_steps,
+            "default_root_dir": self.config.log_root,
         }
         # Update with kwargs to allow them to override config
         trainer_args.update(kwargs)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,10 +35,11 @@ def test_output_dir(tmp_path_factory):
 
 
 @pytest.fixture(scope="session")
-def config():
+def config(tmp_path_factory):
     config = utilities.load_config()
     config.train.fast_dev_run = True
     config.batch_size = 1
+    config.log_root = str(tmp_path_factory.mktemp("logs"))
     return config
 
 
@@ -58,7 +59,7 @@ def ROOT():
 
 
 @pytest.fixture(scope="session")
-def two_class_m():
+def two_class_m(tmp_path_factory):
     m = main.deepforest(config_args={"num_classes": 2, "label_dict": {"Alive": 0, "Dead": 1}})
     m.config.train.csv_file = get_data("testfile_multi.csv")
     m.config.train.root_dir = os.path.dirname(get_data("testfile_multi.csv"))
@@ -67,6 +68,7 @@ def two_class_m():
     m.config.validation.csv_file = get_data("testfile_multi.csv")
     m.config.validation.root_dir = os.path.dirname(get_data("testfile_multi.csv"))
     m.config.validation.val_accuracy_interval = 1
+    m.config.log_root = str(tmp_path_factory.mktemp("logs"))
 
     m.create_trainer()
 
@@ -74,7 +76,7 @@ def two_class_m():
 
 
 @pytest.fixture(scope="session")
-def m(download_release):
+def m(download_release, tmp_path_factory):
     m = main.deepforest()
     m.config.train.csv_file = get_data("example.csv")
     m.config.train.root_dir = os.path.dirname(get_data("example.csv"))
@@ -85,6 +87,7 @@ def m(download_release):
     m.config.workers = 0
     m.config.validation.val_accuracy_interval = 1
     m.config.train.epochs = 2
+    m.config.log_root = str(tmp_path_factory.mktemp("logs"))
 
     m.create_trainer()
     m.load_model("weecology/deepforest-tree")

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -33,7 +33,7 @@ class MockTBLogger(MockCometLogger):
         self._experiment = probe
 
 @pytest.fixture(scope="module")
-def m(download_release):
+def m(download_release, tmp_path_factory):
     m = main.deepforest()
     m.config.train.csv_file = get_data("example.csv")
     m.config.train.root_dir = os.path.dirname(get_data("example.csv"))
@@ -44,6 +44,7 @@ def m(download_release):
     m.config.workers = 0
     m.config.validation.val_accuracy_interval = 1
     m.config.train.epochs = 2
+    m.config.log_root = str(tmp_path_factory.mktemp("logs"))
 
     m.create_trainer()
     m.load_model("weecology/deepforest-tree")

--- a/tests/test_datasets_training.py
+++ b/tests/test_datasets_training.py
@@ -160,9 +160,9 @@ def test_multi_image_warning():
         len(collated_batch[0]) == 2
 
 
-def test_label_validation__training_csv():
+def test_label_validation__training_csv(tmp_path):
     """Test training CSV labels are validated against label_dict"""
-    m = main.deepforest(config_args={"num_classes": 1, "label_dict": {"Bird": 0}})
+    m = main.deepforest(config_args={"num_classes": 1, "label_dict": {"Bird": 0}, "log_root": tmp_path})
     m.config.train.csv_file = get_data("example.csv")  # contains 'Tree' label
     m.config.train.root_dir = os.path.dirname(get_data("example.csv"))
     m.create_trainer()
@@ -173,9 +173,9 @@ def test_label_validation__training_csv():
         m.trainer.fit(m)
 
 
-def test_csv_label_validation__validation_csv(m):
+def test_csv_label_validation__validation_csv(m, tmp_path):
     """Test validation CSV labels are validated against label_dict"""
-    m = main.deepforest(config_args={"num_classes": 1, "label_dict": {"Tree": 0}})
+    m = main.deepforest(config_args={"num_classes": 1, "label_dict": {"Tree": 0}, "log_root": tmp_path})
     m.config.train.csv_file = get_data("example.csv")  # contains 'Tree' label
     m.config.train.root_dir = os.path.dirname(get_data("example.csv"))
     m.config.validation.csv_file = get_data(

--- a/tests/test_detr.py
+++ b/tests/test_detr.py
@@ -13,13 +13,14 @@ from deepforest.models import DeformableDetr
 
 
 @pytest.fixture()
-def config():
+def config(tmp_path_factory):
     config = utilities.load_config()
     config.model.name = "joshvm/milliontrees-detr"
     config.architecture = "DeformableDetr"
     config.train.fast_dev_run = True
     config.batch_size = 1
     config.score_thresh = 0.5
+    config.log_root = str(tmp_path_factory.mktemp("logs"))
     return config
 
 

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -27,7 +27,7 @@ def test_evaluate_image(m):
     assert sum(result["results"].IoU) > 10
 
 
-def test_evaluate_boxes(m, tmpdir):
+def test_evaluate_boxes(m):
     csv_file = get_data("OSBS_029.csv")
     predictions = m.predict_file(csv_file=csv_file, root_dir=os.path.dirname(csv_file))
     predictions.label = "Tree"
@@ -61,7 +61,7 @@ def test_evaluate_boxes_multiclass():
     assert results["class_recall"].shape == (2, 4)
 
 
-def test_evaluate_boxes_save_images(tmpdir):
+def test_evaluate_boxes_save_images():
     csv_file = get_data("testfile_multi.csv")
     ground_truth = read_file(csv_file)
     ground_truth["label"] = ground_truth.label.astype("category").cat.codes
@@ -74,9 +74,10 @@ def test_evaluate_boxes_save_images(tmpdir):
                                       ground_df=ground_truth)
 
 
-def test_evaluate_empty(m):
+def test_evaluate_empty(m, tmp_path):
     # Evaluate with an empty model which should return no predictions.
-    m = main.deepforest(config_args={"model": {"name": None}})
+    m = main.deepforest(config_args={"model": {"name": None},
+                                     "log_root": str(tmp_path)})
     csv_file = get_data("OSBS_029.csv")
     results = m.evaluate(csv_file, iou_threshold=0.4)
 


### PR DESCRIPTION
## Description

Tests currently log to the default Lightning root (`lightning_logs`) which causes a lot of wasted space when testing locally, and also may be causing issues on the CI as the folder isn't cleaned up automatically. This PR makes a couple of changes:

- Add a `log_root` item to the config. This is by default set to `./` and is where lightning will create "lightning_logs". This also has the benefit that users can overwrite this easily.
- Per docs, the default in Lightning is `os.cwd()` so `./` in logs should be equivalent.
- Any time `deepforest.main` is called in tests, set `log_root = tmp_path`. There are a few places outside the fixtures where this is necessary, but modifying the default configs is enough to cover the majority.

## AI-Assisted Development

<!-- Be transparent about AI tool usage -->

- [] I used AI tools (e.g., GitHub Copilot, ChatGPT, etc.) in developing this PR
- [X] I understand all the code I'm submitting
- [] I have reviewed and validated all AI-generated code
