### PR TITLE
Fix padding ordering issues in augmentation pipeline

### DIFF
--- a/src/deepforest/augmentations.py
+++ b/src/deepforest/augmentations.py
@@ -251,6 +251,14 @@ def get_transform(
             aug_transform = _create_augmentation(aug_name, aug_params)
             transforms_list.append(aug_transform)
 
+    # Enforce ordering to avoid issues with padding and cropping
+    _crop_types = (K.RandomCrop, K.RandomResizedCrop)
+    _pad_types = (K.PadTo, RandomPadTo)
+    standard = [t for t in transforms_list if not isinstance(t, _crop_types + _pad_types)]
+    crops = [t for t in transforms_list if isinstance(t, _crop_types)]
+    pads = [t for t in transforms_list if isinstance(t, _pad_types)]
+    transforms_list = standard + crops + pads
+
     # Create a sequential container for all transforms
     return K.AugmentationSequential(*transforms_list, data_keys=data_keys)
 

--- a/src/deepforest/datasets/training.py
+++ b/src/deepforest/datasets/training.py
@@ -184,25 +184,24 @@ class BoxDataset(TrainingDataset):
         if errors:
             raise ValueError("\n".join(errors))
 
-    def filter_boxes(self, boxes, labels, image_shape, min_size=1) -> tuple:
+    def filter_boxes(self, boxes, labels, width, height, min_size=1):
         """Clamp boxes to image bounds and filter by minimum dimension.
 
         Args:
             boxes (torch.Tensor): Bounding boxes of shape (N, 4) in xyxy format.
             labels (torch.Tensor): Labels of shape (N,).
-            image_shape (tuple): Image shape as (C, H, W).
+            width (int): Image width in pixels.
+            height (int): Image height in pixels.
             min_size (int): Minimum box width/height in pixels. Defaults to 1.
 
         Returns:
             tuple: A tuple of (filtered_boxes, filtered_labels)
         """
-        _, H, W = image_shape
-
         # Clamp boxes to image bounds
-        boxes[:, 0] = torch.clamp(boxes[:, 0], min=0, max=W)  # x1
-        boxes[:, 1] = torch.clamp(boxes[:, 1], min=0, max=H)  # y1
-        boxes[:, 2] = torch.clamp(boxes[:, 2], min=0, max=W)  # x2
-        boxes[:, 3] = torch.clamp(boxes[:, 3], min=0, max=H)  # y2
+        boxes[:, 0] = torch.clamp(boxes[:, 0], min=0, max=width)  # x1
+        boxes[:, 1] = torch.clamp(boxes[:, 1], min=0, max=height)  # y1
+        boxes[:, 2] = torch.clamp(boxes[:, 2], min=0, max=width)  # x2
+        boxes[:, 3] = torch.clamp(boxes[:, 3], min=0, max=height)  # y2
 
         # Filter boxes with minimum size
         width = boxes[:, 2] - boxes[:, 0]
@@ -275,7 +274,15 @@ class BoxDataset(TrainingDataset):
         labels = torch.from_numpy(targets["labels"].astype(np.int64))
 
         # Filter invalid boxes after augmentation
-        boxes, labels = self.filter_boxes(boxes, labels, image.shape)
+        # Since the augmentation operation may change image size, we take the smallest
+        # of the source and transformed dimensions assuming that padding is always the
+        # last operation in the pipeline.
+        boxes, labels = self.filter_boxes(
+            boxes,
+            labels,
+            width=min(image_tensor.shape[3], image.shape[2]),
+            height=min(image_tensor.shape[2], image.shape[1]),
+        )
 
         # Edge case if all labels were augmented away, keep the image
         if len(boxes) == 0:
@@ -386,25 +393,23 @@ class PointDataset(TrainingDataset):
         if errors:
             raise ValueError("\n".join(errors))
 
-    def filter_points(self, points, labels, image_shape) -> tuple:
+    def filter_points(self, points, labels, width, height) -> tuple:
         """Filter points to be within the image.
 
         Args:
             points (torch.Tensor): Points of shape (N, 2) in xy format.
             labels (torch.Tensor): Labels of shape (N,).
-            image_shape (tuple): Image shape as (C, H, W).
+            width (int): Image width in pixels.
+            height (int): Image height in pixels.
 
         Returns:
             tuple: A tuple of (filtered_points, filtered_labels)
         """
-        _, H, W = image_shape
-
-        # Filter out of bounds
         valid_mask = (
             (points[:, 0] >= 0)
-            & (points[:, 0] <= W)
+            & (points[:, 0] <= width)
             & (points[:, 1] >= 0)
-            & (points[:, 1] <= H)
+            & (points[:, 1] <= height)
         )
 
         return points[valid_mask], labels[valid_mask]
@@ -541,8 +546,14 @@ class PointDataset(TrainingDataset):
         points = augmented_points.squeeze(0)
         labels = torch.from_numpy(targets["labels"].astype(np.int64))
 
-        # Filter out-of-bounds points after augmentation
-        points, labels = self.filter_points(points, labels, image.shape)
+        # Filter out-of-bounds points after augmentation accounting for
+        # potential size changes due to augmentation.
+        points, labels = self.filter_points(
+            points,
+            labels,
+            width=min(image_tensor.shape[3], image.shape[2]),
+            height=min(image_tensor.shape[2], image.shape[1]),
+        )
 
         # Edge case if all labels were augmented away, keep the image
         if len(points) == 0:
@@ -763,6 +774,26 @@ class PolygonDataset(TrainingDataset):
         iscrowd = torch.as_tensor(targets["iscrowd"], dtype=torch.bool)
         area = torch.as_tensor(targets["area"])
         image_id = targets["image_id"]
+
+        # Filter out-of-bounds boxes and sync with transformed
+        # segmentation masks
+        filter_w = min(image_tensor.shape[3], image.shape[2])
+        filter_h = min(image_tensor.shape[2], image.shape[1])
+        if boxes.dim() == 2 and boxes.shape[0] > 0:
+            boxes[:, 0] = torch.clamp(boxes[:, 0], min=0, max=filter_w)
+            boxes[:, 1] = torch.clamp(boxes[:, 1], min=0, max=filter_h)
+            boxes[:, 2] = torch.clamp(boxes[:, 2], min=0, max=filter_w)
+            boxes[:, 3] = torch.clamp(boxes[:, 3], min=0, max=filter_h)
+            box_w = boxes[:, 2] - boxes[:, 0]
+            box_h = boxes[:, 3] - boxes[:, 1]
+            valid = (box_w >= 1) & (box_h >= 1)
+
+            boxes = boxes[valid]
+            labels = labels[valid]
+            if masks.dim() == 3:
+                masks = masks[valid]
+            iscrowd = iscrowd[valid]
+            area = area[valid]
 
         targets = {
             "image_id": image_id,

--- a/tests/test_augmentations.py
+++ b/tests/test_augmentations.py
@@ -295,10 +295,9 @@ def test_filter_boxes():
         [0., 0., 0., 10.],         # Too small
     ])
     labels = torch.tensor([0, 1, 2, 3, 4, 5])
