### PR TITLE
[WIP] Improve predict_tile memory use and windowed raster inference

### DIFF
--- a/src/deepforest/datasets/prediction.py
+++ b/src/deepforest/datasets/prediction.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -12,6 +13,61 @@ from torch.utils.data import Dataset
 
 from deepforest import preprocess
 from deepforest.utilities import format_geometry, read_file
+
+
+def _ensure_rgb_chw_float32(image: np.ndarray) -> np.ndarray:
+    """Normalize an image into RGB CHW float32 in [0, 1].
+
+    Supported inputs:
+    - HWC uint8 RGB
+    - CHW uint8 RGB
+    - HWC float RGB in [0, 1] or [0, 255]
+    - CHW float RGB in [0, 1] or [0, 255]
+
+    Raises:
+        ValueError: if grayscale, unexpected dimensions, non-3-channel.
+    """
+    if image.ndim == 2:
+        raise ValueError("Grayscale images are not supported (expected 3-channel RGB)")
+    if image.ndim != 3:
+        raise ValueError(f"Expected 3D image array, got shape {image.shape}")
+
+    # Ensure channels-first (C, H, W)
+    if image.shape[0] == 3:
+        chw = image
+    elif image.shape[-1] == 3:
+        chw = np.moveaxis(image, -1, 0)
+    else:
+        raise ValueError(f"Expected image with 3 channels, got shape {image.shape}")
+
+    # Normalize based primarily on dtype
+    if chw.dtype == np.uint8:
+        chw = chw.astype(np.float32)
+        chw /= 255.0
+    elif np.issubdtype(chw.dtype, np.floating):
+        if chw.dtype != np.float32:
+            chw = chw.astype(np.float32)
+
+        # Allow already-normalized float images.
+        # If values look like 0-255 floats, normalize.
+        max_val = float(chw.max())
+        min_val = float(chw.min())
+        if min_val < 0:
+            raise ValueError(
+                f"Expected float image in [0, 1] or [0, 255], got min {min_val}"
+            )
+        if max_val > 1.0:
+            if max_val <= 255.0:
+                chw /= 255.0
+            else:
+                raise ValueError(
+                    f"Expected float image in [0, 1] or [0, 255], got max {max_val}"
+                )
+    else:
+        # Integers other than uint8 are ambiguous; be explicit.
+        raise ValueError(f"Unsupported image dtype {chw.dtype}. Expected uint8 or float.")
+
+    return np.ascontiguousarray(chw)
 
 
 # Base prediction class
@@ -51,29 +107,12 @@ class PredictionDataset(Dataset):
         if image is None:
             if image_path is None:
                 raise ValueError("Either image_path or image must be provided")
-            image = np.array(Image.open(image_path).convert("RGB"))
+            image_arr = np.asarray(Image.open(image_path).convert("RGB"))
         else:
-            image = np.array(image)
-        # If dtype is not float32, convert to float32
-        if image.dtype != "float32":
-            image = image.astype("float32")
+            image_arr = image if isinstance(image, np.ndarray) else np.asarray(image)
 
