### PR TITLE
Replace tmpdir with tmp_path in tests

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -54,7 +54,7 @@ jobs:
         run: uv sync --all-extras --dev
 
       - name: Run pytest with coverage
-        run: uv run pytest -v --cov=src/deepforest --cov-report=xml --cov-report=term-missing
+        run: uv run pytest -v --cov=src/deepforest --cov-report=xml --cov-report=term-missing -o tmp_path_retention=none tests/
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -30,7 +30,7 @@ def test_config_main_empty_config():
     m = main.deepforest(config=None)
     assert m.config.model.name == "weecology/deepforest-tree"
 
-def test_custom_config_file(tmpdir):
+def test_custom_config_file(tmp_path):
     # Verify that we can use a custom config file which overrides the default
     config = {
         'label_dict': {
@@ -38,22 +38,22 @@ def test_custom_config_file(tmpdir):
         }
     }
 
-    config_path = os.path.join(tmpdir, "custom-config.yaml")
+    config_path = tmp_path / "custom-config.yaml"
     with open(config_path, 'w') as fp:
         yaml.dump(config, fp)
 
-    m = main.deepforest(config = config_path)
+    m = main.deepforest(config = str(config_path))
     assert 'foo' in m.config.label_dict
     assert 'Tree' not in m.config.label_dict
 
 
-def test_load_config_missing_field(m, tmpdir):
+def test_load_config_missing_field(m, tmp_path):
     """Test that checkpoints load successfully when they're
     missing fields added to the schema
     """
     # Calling fit/predict etc. is required before save_model
     m.predict_tile(get_data("SOAP_061.png"))
-    checkpoint_path = tmpdir / "checkpoint.pl"
+    checkpoint_path = tmp_path / "checkpoint.pl"
     m.save_model(checkpoint_path)
 
     # Load the checkpoint and remove "batch size"
@@ -66,12 +66,12 @@ def test_load_config_missing_field(m, tmpdir):
     loaded = main.deepforest.load_from_checkpoint(checkpoint_path)
     assert isinstance(loaded.config.batch_size, int)
 
-def test_config_additional_field(m, tmpdir):
+def test_config_additional_field(m, tmp_path):
     """Test that checkpoints with extra fields not in schema still load successfully,
     such as added config items in newer versions of DeepForest.
     """
     m.predict_tile(get_data("SOAP_061.png"))
-    checkpoint_path = tmpdir / "checkpoint.pl"
+    checkpoint_path = tmp_path / "checkpoint.pl"
     m.save_model(checkpoint_path)
 
     # Load the checkpoint and add a field not in the current schema
@@ -94,11 +94,11 @@ def test_strict_mode_rejects_unknown_fields():
     with pytest.raises(omegaconf_errors.ConfigKeyError):
         utilities.load_config(overrides=config_with_unknown_field, strict=True)
 
-def test_load_checkpoint_with_dictconfig(m, tmpdir):
+def test_load_checkpoint_with_dictconfig(m, tmp_path):
     """Test that we can load an older checkpoint with a DictConfig in it.
     """
     m.predict_tile(get_data("SOAP_061.png"))
-    checkpoint_path = tmpdir / "checkpoint.pl"
+    checkpoint_path = tmp_path / "checkpoint.pl"
     m.save_model(checkpoint_path)
 
     # Load the checkpoint and replace the config dict with a DictConfig

--- a/tests/test_crop_model.py
+++ b/tests/test_crop_model.py
@@ -26,7 +26,7 @@ def crop_model():
 
 
 @pytest.fixture()
-def crop_model_data(crop_model, tmpdir):
+def crop_model_data(crop_model, tmp_path):
     df = pd.read_csv(get_data("testfile_multi.csv"))
     boxes = df[['xmin', 'ymin', 'xmax', 'ymax']].values.tolist()
     root_dir = os.path.dirname(get_data("SOAP_061.png"))
@@ -36,7 +36,7 @@ def crop_model_data(crop_model, tmpdir):
                            labels=df.label.values,
                            root_dir=root_dir,
                            images=images,
-                           savedir=tmpdir)
+                           savedir=tmp_path)
 
     return None
 
@@ -56,10 +56,10 @@ def test_crop_model(crop_model):
     val_loss = crop_model.validation_step(val_batch, batch_idx=0)
     assert isinstance(val_loss, torch.Tensor)
 
-def test_crop_model_train(crop_model, tmpdir, crop_model_data):
+def test_crop_model_train(crop_model, tmp_path, crop_model_data):
     # Create a trainer
-    crop_model.create_trainer(fast_dev_run=True, default_root_dir=tmpdir)
-    crop_model.load_from_disk(train_dir=tmpdir, val_dir=tmpdir)
+    crop_model.create_trainer(fast_dev_run=True, default_root_dir=tmp_path)
+    crop_model.load_from_disk(train_dir=tmp_path, val_dir=tmp_path)
 
     # Test training dataloader
     train_loader = crop_model.train_dataloader()
@@ -130,21 +130,22 @@ def test_crop_model_load_checkpoint(tmp_path_factory, crop_model):
         root_dir = os.path.dirname(get_data("SOAP_061.png"))
         images = df.image_path.values
         labels = np.random.randint(0, num_classes, size=len(df)).astype(str)
-        tmpdir = tmp_path_factory.mktemp(f"crop_model_{num_classes}_classes")
+        out_tmp = tmp_path_factory.mktemp(f"num_classes_{num_classes}")
+        crop_data_dir = str(out_tmp)
         crop_model.write_crops(boxes=boxes,
                             labels=labels,
                             root_dir=root_dir,
                             images=images,
-                            savedir=tmpdir)
+                            savedir=crop_data_dir)
 
         # Create initial model and save checkpoint
         crop_model = model.CropModel()
-        crop_model.create_trainer(fast_dev_run=False, limit_train_batches=1, limit_val_batches=1, max_epochs=1, default_root_dir=tmpdir)
-        crop_model.load_from_disk(train_dir=tmpdir, val_dir=tmpdir)
+        crop_model.create_trainer(fast_dev_run=False, limit_train_batches=1, limit_val_batches=1, max_epochs=1, default_root_dir=tmp_path_factory.mktemp("logs"))
+        crop_model.load_from_disk(train_dir=crop_data_dir, val_dir=crop_data_dir)
         # Initialize classification head based on discovered labels
         crop_model.create_model(num_classes=len(crop_model.label_dict))
         crop_model.trainer.fit(crop_model)
-        checkpoint_path = os.path.join(tmpdir, "epoch=0-step=0.ckpt")
+        checkpoint_path = out_tmp.joinpath("epoch=0-step=0.ckpt")
         crop_model.trainer.save_checkpoint(checkpoint_path)
 
         # Load from checkpoint
@@ -190,12 +191,12 @@ def test_expand_bbox_to_square_edge_cases(crop_model):
     result = crop_model.expand_bbox_to_square(bbox, image_width, image_height)
     assert result == expected
 
-def test_crop_model_val_dataset_confusion(tmpdir, crop_model, crop_model_data):
-    crop_model.create_trainer(fast_dev_run=True, default_root_dir=tmpdir)
-    crop_model.load_from_disk(train_dir=tmpdir, val_dir=tmpdir)
+def test_crop_model_val_dataset_confusion(tmp_path, crop_model, crop_model_data):
+    crop_model.create_trainer(fast_dev_run=True, default_root_dir=tmp_path)
+    crop_model.load_from_disk(train_dir=tmp_path, val_dir=tmp_path)
     crop_model.trainer.fit(crop_model)
 
-    crop_model.create_trainer(fast_dev_run=False, default_root_dir=tmpdir)
+    crop_model.create_trainer(fast_dev_run=False, default_root_dir=tmp_path)
     images, labels, predictions = crop_model.val_dataset_confusion(return_images=True)
 
     # There are 37 images in the testfile_multi.csv

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -53,13 +53,13 @@ def mock_arcgis_response_image():
 
 
 @pytest.mark.parametrize("image_name, url, box, params, download_service_name", url_box_pairs)
-def test_download_arcgis_rest(tmpdir, image_name, url, box, params, download_service_name):
+def test_download_arcgis_rest(tmp_path, image_name, url, box, params, download_service_name):
     async def run_test():
         semaphore = asyncio.Semaphore(20)
         limiter = AsyncLimiter(1, 0.05)
         xmin, ymin, xmax, ymax = box
         bbox_crs = "EPSG:4326"  # Assuming WGS84 for bounding box CRS
-        savedir = tmpdir
+        savedir = tmp_path
 
         # Mock network requests to prevent flakes
         with patch("aiohttp.ClientSession.get", side_effect=[mock_arcgis_response_json(), mock_arcgis_response_image()]):