-    image_shape = (3, 200, 200)
 
     dataset = BoxDataset.__new__(BoxDataset)
-    filtered_boxes, filtered_labels = dataset.filter_boxes(boxes, labels, image_shape)
+    filtered_boxes, filtered_labels = dataset.filter_boxes(boxes, labels, width=200, height=200, min_size=1)
 
     assert filtered_boxes.shape[0] == 3
     assert torch.equal(filtered_labels, torch.tensor([2, 3, 4]))
@@ -346,6 +345,42 @@ def test_geometric_augmentation_filters_boxes():
 
         # Labels should match box count
         assert len(labels) == len(boxes), f"Label count mismatch: {len(labels)} labels, {len(boxes)} boxes"
+
+
+def test_reordering_produces_correct_output():
+    """Specifying pad-before-flips and flips-before-pad both yield flipped coords and padded size.
+
+    Padding in kornia is in the positive direction and preserves coordinates. However, if padding
+    is applied first, the original label coordinates are transformed (they do not have padding applied).
+    This test checks the logic in the augmentation class to check that the transform pipeline is
+    correctly ordered to pad last and that the resulting transformed labels are as expected given
+    the flips.
+    """
+    image = torch.zeros(1, 3, 100, 100)
+    box = torch.tensor([[[10., 5., 40., 30.]]])  # x1,y1,x2,y2
+
+    augs_wrong_order = [
+        {"RandomPadTo": {"pad_range": (50, 50), "p": 1.0}},
+        {"HorizontalFlip": {"p": 1.0}},
+        {"VerticalFlip": {"p": 1.0}},
+    ]
+    augs_correct_order = [
+        {"HorizontalFlip": {"p": 1.0}},
+        {"VerticalFlip": {"p": 1.0}},
+        {"RandomPadTo": {"pad_range": (50, 50), "p": 1.0}},
+    ]
+
+    img_wrong, box_wrong = get_transform(augmentations=augs_wrong_order)(image.clone(), box.clone())
+    img_correct, box_correct = get_transform(augmentations=augs_correct_order)(image.clone(), box.clone())
+
+    # Both pipelines must produce the same padded canvas size
+    assert img_wrong.shape == torch.Size([1, 3, 150, 150])
+    assert img_correct.shape == torch.Size([1, 3, 150, 150])
+
+    # Flipped box: HFlip on W=100 -> x: 99-40=59, 99-10=89; VFlip on H=100 -> y: 99-30=69, 99-5=94
+    expected_box = torch.tensor([[[59., 69., 89., 94.]]])
+    assert torch.allclose(box_wrong, expected_box, atol=1.0)
+    assert torch.allclose(box_correct, expected_box, atol=1.0)
 
 
 if __name__ == "__main__":