-        # If image is not normalized, normalize to [0, 1]
-        if image.max() > 1 or image.min() < 0:
-            image = image / 255.0
-
-        # If image is not in CHW format, convert to CHW
-        if image.shape[0] != 3:
-            if image.shape[-1] != 3:
-                raise ValueError(
-                    f"Expected 3 channel image, got image shape {image.shape}"
-                )
-            else:
-                image = np.rollaxis(image, 2, 0)
-
-        image = torch.from_numpy(image)
-
-        return image
+        image_arr = _ensure_rgb_chw_float32(image_arr)
+        return torch.from_numpy(image_arr)
 
     def prepare_items(self):
         """Prepare the items for the dataset.
@@ -169,7 +208,26 @@ class SingleImage(PredictionDataset):
         )
 
     def prepare_items(self):
-        self.image = self.load_and_preprocess_image(self.path, image=self.image)
+        if self.image is None:
+            if self.path is None:
+                raise ValueError("Either image_path or image must be provided")
+            image = np.asarray(Image.open(self.path).convert("RGB"))
+        else:
+            image = (
+                self.image
+                if isinstance(self.image, np.ndarray)
+                else np.asarray(self.image)
+            )
+
+        if image.shape[0] != 3:
+            if image.shape[-1] != 3:
+                raise ValueError(
+                    f"Expected 3 channel image, got image shape {image.shape}"
+                )
+            image = np.moveaxis(image, -1, 0)
+
+        # Keep as uint8/float in CHW; normalize per-crop to avoid full-image float copy
+        self.image = image
         self.windows = preprocess.compute_windows(
             self.image, self.patch_size, self.patch_overlap
         )
@@ -182,8 +240,11 @@ class SingleImage(PredictionDataset):
 
     def get_crop(self, idx):
         crop = self.image[self.windows[idx].indices()]
-
-        return crop
+        if crop.dtype != "float32":
+            crop = crop.astype("float32")
+        if crop.max() > 1 or crop.min() < 0:
+            crop /= 255.0
+        return torch.from_numpy(crop)
 
     def get_image_basename(self, idx):
         if self.path is not None:
@@ -433,24 +494,25 @@ class TiledRaster(PredictionDataset):
     def __init__(self, path, patch_size, patch_overlap):
         if path is None:
             raise ValueError("path is required for a memory raster dataset")
+        self._src = None
         super().__init__(path=path, patch_size=patch_size, patch_overlap=patch_overlap)
 
     def prepare_items(self):
-        # Get raster shape without keeping file open
-        with rio.open(self.path) as src:
-            width = src.shape[0]
-            height = src.shape[1]
+        # Open once; workers=0 is enforced by caller for this dataset.
+        self._src = rio.open(self.path)
+        height = self._src.height
+        width = self._src.width
 
-            # Check is tiled
-            if not src.is_tiled:
-                raise ValueError(
-                    "Out-of-memory dataset is selected, but raster is not tiled, "
-                    "leading to entire raster being read into memory and defeating "
-                    "the purpose of an out-of-memory dataset. "
-                    "\nPlease run: "
-                    "\ngdal_translate -of GTiff -co TILED=YES <input> <output> "
-                    "to create a tiled raster"
-                )
+        # Warn on non-tiled rasters: window reads may still be efficient (strip-based),
+        # but performance can degrade depending on driver/strip layout.
+        if not self._src.is_tiled:
+            warnings.warn(
+                "dataloader_strategy='window' is selected, but raster is not tiled. "
+                "Windowed reads may be slower depending on file layout. If needed, "
+                "create a tiled GeoTIFF with: "
+                "gdal_translate -of GTiff -co TILED=YES <input> <output>",
+                stacklevel=2,
+            )
 
         # Generate sliding windows
         self.windows = slidingwindow.generateForSize(
@@ -469,12 +531,15 @@ class TiledRaster(PredictionDataset):
 
     def get_crop(self, idx):
         window = self.windows[idx]
-        with rio.open(self.path) as src:
-            window_data = src.read(window=Window(window.x, window.y, window.w, window.h))
+        assert self._src is not None, "Raster dataset is not open"
+        window_data = self._src.read(
+            window=Window(window.x, window.y, window.w, window.h)
+        )
 
         # Rasterio already returns (C, H, W), just normalize and convert
-        window_data = window_data.astype("float32") / 255.0
-        window_data = torch.from_numpy(window_data).float()
+        window_data = window_data.astype(np.float32)
+        window_data /= 255.0
+        window_data = torch.from_numpy(window_data)
         if window_data.shape[0] != 3:
             raise ValueError(
                 f"Expected 3 channel image, got {window_data.shape[0]} channels"
@@ -487,3 +552,16 @@ class TiledRaster(PredictionDataset):
 
     def get_crop_bounds(self, idx):
         return self.window_list()[idx]
+
+    def close(self) -> None:
+        """Close the underlying raster dataset."""
+        if self._src is not None:
+            self._src.close()
+            self._src = None
+
+    def __del__(self):
+        # Best-effort cleanup
+        try:
+            self.close()
+        except Exception:
+            pass

--- a/src/deepforest/main.py
+++ b/src/deepforest/main.py
@@ -587,6 +587,10 @@ class deepforest(pl.LightningModule):
                         image_results.append(formatted_result)
                         global_window_idx += 1
 
+                # Ensure raster datasets are closed promptly
+                if hasattr(ds, "close"):
+                    ds.close()
+
             if not image_results:
                 results = pd.DataFrame()
             else:


### PR DESCRIPTION
This changes the prediction input pipeline to be less memory-hungry on large rasters.

- Add helper to coerce inputs to RGB CHW float32 in [0, 1]
  - Validate ndim/channel placement and reject grayscale early
  - Normalize based on dtype (uint8 -> /255), not max/min heuristics
  - Ensure contiguous arrays before torch conversion
- Refactor SingleImage to keep the full image in CHW without forcing a full float32 copy; convert/normalize per-window crops in get_crop
- Improve TiledRaster/window strategy
  - Reuse a single rasterio dataset handle instead of reopening per window
  - Warn (don’t error) when the raster is untiled
  - Provide close() and ensure datasets are closed after predict

```j
- `image = np.array(image)` often makes copies, Better to use `np.asarray(...)`
- `if image.dtype != "float32": ...` (bug),
	- `image.dtype` is a `numpy.dtype`, not the string `"float32"`
- `if image.max() > 1 or image.min() < 0: image /= 255` (fragile heuristic)
	- If it’s `uint8`, it *definitely* means 0–255 → convert to float32 and divide by 255.
	- If it’s already float, you should only accept known conventions and error on surprising ranges.
```

## Description

<!-- Provide a clear and concise description of what this PR does -->

## Related Issue(s)

<!-- Link to related issues using: Closes #123, Fixes #456, Related to #789 -->
<!-- If no issue exists, explain why this change is needed -->


## AI-Assisted Development

<!-- Be transparent about AI tool usage -->

- [ ] I used AI tools (e.g., GitHub Copilot, ChatGPT, etc.) in developing this PR
- [ ] I understand all the code I'm submitting
- [ ] I have reviewed and validated all AI-generated code

**AI tools used (if applicable):**
<!-- List AI tools used, if any -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes image preprocessing/normalization behavior and rasterio handle lifecycle during inference, which can affect prediction inputs and resource cleanup on large rasters.
> 
> **Overview**
> **Reduces memory pressure during `predict_tile`** by standardizing image coercion via `_ensure_rgb_chw_float32` (strict RGB/shape validation, dtype-based normalization, contiguous arrays) and switching `np.array(...)` to `np.asarray(...)` to avoid unnecessary copies.
> 
> **Improves `dataloader_strategy='single'` and `'window'` paths**: `SingleImage` keeps the full image in CHW without forcing a full float32 conversion, normalizing per-window in `get_crop`, while `TiledRaster` reuses a single `rasterio` dataset handle across windows, warns (instead of erroring) on untiled rasters, and adds `close()`/best-effort cleanup; `predict_tile` now calls `ds.close()` when available.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bb6e8e0428a3ec4b52ba5f207fd885bd308fb57e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->