@@ -108,13 +108,13 @@ locations = [
 
 # Parametrize test cases with different locations
 @pytest.mark.parametrize("source, lat0, lon0, lat1, lon1, zoom, save_image, save_dir, image_name", locations)
-def test_download_tile_mapserver(tmpdir, source, lat0, lon0, lat1, lon1, zoom, save_image, save_dir, image_name):
+def test_download_tile_mapserver(tmp_path, source, lat0, lon0, lat1, lon1, zoom, save_image, save_dir, image_name):
     async def run_test():
         semaphore = asyncio.Semaphore(20)
         limiter = AsyncLimiter(1, 0.05)
-        save_path = os.path.join(tmpdir, image_name)
+        save_path = tmp_path / image_name
         await download.download_web_server(semaphore, limiter, source, lat0, lon0, lat1, lon1, zoom, save_image=True,
-                                           save_dir=tmpdir, image_name=image_name)
+                                           save_dir=tmp_path, image_name=image_name)
         try:
             # Check if the image file is saved
             assert os.path.exists(save_path)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -103,8 +103,7 @@ def path():
 
 
 @pytest.fixture()
-def big_file():
-    tmpdir = tempfile.gettempdir()
+def big_file(tmp_path):
     csv_file = get_data("OSBS_029.csv")
     df = pd.read_csv(csv_file)
 
@@ -112,15 +111,15 @@ def big_file():
     for x in range(3):
         img = Image.open("{}/{}".format(os.path.dirname(csv_file),
                                         df.image_path.unique()[0]))
-        cv2.imwrite("{}/{}.png".format(tmpdir, x), np.array(img))
+        cv2.imwrite(str(tmp_path.joinpath("{}.png".format(x))), np.array(img))
         new_df = df.copy()
         new_df.image_path = "{}.png".format(x)
         big_frame.append(new_df)
 
     big_frame = pd.concat(big_frame)
-    big_frame.to_csv("{}/annotations.csv".format(tmpdir))
+    big_frame.to_csv(tmp_path / "annotations.csv")
 
-    return "{}/annotations.csv".format(tmpdir)
+    return str(tmp_path / "annotations.csv")
 
 def state_dicts_equal(model_a, model_b):
     state_dict_a = model_a.state_dict()
@@ -173,7 +172,7 @@ def test_load_model(m):
     assert not boxes.empty
 
 
-def test_train_empty_train_csv(m, tmpdir):
+def test_train_empty_train_csv(m, tmp_path):
     empty_csv = pd.DataFrame({
         "image_path": ["OSBS_029.png", "OSBS_029.tif"],
         "xmin": [0, 10],
@@ -182,13 +181,13 @@ def test_train_empty_train_csv(m, tmpdir):
         "ymax": [0, 30],
         "label": ["Tree", "Tree"]
     })
-    empty_csv.to_csv("{}/empty.csv".format(tmpdir))
-    m.config.train.csv_file = "{}/empty.csv".format(tmpdir)
+    empty_csv.to_csv(tmp_path / "empty.csv")
+    m.config.train.csv_file = str(tmp_path / "empty.csv")
     m.config.batch_size = 2
     m.create_trainer(fast_dev_run=True)
     m.trainer.fit(m)
 
-def test_train_with_empty_validation_csv(m, tmpdir):
+def test_train_with_empty_validation_csv(m, tmp_path):
     empty_csv = pd.DataFrame({
         "image_path": ["OSBS_029.png", "OSBS_029.tif"],
         "xmin": [0, 10],
@@ -197,9 +196,9 @@ def test_train_with_empty_validation_csv(m, tmpdir):
         "ymax": [0, 30],
         "label": ["Tree", "Tree"]
     })
-    empty_csv.to_csv("{}/empty.csv".format(tmpdir))
-    m.config.train.csv_file = "{}/empty.csv".format(tmpdir)
-    m.config.validation.csv_file = "{}/empty.csv".format(tmpdir)
+    empty_csv.to_csv(tmp_path / "empty.csv")
+    m.config.train.csv_file = str(tmp_path / "empty.csv")
+    m.config.validation.csv_file = str(tmp_path / "empty.csv")
     m.config.batch_size = 2
     m.create_trainer(fast_dev_run=True)
     m.trainer.fit(m)
@@ -264,7 +263,7 @@ def test_train_preload_images(m):
     m.trainer.fit(m)
 
 
-def test_train_geometry_column(m, tmpdir):
+def test_train_geometry_column(m, tmp_path):
     """Test that training works with a geometry column from a shapefile"""
 
     # Get the source data
@@ -285,15 +284,15 @@ def test_train_geometry_column(m, tmpdir):
     gdf = gdf[["label", "geometry", "image_path"]]
 
     # Save to temporary shapefile with only a geometry and label column
-    temp_shp = os.path.join(tmpdir, "temp_trees.shp")
+    temp_shp = tmp_path / "temp_trees.shp"
     gdf.to_file(temp_shp)
 
     # Read shapefile using utilities
-    df = read_file(temp_shp, root_dir=os.path.dirname(get_data("OSBS_029.tif")))
-    df.to_csv(os.path.join(tmpdir, "OSBS_029.csv"), index=False)
+    df = read_file(str(temp_shp), root_dir=os.path.dirname(get_data("OSBS_029.tif")))
+    df.to_csv(tmp_path / "OSBS_029.csv", index=False)
 
     # Train model
-    m.config.train.csv_file = os.path.join(tmpdir, "OSBS_029.csv")
+    m.config.train.csv_file = str(tmp_path / "OSBS_029.csv")
     m.config.train.root_dir = os.path.dirname(get_data("OSBS_029.tif"))
     m.create_trainer(fast_dev_run=True)
     m.trainer.fit(m)
@@ -522,7 +521,7 @@ def test_predict_tile_from_array(m, path):
 
     assert not prediction.empty
 
-def test_evaluate(m, tmpdir):
+def test_evaluate(m):
     csv_file = get_data("OSBS_029.csv")
     results = m.evaluate(csv_file, iou_threshold=0.4)
 
@@ -558,18 +557,18 @@ def test_train_callbacks(m):
     trainer.fit(m, train_ds)
 
 
-def test_checkpoint_label_dict(m, tmpdir):
+def test_checkpoint_label_dict(m, tmp_path):
     """Test that the label dict is saved and loaded correctly from a checkpoint."""
     csv_file = get_data("example.csv")
     df = pd.read_csv(csv_file)
     df["label"] = "Object"
 
-    #write to tmpdir
-    df.to_csv(os.path.join(tmpdir, "example.csv"), index=False)
+    #write to temp path
+    df.to_csv(tmp_path / "example.csv", index=False)
 
-    m.config["train"]["csv_file"] = os.path.join(tmpdir, "example.csv")
+    m.config["train"]["csv_file"] = str(tmp_path / "example.csv")
     m.config["train"]["root_dir"] = os.path.dirname(csv_file)
-    m.config["validation"]["csv_file"] = os.path.join(tmpdir, "example.csv")
+    m.config["validation"]["csv_file"] = str(tmp_path / "example.csv")
     m.config["validation"]["root_dir"] = os.path.dirname(csv_file)
 
     m.config.train.fast_dev_run = True
@@ -577,12 +576,12 @@ def test_checkpoint_label_dict(m, tmpdir):
     m.label_dict = {"Object": 0}
     m.numeric_to_label_dict = {0: "Object"}
     m.trainer.fit(m)
-    m.trainer.save_checkpoint("{}/checkpoint.pl".format(tmpdir))
-    after = main.deepforest.load_from_checkpoint("{}/checkpoint.pl".format(tmpdir))
+    m.trainer.save_checkpoint("{}/checkpoint.pl".format(tmp_path))
+    after = main.deepforest.load_from_checkpoint("{}/checkpoint.pl".format(tmp_path))
     assert after.label_dict == {"Object": 0}
     assert after.numeric_to_label_dict == {0: "Object"}
 
-def test_save_and_reload_checkpoint(m, tmpdir):
+def test_save_and_reload_checkpoint(m, tmp_path):
     img_path = get_data(path="2019_YELL_2_528000_4978000_image_crop2.png")
     m.config.train.fast_dev_run = True
     m.create_trainer()
@@ -590,10 +589,10 @@ def test_save_and_reload_checkpoint(m, tmpdir):
     # compare with prediction after reload checkpoint
     m.trainer.fit(m)
     pred_after_train = m.predict_image(path=img_path)
-    m.save_model("{}/checkpoint.pl".format(tmpdir))
+    m.save_model("{}/checkpoint.pl".format(tmp_path))
 
     # reload the checkpoint to model object
-    after = main.deepforest.load_from_checkpoint("{}/checkpoint.pl".format(tmpdir))
+    after = main.deepforest.load_from_checkpoint("{}/checkpoint.pl".format(tmp_path))
     pred_after_reload = after.predict_image(path=img_path)
 
     assert not pred_after_train.empty
@@ -603,7 +602,7 @@ def test_save_and_reload_checkpoint(m, tmpdir):
     pd.testing.assert_frame_equal(pred_after_train, pred_after_reload)
 
 
-def test_save_and_reload_weights(m, tmpdir):
+def test_save_and_reload_weights(m, tmp_path):
     img_path = get_data(path="2019_YELL_2_528000_4978000_image_crop2.png")
     m.config.train.fast_dev_run = True
     m.create_trainer()
