### PR TITLE
Block incompatible transformers versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ dependencies = [
     "torch>=2.2.0",
     "torchvision>=0.17.0",
     "tqdm",
-    "transformers",
+    "transformers!=5.1.0,!=4.57",
     "xmltodict",
 ]
 


### PR DESCRIPTION
This PR adds some version exclusions for transformers to prevent a couple of bugs from causing the CI to fail. These are known to be 4.57.x and 5.1.0, currently. Fixes for underlying issues have been proposed or merged upstream, so alternatively we could wait for the next release cycle.
