### PR TITLE
Fix band check bug in split_raster and typo fixes

### DIFF
--- a/src/deepforest/predict.py
+++ b/src/deepforest/predict.py
@@ -152,7 +152,7 @@ def across_class_nms(predicted_boxes, iou_threshold=0.15):
     if predicted_boxes.shape[0] <= 1:
         return predicted_boxes
 
-    # move prediciton to tensor
+    # move prediction to tensor
     boxes = torch.tensor(
         predicted_boxes[["xmin", "ymin", "xmax", "ymax"]].values, dtype=torch.float32
     )

--- a/src/deepforest/preprocess.py
+++ b/src/deepforest/preprocess.py
@@ -207,7 +207,7 @@ def split_raster(
         numpy_image = numpy_image.transpose(2, 0, 1)
 
     # Check that it's 3 bands
-    bands = numpy_image.shape[2]
+    bands = numpy_image.shape[0]
     if not bands == 3:
         warnings.warn(
             f"Input image had non-3 band shape of {numpy_image.shape}, selecting first 3 bands",


### PR DESCRIPTION
- Fix bug in preprocess.py where band count check used shape[2] (width) instead of shape[0] (channels) after transposing to channels-first format
- Fix typo 'prediciton' -> 'prediction' in evaluate.py docstring
- Fix typo 'prediciton' -> 'prediction' in predict.py comment

## Description

<!-- Provide a clear and concise description of what this PR does -->
 band check was reading width instead of channels after transpose