@@ -611,27 +610,27 @@ def test_save_and_reload_weights(m, tmpdir):
     # compare with prediction after reload checkpoint
     m.trainer.fit(m)
     pred_after_train = m.predict_image(path=img_path)
-    torch.save(m.model.state_dict(), "{}/checkpoint.pt".format(tmpdir))
+    torch.save(m.model.state_dict(), tmp_path / "checkpoint.pt")
 
     # reload the checkpoint to model object
     after = main.deepforest()
     after.model.load_state_dict(
-        torch.load("{}/checkpoint.pt".format(tmpdir), weights_only=True))
+        torch.load(tmp_path / "checkpoint.pt", weights_only=True))
     pred_after_reload = after.predict_image(path=img_path)
 
     assert not pred_after_train.empty
     assert not pred_after_reload.empty
     pd.testing.assert_frame_equal(pred_after_train, pred_after_reload)
 
-def test_reload_multi_class(two_class_m, tmpdir):
+def test_reload_multi_class(two_class_m, tmp_path):
     two_class_m.config.train.fast_dev_run = True
     two_class_m.create_trainer()
     two_class_m.trainer.fit(two_class_m)
-    two_class_m.save_model("{}/checkpoint.pl".format(tmpdir))
+    two_class_m.save_model(tmp_path / "checkpoint.pl")
     before = two_class_m.trainer.validate(two_class_m)
 
     # reload
-    old_model = main.deepforest.load_from_checkpoint("{}/checkpoint.pl".format(tmpdir),
+    old_model = main.deepforest.load_from_checkpoint(tmp_path / "checkpoint.pl",
                                                      weights_only=True)
     old_model.config = two_class_m.config
     assert old_model.config.num_classes == 2
@@ -680,43 +679,43 @@ def test_config_args(m):
 
 
 @pytest.fixture()
-def existing_loader(m, tmpdir):
+def existing_loader(m, tmp_path):
     # Create dummy loader with a different batch size to assert, we'll need a few more images to assess
     train = pd.read_csv(m.config.train.csv_file)
     train2 = train.copy(deep=True)
     train3 = train.copy(deep=True)
     train2.image_path = train2.image_path + "2"
     train3.image_path = train3.image_path + "3"
-    pd.concat([train, train2, train3]).to_csv("{}/train.csv".format(tmpdir.strpath))
+    pd.concat([train, train2, train3]).to_csv(tmp_path / "train.csv")
 
-    # Copy the new images to the tmpdir
+    # Copy the new images to the temp dir
     train.image_path.unique()
     image_path = train.image_path.unique()[0]
     shutil.copyfile("{}/{}".format(m.config.train.root_dir, image_path),
-                    tmpdir.strpath + "/{}".format(image_path))
+                    tmp_path / "{}".format(image_path))
     shutil.copyfile("{}/{}".format(m.config.train.root_dir, image_path),
-                    tmpdir.strpath + "/{}".format(image_path + "2"))
+                    tmp_path / "{}".format(image_path + "2"))
     shutil.copyfile("{}/{}".format(m.config.train.root_dir, image_path),
-                    tmpdir.strpath + "/{}".format(image_path + "3"))
-    existing_loader = m.load_dataset(csv_file="{}/train.csv".format(tmpdir.strpath),
-                                     root_dir=tmpdir.strpath,
+                    tmp_path / "{}".format(image_path + "3"))
+    existing_loader = m.load_dataset(csv_file=str(tmp_path / "train.csv"),
+                                     root_dir=str(tmp_path),
                                      batch_size=m.config.batch_size + 1)
     return existing_loader
 
 
-def test_load_existing_train_dataloader(m, tmpdir, existing_loader):
+def test_load_existing_train_dataloader(m, tmp_path, existing_loader):
     """Allow the user to optionally create a dataloader outside
     of the DeepForest class, ensure this works for train/val/predict
     """
     # Inspect original for comparison of batch size
-    m.config.train.csv_file = "{}/train.csv".format(tmpdir.strpath)
-    m.config.train.root_dir = tmpdir.strpath
+    m.config.train.csv_file = str(tmp_path / "train.csv")
+    m.config.train.root_dir = str(tmp_path)
     batch = next(iter(m.train_dataloader()))
     assert len(batch[0]) == m.config.batch_size
 
     # Existing train dataloader
-    m.config.train.csv_file = "{}/train.csv".format(tmpdir.strpath)
-    m.config.train.root_dir = tmpdir.strpath
+    m.config.train.csv_file = str(tmp_path / "train.csv")
+    m.config.train.root_dir = str(tmp_path)
     m.existing_train_dataloader = existing_loader
     m.create_trainer(fast_dev_run=True)
     m.trainer.fit(m)
@@ -724,9 +723,9 @@ def test_load_existing_train_dataloader(m, tmpdir, existing_loader):
     assert len(batch[0]) == m.config.batch_size + 1
 
 
-def test_existing_val_dataloader(m, tmpdir, existing_loader):
-    m.config.validation["csv_file"] = "{}/train.csv".format(tmpdir.strpath)
-    m.config.validation["root_dir"] = tmpdir.strpath
+def test_existing_val_dataloader(m, tmp_path, existing_loader):
+    m.config.validation.csv_file = str(tmp_path / "train.csv")
+    m.config.validation.root_dir = str(tmp_path)
     m.existing_val_dataloader = existing_loader
     m.create_trainer()
     m.trainer.validate(m)
@@ -734,7 +733,7 @@ def test_existing_val_dataloader(m, tmpdir, existing_loader):
     assert len(batch[0]) == m.config.batch_size + 1
 
 