--- a/tests/test_datasets_training_point.py
+++ b/tests/test_datasets_training_point.py
@@ -200,7 +200,7 @@ def test_point_dataset_filter_points():
     labels = torch.tensor([0, 0, 0, 0])
     image_shape = (3, 100, 100)  # H=100, W=100
 
-    filtered_points, filtered_labels = ds.filter_points(points, labels, image_shape)
+    filtered_points, filtered_labels = ds.filter_points(points, labels, width=100, height=100)
 
     assert filtered_points.shape[0] == 2  # only (10,20) and (50,60) are in bounds
     assert filtered_labels.shape[0] == 2


### PR DESCRIPTION
## Description

Fixes some unexpected behavior during augmentation.

1. If a padding operation is performed before other geometric transforms, the final labels are not transformed correctly. It seems that the geometric transform is correct, though probably not what the user would want, but the labels are definitely wrong. Here for example, if we pad and then flip, the image is correctly vflipped. The labels however are only vflipped in _original_ image coordinates. From what I can see it's not as simple as resizing the labels, this should be handled by `kornia`.

This may be a limitation of how `kornia` constructs/chains the transformation matrices for different operations.

<img width="300" alt="image" src="https://github.com/user-attachments/assets/45835e22-43ea-437e-8196-ae5d7acc3dc9" />

3. `kornia` transforms input boxes/points but it doesn't do any filtering afterwards. If the source image is rotated for example, it will may result in boxes going out of bounds. Currently, we clip to the bounds of the augmented image, but if padding is forced to be the last operation, we should clip to the _source_ image and then pad to the desired size. In the other direction, if the image is _cropped_, then we want to bound the labels to the transformed image.

<img width="300" alt="image" src="https://github.com/user-attachments/assets/1987f257-d799-4f69-b586-c9617023d1f6" />

This PR makes two changes:

1. If the pipeline contains a `PadTo` operation, move it to the final step. This ensures that the resulting labels are correct. This is opinionated, but until we figure out a way to solve the label transform problem, it's a safe compromise and _should_ always yield correct labels even if the transform pipeline is specified out of order by mistake.
3. Modify box filtering to clamp to the minimum of the source/augmented image width and height.

Typical corrected sample:

<img width="300" alt="image" src="https://github.com/user-attachments/assets/7aa52a41-d490-4a28-a3e8-d391bb9f848b" />
<img width="300" alt="image" src="https://github.com/user-attachments/assets/aa615a59-549a-46b3-b1b8-eb560a0c9cb2" />

## Related Issue(s)

https://github.com/weecology/deepForest/issues/1274 - related, but this does not change the behavior of PadTo (unexpected cropping).

## AI-Assisted Development

Auto-complete only for updating filter_boxes

- [X] I understand all the code I'm submitting
- [X] I have reviewed and validated all AI-generated code