### PR TITLE
Update installation guide with Python compatibility

### DIFF
--- a/docs/getting_started/install.md
+++ b/docs/getting_started/install.md
@@ -2,6 +2,17 @@
 # Installation
 
 DeepForest has Windows, Linux, and macOS prebuilt wheels on PyPI. We *strongly* recommend using uv or a virtualenv to create a clean installation container.
+### Python Version Compatibility
+
+DeepForest relies on several dependencies that may not yet support the latest Python releases.
+
+| Python Version | Status | Notes |
+| :--- | :--- | :--- |
+| **3.10 / 3.11** | **Stable** | **Highly Recommended** |
+| 3.12 | Compatible | Most features work stable. |
+| 3.13 / 3.14+ | Experimental | Known `AST` issues via `docformatter` (see [PyCQA/docformatter#327](https://github.com/PyCQA/docformatter/issues/327)). |
+
+**Recommendation:** If you encounter installation errors on newer Python versions, please use a virtual environment with Python 3.11.
 
 ```bash
 pip install deepforest


### PR DESCRIPTION
I encountered an AttributeError related to AST objects in the untokenize dependency while installing DeepForest on macOS (M4) using Python 3.14.

Signed-off-by: Salih Tangel [salihtangel@gmail.com](mailto:salihtangel@gmail.com)

Description

This PR adds a Python Version Compatibility matrix to the install.md documentation. The goal is to provide clear guidance for users on which Python versions are stable (3.10-3.12) and to warn about experimental versions (3.13+) where certain dependencies like docformatter currently fail due to AST changes in newer Python releases.

Related Issue(s)

No internal issue exists for this in DeepForest, but this change is needed to address installation failures on experimental Python environments. This is related to the known upstream issue: [PyCQA/docformatter#327](https://github.com/PyCQA/docformatter/issues/327).

AI-Assisted Development

[x] I used AI tools (e.g., GitHub Copilot, ChatGPT, etc.) in developing this PR

[x] I understand all the code I'm submitting

[x] I have reviewed and validated all AI-generated code

AI tools used (if applicable):
Google Gemini (Assisted in drafting the compatibility table and structuring the PR description).