-def test_existing_predict_dataloader(m, tmpdir):
+def test_existing_predict_dataloader(m):
     # Predict datasets yield only images
     ds = prediction.TiledRaster(path=get_data("test_tiled.tif"),
                              patch_overlap=0.1,
@@ -973,7 +972,7 @@ def test_batch_inference_consistency(m, path):
     pd.testing.assert_frame_equal(batch_df[["xmin", "ymin", "xmax", "ymax"]], single_df[["xmin", "ymin", "xmax", "ymax"]], check_dtype=False)
 
 
-def test_epoch_evaluation_end(m, tmpdir):
+def test_epoch_evaluation_end(m, tmp_path):
     """Test the epoch evaluation end method by """
     preds = [{
         'boxes': torch.tensor([
@@ -998,12 +997,12 @@ def test_epoch_evaluation_end(m, tmpdir):
     predictions = boxes.copy()
     assert m.iou_metric.compute()["iou"] == 1.0
 
-    # write a csv file to the tmpdir
+    # write a csv file to the temp dir
     boxes["label"] = "Tree"
     m.predictions = [predictions]
-    boxes.to_csv(tmpdir.strpath + "/predictions.csv", index=False)
-    m.config.validation.csv_file = tmpdir.strpath + "/predictions.csv"
-    m.config.validation.root_dir = tmpdir.strpath
+    boxes.to_csv(tmp_path / "predictions.csv", index=False)
+    m.config.validation.csv_file = str(tmp_path / "predictions.csv")
+    m.config.validation.root_dir = str(tmp_path)
 
     results = m.on_validation_epoch_end()
 
@@ -1027,7 +1026,7 @@ def test_epoch_evaluation_end_empty(m):
     m.predictions = [boxes]
     m.on_validation_epoch_end()
 
-def test_empty_frame_accuracy_all_empty_with_predictions(m, tmpdir):
+def test_empty_frame_accuracy_all_empty_with_predictions(m, tmp_path):
     """Test empty frame accuracy when all frames are empty but model predicts objects.
     The accuracy should be 0 since model incorrectly predicts objects in empty frames."""
     # Create ground truth with all empty frames
@@ -1037,8 +1036,8 @@ def test_empty_frame_accuracy_all_empty_with_predictions(m, tmpdir):
     ground_df.drop_duplicates(subset=["image_path"], keep="first", inplace=True)
 
     # Save the ground truth to a temporary file
-    ground_df.to_csv(tmpdir.strpath + "/ground_truth.csv", index=False)
-    m.config.validation["csv_file"] = tmpdir.strpath + "/ground_truth.csv"
+    ground_df.to_csv(tmp_path / "ground_truth.csv", index=False)
+    m.config.validation["csv_file"] = str(tmp_path / "ground_truth.csv")
     m.config.validation["root_dir"] = os.path.dirname(get_data("testfile_deepforest.csv"))
 
     m.create_trainer()
@@ -1048,7 +1047,7 @@ def test_empty_frame_accuracy_all_empty_with_predictions(m, tmpdir):
     assert results[0]["empty_frame_accuracy"] == 0.0
     assert results[0]["box_precision"] == 0.0
 
-def test_empty_frame_accuracy_mixed_frames_with_predictions(m, tmpdir):
+def test_empty_frame_accuracy_mixed_frames_with_predictions(m, tmp_path):
     """Test empty frame accuracy with a mix of empty and non-empty frames.
     Model predicts objects in all frames, so accuracy for empty frames should be 0."""
     # Create ground truth with mix of empty and non-empty frames
@@ -1065,8 +1064,8 @@ def test_empty_frame_accuracy_mixed_frames_with_predictions(m, tmpdir):
     ground_df = pd.concat([tree_ground_df, empty_ground_df])
 
     # Save the ground truth to a temporary file
-    ground_df.to_csv(tmpdir.strpath + "/ground_truth.csv", index=False)
-    m.config.validation.csv_file = tmpdir.strpath + "/ground_truth.csv"
+    ground_df.to_csv(tmp_path / "ground_truth.csv", index=False)
+    m.config.validation.csv_file = str(tmp_path / "ground_truth.csv")
     m.config.validation.root_dir = os.path.dirname(get_data("testfile_deepforest.csv"))
     m.config.validation.size = 400
 
@@ -1074,7 +1073,7 @@ def test_empty_frame_accuracy_mixed_frames_with_predictions(m, tmpdir):
     results = m.trainer.validate(m)
     assert results[0]["empty_frame_accuracy"] == 0
 
-def test_empty_frame_accuracy_without_predictions(m_without_release, tmpdir):
+def test_empty_frame_accuracy_without_predictions(m_without_release, tmp_path):
     """Create a ground truth with empty frames, the accuracy should be 1 with a random model"""
     m = m_without_release
 
@@ -1085,15 +1084,15 @@ def test_empty_frame_accuracy_without_predictions(m_without_release, tmpdir):
     ground_df.drop_duplicates(subset=["image_path"], keep="first", inplace=True)
 
     # Save the ground truth to a temporary file
-    ground_df.to_csv(tmpdir.strpath + "/ground_truth.csv", index=False)
-    m.config.validation["csv_file"] = tmpdir.strpath + "/ground_truth.csv"
+    ground_df.to_csv(tmp_path / "ground_truth.csv", index=False)
+    m.config.validation["csv_file"] = str(tmp_path / "ground_truth.csv")
     m.config.validation["root_dir"] = os.path.dirname(get_data("testfile_deepforest.csv"))
 
     m.create_trainer()
     results = m.trainer.validate(m)
     assert results[0]["empty_frame_accuracy"] == 1
 
-def test_multi_class_with_empty_frame_accuracy_without_predictions(two_class_m, tmpdir):
+def test_multi_class_with_empty_frame_accuracy_without_predictions(two_class_m, tmp_path):
     """Create a ground truth with empty frames, the accuracy should be 1 with a random model"""
     # Create ground truth with empty frames
     ground_df = pd.read_csv(get_data("testfile_deepforest.csv"))
@@ -1107,8 +1106,8 @@ def test_multi_class_with_empty_frame_accuracy_without_predictions(two_class_m, 
     ground_df = pd.concat([ground_df, multi_class_df])
 
     # Save the ground truth to a temporary file
-    ground_df.to_csv(tmpdir.strpath + "/ground_truth.csv", index=False)
-    two_class_m.config.validation["csv_file"] = tmpdir.strpath + "/ground_truth.csv"
+    ground_df.to_csv(tmp_path / "ground_truth.csv", index=False)
+    two_class_m.config.validation["csv_file"] = str(tmp_path / "ground_truth.csv")
     two_class_m.config.validation["root_dir"] = os.path.dirname(get_data("testfile_deepforest.csv"))
 
     two_class_m.create_trainer()

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -68,12 +68,12 @@ def test_select_annotations(config, image):
 
 
 @pytest.mark.parametrize("input_type", ["path", "dataframe"])
-def test_split_raster(config, tmpdir, input_type, geodataframe):
+def test_split_raster(config, tmp_path, input_type, geodataframe):
     """Split raster into crops with overlaps to maintain all annotations"""
     raster = get_data("2019_YELL_2_528000_4978000_image_crop2.png")
     annotations = utilities.read_pascal_voc(
         get_data("2019_YELL_2_528000_4978000_image_crop2.xml"))
-    annotations.to_csv("{}/example.csv".format(tmpdir), index=False)
+    annotations.to_csv(tmp_path / "example.csv", index=False)
 
     if input_type == "path":
         annotations_file = get_data("OSBS_029.csv")
@@ -82,7 +82,7 @@ def test_split_raster(config, tmpdir, input_type, geodataframe):
 
     output_annotations = preprocess.split_raster(path_to_raster=get_data("OSBS_029.tif"),
                                                  annotations_file=annotations_file,
-                                                 save_dir=tmpdir,
+                                                 save_dir=tmp_path,
                                                  patch_size=300,
                                                  patch_overlap=0)
 
@@ -90,12 +90,12 @@ def test_split_raster(config, tmpdir, input_type, geodataframe):
     assert output_annotations.shape[1] == 7
     assert not output_annotations.empty
 
-def test_split_raster_from_pd_dataframe(tmpdir):
+def test_split_raster_from_pd_dataframe(tmp_path):
     """Split raster into crops with overlaps to maintain all annotations"""
     annotations_file = pd.read_csv(get_data("OSBS_029.csv"))
     output_annotations = preprocess.split_raster(path_to_raster=get_data("OSBS_029.tif"),
                                                  annotations_file=annotations_file,
-                                                 save_dir=tmpdir,
+                                                 save_dir=tmp_path,
                                                  root_dir=os.path.dirname(get_data("OSBS_029.tif")),
                                                  patch_size=300,
                                                  patch_overlap=0)
@@ -104,13 +104,13 @@ def test_split_raster_from_pd_dataframe(tmpdir):
     assert output_annotations.shape[1] == 7
     assert not output_annotations.empty
 
-def test_split_raster_no_annotations(config, tmpdir):
+def test_split_raster_no_annotations(config, tmp_path):
     """Split raster into crops with overlaps to maintain all annotations"""
     raster = get_data("2019_YELL_2_528000_4978000_image_crop2.png")
 
     output_crops = preprocess.split_raster(path_to_raster=raster,
                                            annotations_file=None,
-                                           save_dir=tmpdir,
+                                           save_dir=tmp_path,
                                            patch_size=500,
                                            patch_overlap=0)
 
@@ -122,12 +122,12 @@ def test_split_raster_no_annotations(config, tmpdir):
         assert os.path.exists(crop)
 
 
-def test_split_raster_from_image(config, tmpdir, geodataframe):
+def test_split_raster_from_image(config, tmp_path, geodataframe):
     r = rasterio.open(config.path_to_raster).read()
     r = np.rollaxis(r, 0, 3)
     annotations_file = preprocess.split_raster(numpy_image=r,
                                                annotations_file=geodataframe,
-                                               save_dir=tmpdir,
+                                               save_dir=tmp_path,
                                                patch_size=config.patch_size,
                                                patch_overlap=config.patch_overlap,
                                                image_name="OSBS_029.tif")
@@ -136,7 +136,7 @@ def test_split_raster_from_image(config, tmpdir, geodataframe):
 
 
 @pytest.mark.parametrize("allow_empty", [True, False])
-def test_split_raster_empty(tmpdir, config, allow_empty):
+def test_split_raster_empty(tmp_path, config, allow_empty):
     # Blank annotations file
     blank_annotations = pd.DataFrame({
         "image_path": "OSBS_029.tif",
@@ -146,23 +146,23 @@ def test_split_raster_empty(tmpdir, config, allow_empty):
         "ymax": [0],
         "label": ["Tree"]
     })
-    blank_annotations.to_csv(tmpdir.join("blank_annotations.csv").strpath, index=False)
+    blank_annotations.to_csv(tmp_path / "blank_annotations.csv", index=False)
 
     # Ignore blanks
     if not allow_empty:
         with pytest.raises(ValueError):
             annotations_file = preprocess.split_raster(
                 path_to_raster=config.path_to_raster,
-                annotations_file=tmpdir.join("blank_annotations.csv").strpath,
-                save_dir=tmpdir,
+                annotations_file=str(tmp_path / "blank_annotations.csv"),
+                save_dir=tmp_path,
                 patch_size=config.patch_size,
                 patch_overlap=config.patch_overlap,
                 allow_empty=allow_empty)
     else:
         annotations_file = preprocess.split_raster(
             path_to_raster=config.path_to_raster,
-            annotations_file=tmpdir.join("blank_annotations.csv").strpath,
-            save_dir=tmpdir,
+            annotations_file=str(tmp_path / "blank_annotations.csv"),
+            save_dir=tmp_path,
             patch_size=config.patch_size,
             patch_overlap=config.patch_overlap,
             allow_empty=allow_empty)
@@ -171,21 +171,21 @@ def test_split_raster_empty(tmpdir, config, allow_empty):
         assert annotations_file["ymin"].sum() == 0
         assert annotations_file["xmax"].sum() == 0
         assert annotations_file["ymax"].sum() == 0
-        assert tmpdir.join("OSBS_029_1.png").exists()
+        assert (tmp_path / "OSBS_029_1.png").exists()
 
 
-def test_split_size_error(config, tmpdir, geodataframe):
+def test_split_size_error(config, tmp_path, geodataframe):
     with pytest.raises(ValueError):
         annotations_file = preprocess.split_raster(
             path_to_raster=config.path_to_raster,
             annotations_file=geodataframe,
-            save_dir=tmpdir,
+            save_dir=tmp_path,
             patch_size=2000,
             patch_overlap=config.patch_overlap)
 
 
 @pytest.mark.parametrize("orders", [(4, 400, 400), (400, 400, 4)])
-def test_split_raster_4_band_warns(config, tmpdir, orders, geodataframe):
+def test_split_raster_4_band_warns(config, tmp_path, orders, geodataframe):
     """Test rasterio channel order
     (400, 400, 4) C x H x W
     (4, 400, 400) wrong channel order, H x W x C
@@ -198,14 +198,14 @@ def test_split_raster_4_band_warns(config, tmpdir, orders, geodataframe):
     with pytest.warns(UserWarning):
         preprocess.split_raster(numpy_image=numpy_image,
                                 annotations_file=geodataframe,
-                                save_dir=tmpdir,
+                                save_dir=tmp_path,
                                 patch_size=config.patch_size,
                                 patch_overlap=config.patch_overlap,
                                 image_name="OSBS_029.tif")
 
 
 # Test split_raster with point annotations file
-def test_split_raster_with_point_annotations(tmpdir, config):
+def test_split_raster_with_point_annotations(tmp_path, config):
     # Create a temporary point annotations file
     annotations = pd.DataFrame({
         "image_path": ["OSBS_029.tif", "OSBS_029.tif"],
@@ -213,20 +213,20 @@ def test_split_raster_with_point_annotations(tmpdir, config):
         "y": [100, 200],
         "label": ["Tree", "Tree"]
     })
-    annotations_file = tmpdir.join("point_annotations.csv")
+    annotations_file = str(tmp_path / "point_annotations.csv")
     annotations.to_csv(annotations_file, index=False)
 
     # Call split_raster function
-    preprocess.split_raster(annotations_file=annotations_file.strpath,
+    preprocess.split_raster(annotations_file=annotations_file,
                             path_to_raster=config.path_to_raster,
-                            save_dir=tmpdir)
+                            save_dir=tmp_path)
 
     # Assert that the output annotations file is created
-    assert tmpdir.join("OSBS_029_0.png").exists()
+    assert (tmp_path / "OSBS_029_0.png").exists()
 
 
 # Test split_raster with box annotations file
-def test_split_raster_with_box_annotations(tmpdir, config):
+def test_split_raster_with_box_annotations(tmp_path, config):
     # Create a temporary box annotations file
     annotations = pd.DataFrame({
         "image_path": ["OSBS_029.tif", "OSBS_029.tif"],
@@ -236,20 +236,20 @@ def test_split_raster_with_box_annotations(tmpdir, config):
         "ymax": [200, 300],
         "label": ["Tree", "Tree"]
     })
-    annotations_file = tmpdir.join("box_annotations.csv")
+    annotations_file = str(tmp_path / "box_annotations.csv")
     annotations.to_csv(annotations_file, index=False)
 
     # Call split_raster function
-    preprocess.split_raster(annotations_file=annotations_file.strpath,
+    preprocess.split_raster(annotations_file=annotations_file,
                             path_to_raster=config.path_to_raster,
-                            save_dir=tmpdir)
+                            save_dir=tmp_path)
 
     # Assert that the output annotations file is created
-    assert tmpdir.join("OSBS_029_0.png").exists()
+    assert (tmp_path / "OSBS_029_0.png").exists()
 
 
 # Test split_raster with polygon annotations file
-def test_split_raster_with_polygon_annotations(tmpdir, config):
+def test_split_raster_with_polygon_annotations(tmp_path, config):
     # Create a temporary polygon annotations file with a polygon in WKT format
     sample_geometry = [
         geometry.Polygon([(0, 0), (0, 2), (1, 1), (1, 0), (0, 0)]),
@@ -260,21 +260,21 @@ def test_split_raster_with_polygon_annotations(tmpdir, config):
         "polygon": [sample_geometry[0].wkt, sample_geometry[1].wkt],
         "label": ["Tree", "Tree"]
     })
-    annotations_file = tmpdir.join("polygon_annotations.csv")
+    annotations_file = str(tmp_path / "polygon_annotations.csv")
     annotations.to_csv(annotations_file, index=False)
 
     # Call split_raster function
-    split_annotations = preprocess.split_raster(annotations_file=annotations_file.strpath,
+    split_annotations = preprocess.split_raster(annotations_file=annotations_file,
                                                 path_to_raster=config.path_to_raster,
-                                                save_dir=tmpdir)
+                                                save_dir=tmp_path)
 
     assert not split_annotations.empty
 
     # Assert that the output annotations file is created
-    assert tmpdir.join("OSBS_029_0.png").exists()
+    assert (tmp_path / "OSBS_029_0.png").exists()
 
 
-def test_split_raster_points_translate_and_bounds(tmpdir):
+def test_split_raster_points_translate_and_bounds(tmp_path):
     """Ensure split_raster keeps point geometry, translates to window coords,
     preserves count, and points lie within patch window when patch_overlap=0."""
     path_to_raster = get_data("OSBS_029.tif")
@@ -287,14 +287,14 @@ def test_split_raster_points_translate_and_bounds(tmpdir):
             "label": ["Tree", "Tree"],
         }
     )
-    csv_path = tmpdir.join("point_ann.csv").strpath
+    csv_path = str(tmp_path / "point_ann.csv")
     df.to_csv(csv_path, index=False)
 
     # Split with no overlap
     split_df = preprocess.split_raster(
         annotations_file=csv_path,
         path_to_raster=path_to_raster,
-        save_dir=tmpdir,
+        save_dir=tmp_path,
         patch_size=300,
         patch_overlap=0,
     )
@@ -313,7 +313,7 @@ def test_split_raster_points_translate_and_bounds(tmpdir):
     assert (split_df.geometry.y <= 300).all()
 
 
-def test_split_raster_from_csv(tmpdir):
+def test_split_raster_from_csv(tmp_path):
     """Read in annotations, convert to a projected shapefile, read back in and crop,
     the output annotations should still be maintained in logical place"""
     annotations = get_data("2018_SJER_3_252000_4107000_image_477.csv")
@@ -322,24 +322,24 @@ def test_split_raster_from_csv(tmpdir):
     # Check original data
     split_annotations = preprocess.split_raster(annotations_file=annotations,
                                                 path_to_raster=path_to_raster,
-                                                save_dir=tmpdir,
+                                                save_dir=tmp_path,
                                                 root_dir=os.path.dirname(path_to_raster),
                                                 patch_size=300)
     assert not split_annotations.empty
 
 
-def test_split_raster_from_shp(tmpdir):
+def test_split_raster_from_shp(tmp_path):
     annotations = get_data("2018_SJER_3_252000_4107000_image_477.csv")
     path_to_raster = get_data("2018_SJER_3_252000_4107000_image_477.tif")
     gdf = utilities.read_file(annotations)
     geo_coords = utilities.image_to_geo_coordinates(gdf)
-    annotations_file = tmpdir.join("projected_annotations.shp").strpath
+    annotations_file = str(tmp_path / "projected_annotations.shp")
     geo_coords.to_file(annotations_file)
 
     # Call split_raster function
     split_annotations = preprocess.split_raster(annotations_file=annotations_file,
                                                 path_to_raster=path_to_raster,
-                                                save_dir=tmpdir,
+                                                save_dir=tmp_path,
                                                 root_dir=os.path.dirname(path_to_raster),
                                                 patch_size=300)
 

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -41,7 +41,7 @@ def test_float_warning(config):
     assert annotations.xmin.dtype is np.dtype('int64')
 
 
-def test_read_file(tmpdir):
+def test_read_file(tmp_path):
     sample_geometry = [geometry.Point(404211.9 + 10, 3285102 + 20), geometry.Point(404211.9 + 20, 3285102 + 20)]
     labels = ["Tree", "Tree"]
     df = pd.DataFrame({"geometry": sample_geometry, "label": labels})
@@ -49,8 +49,8 @@ def test_read_file(tmpdir):
     gdf["geometry"] = [geometry.box(left, bottom, right, top) for left, bottom, right, top in
                        gdf.geometry.buffer(0.5).bounds.values]
     gdf["image_path"] = os.path.basename(get_data("OSBS_029.tif"))
-    gdf.to_file("{}/annotations.shp".format(tmpdir))
-    shp = utilities.read_file(input="{}/annotations.shp".format(tmpdir), root_dir=os.path.dirname(get_data("OSBS_029.tif")))
+    gdf.to_file(tmp_path / "annotations.shp")
+    shp = utilities.read_file(input=str(tmp_path / "annotations.shp"), root_dir=os.path.dirname(get_data("OSBS_029.tif")))
 
     assert shp.shape[0] == 2
     assert "image_path" in shp.columns
@@ -58,7 +58,7 @@ def test_read_file(tmpdir):
     assert hasattr(shp, "root_dir")
 
 
-def test_read_file_multiple_images(tmpdir):
+def test_read_file_multiple_images(tmp_path):
     sample_geometry = [geometry.Point(404211.9 + 10, 3285102 + 20), geometry.Point(404211.9 + 20, 3285102 + 20)]
     labels = ["Tree", "Tree"]
     df = pd.DataFrame({"geometry": sample_geometry, "label": labels})
@@ -66,8 +66,8 @@ def test_read_file_multiple_images(tmpdir):
     gdf["geometry"] = [geometry.box(left, bottom, right, top) for left, bottom, right, top in
                        gdf.geometry.buffer(0.5).bounds.values]
     gdf["image_path"] = [os.path.basename(get_data("OSBS_029.tif")), os.path.basename(get_data("2018_SJER_3_252000_4107000_image_477.tif"))]
-    gdf.to_file("{}/annotations.shp".format(tmpdir))
-    shp = utilities.read_file(input="{}/annotations.shp".format(tmpdir), root_dir=os.path.dirname(get_data("OSBS_029.tif")))
+    gdf.to_file(tmp_path / "annotations.shp")
+    shp = utilities.read_file(input=str(tmp_path / "annotations.shp"), root_dir=os.path.dirname(get_data("OSBS_029.tif")))
 
     assert shp.shape[0] == 2
     assert "image_path" in shp.columns
@@ -127,28 +127,26 @@ def test_read_file_in_memory_dataframe():
     assert result.root_dir == os.path.dirname(get_data("OSBS_029.tif"))
 
 
-def test_convert_point_to_bbox(tmpdir):
+def test_convert_point_to_bbox():
     sample_geometry = [geometry.Point(10, 20), geometry.Point(20, 40)]
     labels = ["Tree", "Tree"]
     df = pd.DataFrame({"geometry": sample_geometry, "label": labels})
     gdf = gpd.GeoDataFrame(df, geometry="geometry")
-    gdf.to_file("{}/annotations.shp".format(tmpdir))
-    image_path = get_data("OSBS_029.png")
     shp = utilities.convert_point_to_bbox(gdf=gdf, buffer_size=10)
     assert shp.shape[0] == 2
 
 
-def test_read_file_shapefile_without_image_path(tmpdir):
+def test_read_file_shapefile_without_image_path(tmp_path):
     # Create a shapefile with no image_path or label columns
     sample_geometry = [geometry.Point(10, 20), geometry.Point(20, 40)]
     df = pd.DataFrame({"geometry": sample_geometry})
     gdf = gpd.GeoDataFrame(df, geometry="geometry")
-    shp_path = "{}/annotations_no_image_label.shp".format(tmpdir)
+    shp_path = tmp_path / "annotations_no_image_label.shp"
     gdf.to_file(shp_path)
 
     # Provide image_path and label via read_file to fill missing columns
     rgb = os.path.basename(get_data("OSBS_029.png"))
-    result = utilities.read_file(input=shp_path, image_path=rgb,label="Tree", root_dir=os.path.dirname(get_data("OSBS_029.png")))
+    result = utilities.read_file(input=str(shp_path), image_path=rgb,label="Tree", root_dir=os.path.dirname(get_data("OSBS_029.png")))
 
     assert result.shape[0] == 2
     # image_path should be taken from the provided rgb_path
@@ -157,19 +155,18 @@ def test_read_file_shapefile_without_image_path(tmpdir):
     assert "label" in result.columns
     assert hasattr(result, "root_dir")
 
-def test_shapefile_to_annotations_invalid_epsg(tmpdir):
+def test_shapefile_to_annotations_invalid_epsg(tmp_path):
     sample_geometry = [geometry.Point(404211.9 + 10, 3285102 + 20), geometry.Point(404211.9 + 20, 3285102 + 20)]
     labels = ["Tree", "Tree"]
     df = pd.DataFrame({"geometry": sample_geometry, "label": labels})
     gdf = gpd.GeoDataFrame(df, geometry="geometry", crs="EPSG:4326")
-    gdf.to_file("{}/annotations.shp".format(tmpdir))
+    gdf.to_file(tmp_path / "annotations.shp")
     assert gdf.crs.to_string() == "EPSG:4326"
     image_path = get_data("OSBS_029.tif")
     with pytest.raises(ValueError):
-        shp = utilities.read_file(input="{}/annotations.shp".format(tmpdir), image_path=image_path)
+        _ = utilities.read_file(input=str(tmp_path / "annotations.shp"), image_path=image_path)
 
-
-def test_read_file_boxes_projected(tmpdir):
+def test_read_file_boxes_projected(tmp_path):
     sample_geometry = [geometry.Point(404211.9 + 10, 3285102 + 20), geometry.Point(404211.9 + 20, 3285102 + 20)]
     labels = ["Tree", "Tree"]
     df = pd.DataFrame({"geometry": sample_geometry, "label": labels})
@@ -178,24 +175,24 @@ def test_read_file_boxes_projected(tmpdir):
                        gdf.geometry.buffer(0.5).bounds.values]
     image_path = get_data("OSBS_029.tif")
     gdf["image_path"] = os.path.basename(image_path)
-    gdf.to_file("{}/test_read_file_boxes_projected.shp".format(tmpdir))
+    gdf.to_file(tmp_path / "test_read_file_boxes_projected.shp")
     image_path = get_data("OSBS_029.tif")
 
-    shp = utilities.read_file(input="{}/test_read_file_boxes_projected.shp".format(tmpdir), root_dir=os.path.dirname(get_data("OSBS_029.tif")))
+    shp = utilities.read_file(input=str(tmp_path / "test_read_file_boxes_projected.shp"), root_dir=os.path.dirname(get_data("OSBS_029.tif")))
     assert shp.shape[0] == 2
     assert "image_path" in shp.columns
     assert "label" in shp.columns
     assert hasattr(shp, "root_dir")
 
 
-def test_read_file_points_csv(tmpdir):
+def test_read_file_points_csv(tmp_path):
     x = [10, 20]
     y = [20, 20]
     labels = ["Tree", "Tree"]
     image_path = [os.path.basename(get_data("OSBS_029.tif")), os.path.basename(get_data("OSBS_029.tif"))]
     df = pd.DataFrame({"x": x, "y": y, "label": labels, "image_path": image_path})
-    df.to_csv("{}/test_read_file_points.csv".format(tmpdir), index=False)
-    read_df = utilities.read_file(input="{}/test_read_file_points.csv".format(tmpdir), root_dir=os.path.dirname(get_data("OSBS_029.tif")))
+    df.to_csv(tmp_path / "test_read_file_points.csv", index=False)
+    read_df = utilities.read_file(input=str(tmp_path / "test_read_file_points.csv"), root_dir=os.path.dirname(get_data("OSBS_029.tif")))
 
     assert read_df.shape[0] == 2
     assert "image_path" in read_df.columns
@@ -203,7 +200,7 @@ def test_read_file_points_csv(tmpdir):
     assert hasattr(read_df, "root_dir")
 
 
-def test_read_file_polygons_csv(tmpdir):
+def test_read_file_polygons_csv(tmp_path):
     # Create a sample GeoDataFrame with polygon geometries with 6 points
     sample_geometry = [geometry.Polygon([(0, 0), (0, 2), (1, 1), (1, 0), (0, 0)]),
                        geometry.Polygon([(2, 2), (2, 4), (3, 3), (3, 2), (2, 2)])]
@@ -211,10 +208,10 @@ def test_read_file_polygons_csv(tmpdir):
     labels = ["Tree", "Tree"]
     image_path = os.path.basename(get_data("OSBS_029.png"))
     df = pd.DataFrame({"geometry": sample_geometry, "label": labels, "image_path": os.path.basename(image_path)})
-    df.to_csv("{}/test_read_file_polygons.csv".format(tmpdir), index=False)
+    df.to_csv(tmp_path / "test_read_file_polygons.csv", index=False)
 
     # Call the function under test
-    annotations = utilities.read_file(input="{}/test_read_file_polygons.csv".format(tmpdir), root_dir=os.path.dirname(get_data("OSBS_029.tif")))
+    annotations = utilities.read_file(input=str(tmp_path / "test_read_file_polygons.csv"), root_dir=os.path.dirname(get_data("OSBS_029.tif")))
 
     # Assert the expected number of annotations
     assert annotations.shape[0] == 2
@@ -224,7 +221,7 @@ def test_read_file_polygons_csv(tmpdir):
     assert hasattr(annotations, "root_dir")
 
 
-def test_read_file_polygons_projected(tmpdir):
+def test_read_file_polygons_projected(tmp_path):
     sample_geometry = [geometry.Point(404211.9 + 10, 3285102 + 20), geometry.Point(404211.9 + 20, 3285102 + 20)]
     labels = ["Tree", "Tree"]
     df = pd.DataFrame({"geometry": sample_geometry, "label": labels})
@@ -233,8 +230,8 @@ def test_read_file_polygons_projected(tmpdir):
                        left, bottom, right, top in gdf.geometry.buffer(0.5).bounds.values]
     image_path = get_data("OSBS_029.tif")
     gdf["image_path"] = os.path.basename(image_path)
-    gdf.to_file("{}/test_read_file_polygons_projected.shp".format(tmpdir))
-    shp = utilities.read_file(input="{}/test_read_file_polygons_projected.shp".format(tmpdir), root_dir=os.path.dirname(get_data("OSBS_029.tif")))
+    gdf.to_file(tmp_path / "test_read_file_polygons_projected.shp")
+    shp = utilities.read_file(input=str(tmp_path / "test_read_file_polygons_projected.shp"), root_dir=os.path.dirname(get_data("OSBS_029.tif")))
 
     assert shp.shape[0] == 2
     assert "image_path" in shp.columns
@@ -242,15 +239,15 @@ def test_read_file_polygons_projected(tmpdir):
     assert hasattr(shp, "root_dir")
 
 
-def test_read_file_points_projected(tmpdir):
+def test_read_file_points_projected(tmp_path):
     sample_geometry = [geometry.Point(404211.9 + 10, 3285102 + 20), geometry.Point(404211.9 + 20, 3285102 + 20)]
     labels = ["Tree", "Tree"]
     df = pd.DataFrame({"geometry": sample_geometry, "label": labels})
     gdf = gpd.GeoDataFrame(df, geometry="geometry", crs="EPSG:32617")
     image_path = get_data("OSBS_029.tif")
     gdf["image_path"] = os.path.basename(image_path)
-    gdf.to_file("{}/test_read_file_points_projected.shp".format(tmpdir))
-    shp = utilities.read_file(input="{}/test_read_file_points_projected.shp".format(tmpdir), root_dir=os.path.dirname(get_data("OSBS_029.tif")))
+    gdf.to_file(tmp_path / "test_read_file_points_projected.shp")
+    shp = utilities.read_file(input=str(tmp_path / "test_read_file_points_projected.shp"), root_dir=os.path.dirname(get_data("OSBS_029.tif")))
 
     assert shp.shape[0] == 2
     assert shp.geometry.iloc[0].type == "Point"
@@ -259,7 +256,7 @@ def test_read_file_points_projected(tmpdir):
     assert hasattr(shp, "root_dir")
 
 
-def test_read_file_boxes_unprojected(tmpdir):
+def test_read_file_boxes_unprojected(tmp_path):
     # Create a sample GeoDataFrame with box geometries
     sample_geometry = [geometry.box(0, 0, 1, 1), geometry.box(2, 2, 3, 3)]
     labels = ["Tree", "Tree"]
@@ -267,8 +264,8 @@ def test_read_file_boxes_unprojected(tmpdir):
     gdf = gpd.GeoDataFrame(df, geometry="geometry")
     image_path = get_data("OSBS_029.png")
     gdf["image_path"] = os.path.basename(image_path)
-    gdf.to_file("{}/test_read_file_boxes_unprojected.shp".format(tmpdir))
-    annotations = utilities.read_file(input="{}/test_read_file_boxes_unprojected.shp".format(tmpdir), root_dir=os.path.dirname(get_data("OSBS_029.png")))
+    gdf.to_file(tmp_path / "test_read_file_boxes_unprojected.shp")
+    annotations = utilities.read_file(input=str(tmp_path / "test_read_file_boxes_unprojected.shp"), root_dir=os.path.dirname(get_data("OSBS_029.png")))
 
     # Assert the expected number of annotations and geometry type
     assert annotations.shape[0] == 2
@@ -278,7 +275,7 @@ def test_read_file_boxes_unprojected(tmpdir):
     assert hasattr(annotations, "root_dir")
 
 
-def test_read_file_points_unprojected(tmpdir):
+def test_read_file_points_unprojected(tmp_path):
     # Create a sample GeoDataFrame with point geometries
     sample_geometry = [geometry.Point(0.5, 0.5), geometry.Point(2.5, 2.5)]
     labels = ["Tree", "Tree"]
@@ -286,9 +283,9 @@ def test_read_file_points_unprojected(tmpdir):
     gdf = gpd.GeoDataFrame(df, geometry="geometry")
     image_path = get_data("OSBS_029.png")
     gdf["image_path"] = os.path.basename(image_path)
-    gdf.to_file("{}/test_read_file_points_unprojected.shp".format(tmpdir))
+    gdf.to_file(tmp_path / "test_read_file_points_unprojected.shp")
 
-    annotations = utilities.read_file(input="{}/test_read_file_points_unprojected.shp".format(tmpdir), root_dir=os.path.dirname(get_data("OSBS_029.png")))
+    annotations = utilities.read_file(input=str(tmp_path / "test_read_file_points_unprojected.shp"), root_dir=os.path.dirname(get_data("OSBS_029.png")))
 
     # Assert the expected number of annotations
     assert annotations.shape[0] == 2
@@ -298,7 +295,7 @@ def test_read_file_points_unprojected(tmpdir):
     assert hasattr(annotations, "root_dir")
 
 
-def test_read_file_polygons_unprojected(tmpdir):
+def test_read_file_polygons_unprojected(tmp_path):
     # Create a sample GeoDataFrame with polygon geometries with 6 points
     sample_geometry = [geometry.Polygon([(0, 0), (0, 2), (1, 1), (1, 0), (0, 0)]),
                        geometry.Polygon([(2, 2), (2, 4), (3, 3), (3, 2), (2, 2)])]
@@ -308,10 +305,10 @@ def test_read_file_polygons_unprojected(tmpdir):
     gdf = gpd.GeoDataFrame(df, geometry="geometry")
     image_path = get_data("OSBS_029.png")
     gdf["image_path"] = os.path.basename(image_path)
-    gdf.to_file("{}/test_read_file_polygons_unprojected.shp".format(tmpdir))
+    gdf.to_file(tmp_path / "test_read_file_polygons_unprojected.shp")
 
     # Call the function under test
-    annotations = utilities.read_file(input="{}/test_read_file_polygons_unprojected.shp".format(tmpdir), root_dir=os.path.dirname(get_data("OSBS_029.png")))
+    annotations = utilities.read_file(input=str(tmp_path / "test_read_file_polygons_unprojected.shp"), root_dir=os.path.dirname(get_data("OSBS_029.png")))
 
     # Assert the expected number of annotations
     assert annotations.shape[0] == 2
@@ -321,7 +318,7 @@ def test_read_file_polygons_unprojected(tmpdir):
     assert hasattr(annotations, "root_dir")
 
 
-def test_crop_raster_valid_crop(tmpdir):
+def test_crop_raster_valid_crop(tmp_path):
     rgb_path = get_data("2018_SJER_3_252000_4107000_image_477.tif")
     raster_bounds = rio.open(rgb_path).bounds
 
@@ -329,10 +326,10 @@ def test_crop_raster_valid_crop(tmpdir):
     bounds = (raster_bounds[0] + 10, raster_bounds[1] + 10, raster_bounds[0] + 30, raster_bounds[1] + 30)
 
     # Call the function under test
-    result = utilities.crop_raster(bounds, rgb_path=rgb_path, savedir=tmpdir, filename="crop")
+    result = utilities.crop_raster(bounds, rgb_path=rgb_path, savedir=tmp_path, filename="crop")
 
     # Assert the output filename (normalize both paths)
-    expected_filename = str(tmpdir.join("crop.tif"))
+    expected_filename = str(tmp_path / "crop.tif")
     assert os.path.normpath(result) == os.path.normpath(expected_filename)
 
     # Assert the saved crop
@@ -344,7 +341,7 @@ def test_crop_raster_valid_crop(tmpdir):
         assert src.dtypes == ("uint8", "uint8", "uint8")
 
 
-def test_crop_raster_invalid_crop(tmpdir):
+def test_crop_raster_invalid_crop(tmp_path):
     rgb_path = get_data("2018_SJER_3_252000_4107000_image_477.tif")
     raster_bounds = rio.open(rgb_path).bounds
 
@@ -353,10 +350,10 @@ def test_crop_raster_invalid_crop(tmpdir):
 
     # Call the function under test
     with pytest.raises(ValueError):
-        result = utilities.crop_raster(bounds, rgb_path=rgb_path, savedir=tmpdir, filename="crop")
+        _ = utilities.crop_raster(bounds, rgb_path=rgb_path, savedir=tmp_path, filename="crop")
 
 
-def test_crop_raster_no_savedir(tmpdir):
+def test_crop_raster_no_savedir():
     rgb_path = get_data("2018_SJER_3_252000_4107000_image_477.tif")
     raster_bounds = rio.open(rgb_path).bounds
 
@@ -371,20 +368,20 @@ def test_crop_raster_no_savedir(tmpdir):
     assert isinstance(result, np.ndarray)
 
 
-def test_crop_raster_png_unprojected(tmpdir):
+def test_crop_raster_png_unprojected(tmp_path):
     # Define the bounds for cropping
     bounds = (0, 0, 100, 100)
 
     # Set the paths
     rgb_path = get_data("OSBS_029.png")
-    savedir = str(tmpdir)
+    savedir = str(tmp_path)
     filename = "crop"
 
     # Call the function under test
     result = utilities.crop_raster(bounds, rgb_path=rgb_path, savedir=savedir, filename=filename, driver="PNG")
 
     # Assert the output filename (normalize both paths)
-    expected_filename = os.path.join(savedir, "crop.png")
+    expected_filename = str(tmp_path / "crop.png")
     assert os.path.normpath(result) == os.path.normpath(expected_filename)
 
     # Assert the saved crop
@@ -396,7 +393,7 @@ def test_crop_raster_png_unprojected(tmpdir):
         assert src.crs is None
 
 
-def test_geo_to_image_coordinates_UTM_N(tmpdir):
+def test_geo_to_image_coordinates_UTM_N():
     """Read in a csv file, make a projected shapefile, convert to image coordinates and view the results"""
     annotations = get_data("2018_SJER_3_252000_4107000_image_477.csv")
     path_to_raster = get_data("2018_SJER_3_252000_4107000_image_477.tif")
@@ -427,7 +424,7 @@ def test_geo_to_image_coordinates_UTM_N(tmpdir):
         annotations).shape[0]
 
 
-def test_geo_to_image_coordinates_UTM_S(tmpdir):
+def test_geo_to_image_coordinates_UTM_S():
     """Read in a csv file, make a projected shapefile, convert to image coordinates and view the results"""
     annotations = get_data("australia.shp")
     path_to_raster = get_data("australia.tif")
@@ -454,7 +451,7 @@ def test_geo_to_image_coordinates_UTM_S(tmpdir):
     assert image_coords[image_coords.intersects(numpy_window)].shape[0] == gpd.read_file(annotations).shape[0]
 
 
-def test_image_to_geo_coordinates(tmpdir):
+def test_image_to_geo_coordinates():
     annotations = get_data("2018_SJER_3_252000_4107000_image_477.csv")
     path_to_raster = get_data("2018_SJER_3_252000_4107000_image_477.tif")
 
@@ -485,7 +482,7 @@ def test_image_to_geo_coordinates(tmpdir):
     assert (geo_coords["ymax"] == bounds.maxy).all()
 
 
-def test_image_to_geo_coordinates_boxes(tmpdir):
+def test_image_to_geo_coordinates_boxes():
     annotations = get_data("2018_SJER_3_252000_4107000_image_477.csv")
     path_to_raster = get_data("2018_SJER_3_252000_4107000_image_477.tif")
 
@@ -509,7 +506,7 @@ def test_image_to_geo_coordinates_boxes(tmpdir):
     # plt.show()
 
 
-def test_image_to_geo_coordinates_points(tmpdir):
+def test_image_to_geo_coordinates_points():
     annotations = get_data("2018_SJER_3_252000_4107000_image_477.csv")
     path_to_raster = get_data("2018_SJER_3_252000_4107000_image_477.tif")
 
@@ -534,7 +531,7 @@ def test_image_to_geo_coordinates_points(tmpdir):
     # plt.show()
 
 
-def test_image_to_geo_coordinates_polygons(tmpdir):
+def test_image_to_geo_coordinates_polygons():
     annotations = get_data("2018_SJER_3_252000_4107000_image_477.csv")
     path_to_raster = get_data("2018_SJER_3_252000_4107000_image_477.tif")
 
@@ -561,7 +558,7 @@ def test_image_to_geo_coordinates_polygons(tmpdir):
 
 
 
-def test_read_coco_json(tmpdir):
+def test_read_coco_json(tmp_path):
     """Test reading a COCO format JSON file"""
     # Create a sample COCO JSON structure
     coco_data = {
@@ -588,7 +585,7 @@ def test_read_coco_json(tmpdir):
     }
 
     # Write the sample JSON to a temporary file
-    json_path = tmpdir.join("test_coco.json")
+    json_path = tmp_path / "annotations.json"
     with open(json_path, "w") as f:
         json.dump(coco_data, f)
 

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -60,28 +60,28 @@ def gdf_box():
     return gdf
 
 
-def test_predict_image_and_plot(m, tmpdir):
+def test_predict_image_and_plot(m, tmp_path):
     sample_image_path = get_data("OSBS_029.png")
     results = m.predict_image(path=sample_image_path)
-    visualize.plot_results(results, savedir=tmpdir)
+    visualize.plot_results(results, savedir=tmp_path)
 
-    assert os.path.exists(os.path.join(tmpdir, "OSBS_029.png"))
+    assert os.path.exists(os.path.join(tmp_path, "OSBS_029.png"))
 
 
-def test_predict_tile_and_plot(m, tmpdir):
+def test_predict_tile_and_plot(m, tmp_path):
     sample_image_path = get_data("OSBS_029.png")
     results = m.predict_tile(path=sample_image_path)
-    visualize.plot_results(results, savedir=tmpdir)
+    visualize.plot_results(results, savedir=tmp_path)
 
-    assert os.path.exists(os.path.join(tmpdir, "OSBS_029.png"))
+    assert os.path.exists(os.path.join(tmp_path, "OSBS_029.png"))
 
 
-def test_multi_class_plot(tmpdir):
+def test_multi_class_plot(tmp_path):
     results = pd.read_csv(get_data("testfile_multi.csv"))
     results = utilities.read_file(results, root_dir=os.path.dirname(get_data("SOAP_061.png")))
-    visualize.plot_results(results, savedir=tmpdir)
+    visualize.plot_results(results, savedir=tmp_path)
 
-    assert os.path.exists(os.path.join(tmpdir, "SOAP_061.png"))
+    assert os.path.exists(os.path.join(tmp_path, "SOAP_061.png"))
 
 
 def test_convert_to_sv_format(gdf_box):
@@ -103,42 +103,41 @@ def test_convert_to_sv_format(gdf_box):
 
 
 
-def test_plot_annotations(gdf_box, tmpdir):
+def test_plot_annotations(gdf_box, tmp_path):
 
     # Call the function
-    visualize.plot_annotations(gdf_box, savedir=tmpdir)
+    visualize.plot_annotations(gdf_box, savedir=tmp_path)
 
     # Assertions
-    assert os.path.exists(os.path.join(tmpdir, "OSBS_029.png"))
+    assert (tmp_path / "OSBS_029.png").exists()
 
 
-def test_plot_results_box(gdf_box, tmpdir):
+def test_plot_results_box(gdf_box, tmp_path):
 
     # Call the function
-    visualize.plot_results(gdf_box, savedir=tmpdir)
+    visualize.plot_results(gdf_box, savedir=tmp_path)
 
     # Assertions
-    assert os.path.exists(os.path.join(tmpdir, "OSBS_029.png"))
+    assert (tmp_path / "OSBS_029.png").exists()
 
 
-def test_plot_results_point(gdf_point, tmpdir):
+def test_plot_results_point(gdf_point, tmp_path):
 
     # Call the function
-    visualize.plot_results(gdf_point, savedir=tmpdir)
+    visualize.plot_results(gdf_point, savedir=tmp_path)
 
     # Assertions
-    assert os.path.exists(os.path.join(tmpdir, "OSBS_029.png"))
+    assert (tmp_path / "OSBS_029.png").exists()
 
-
-def test_plot_results_polygon(gdf_poly, tmpdir):
+def test_plot_results_polygon(gdf_poly, tmp_path):
     # Call the function without height/width
-    visualize.plot_results(gdf_poly, savedir=tmpdir)
+    visualize.plot_results(gdf_poly, savedir=tmp_path)
 
     # Assertions
-    assert os.path.exists(os.path.join(tmpdir, "OSBS_029.png"))
+    assert (tmp_path / "OSBS_029.png").exists()
 
 
-def test_plot_with_relative_paths(tmpdir):
+def test_plot_with_relative_paths(tmp_path):
     # Test that plot_results and plot_annotations work with relative paths and root_dir
     full_path = get_data("OSBS_029.png")
     relative_name = os.path.basename(full_path)
@@ -153,9 +152,9 @@ def test_plot_with_relative_paths(tmpdir):
     gdf = gpd.GeoDataFrame(data)
     gdf.root_dir = root_dir
 
-    visualize.plot_results(gdf, savedir=tmpdir, show=False)
-    visualize.plot_annotations(gdf, savedir=tmpdir, show=False)
-    assert os.path.exists(os.path.join(tmpdir, "OSBS_029.png"))
+    visualize.plot_results(gdf, savedir=tmp_path, show=False)
+    visualize.plot_annotations(gdf, savedir=tmp_path, show=False)
+    assert (tmp_path / "OSBS_029.png").exists()
 
 
 


### PR DESCRIPTION
## Description

This PR refactors tests to use `tmp_path` fixtures instead of `tmpdir` as the latter is deprecated by `pytest`. In addition, it should allow us to use more aggressive cleanup on the CI so we don't run out of disk space during testing. Either by default, or through an additional option `-o "tmp_path_retention_policy=none"`

This is _mostly_ a find + replace job, but also allows us to use path syntax instead of os/glob/etc.

See https://docs.pytest.org/en/stable/how-to/tmp_path.html#the-tmpdir-and-tmpdir-factory-fixtures

We could also enforce `-p no:legacypath` to auto-fail the CI if tmpdir is used.

## AI-Assisted Development

A lot of tab auto-complete with Copilot which saved time with replacing strings.

- [X] I used AI tools (e.g., GitHub Copilot, ChatGPT, etc.) in developing this PR
- [X] I understand all the code I'm submitting
- [X] I have reviewed and validated all AI-generated code
