### PR TITLE
added test and fix to multiImage using the same indices during batch

### DIFF
--- a/src/deepforest/main.py
+++ b/src/deepforest/main.py
@@ -887,10 +887,10 @@ class deepforest(pl.LightningModule):
         """
         if isinstance(batch, dict):
             images = batch["images"]
-            sublist_lengths = batch["sublist_lengths"]
-            self.original_batch_structure.append(sublist_lengths)
+            batch_indices = batch["batch_indices"]
+            self.original_batch_structure.append(batch_indices)
         else:
-            sublist_lengths = None
+            batch_indices = None
             images = batch
 
         self.model.eval()


### PR DESCRIPTION
I found a bug in the MultiImage dataset predict_tile strategy. It was using the same index for each batch, leading to incorrect matching with the filename! High priority in the sense that this is a bug, low priority in the sense that a think few users are using the high performance workflow piece. 

For example this passes

dataloader_strategy="single"

```
def test_predict_tile_batch_uses_global_image_indices(m, tmp_path):
    """Batch strategy must assign image_path using global dataset indices, not batch position.
    """
    source = get_data("OSBS_029.png")
    num_images = 5
    paths = []
    for i in range(num_images):
        dest = tmp_path / f"image_{i}.png"
        shutil.copy(source, dest)
        paths.append(str(dest))
    m.config.train.fast_dev_run = False
    m.create_trainer()
    m.load_model("weecology/deepforest-tree")
    prediction = m.predict_tile(
        path=paths,
        patch_size=300,
        patch_overlap=0,
        dataloader_strategy="single",
    )
    unique_paths = prediction.image_path.unique().tolist()
    assert len(unique_paths) == num_images
    expected_basenames = sorted(os.path.basename(p) for p in paths)
    assert sorted(unique_paths) == expected_basenames
```
but this fails

dataloader_strategy="batch"
```
def test_predict_tile_batch_uses_global_image_indices(m, tmp_path):
    """Batch strategy must assign image_path using global dataset indices, not batch position.
    """
    source = get_data("OSBS_029.png")
    num_images = 5
    paths = []
    for i in range(num_images):
        dest = tmp_path / f"image_{i}.png"
        shutil.copy(source, dest)
        paths.append(str(dest))
    m.config.train.fast_dev_run = False
    m.create_trainer()
    m.load_model("weecology/deepforest-tree")
    prediction = m.predict_tile(
        path=paths,
        patch_size=300,
        patch_overlap=0,
        dataloader_strategy="batch",
    )
    unique_paths = prediction.image_path.unique().tolist()
    assert len(unique_paths) == num_images
    expected_basenames = sorted(os.path.basename(p) for p in paths)
    assert sorted(unique_paths) == expected_basenames
```

It was a fairly simple fix, you need to keep the global index appended to the list. Cursor and I disagreed what was more pythonic, I did it as an iterator and it recommended a subclass. I don't think it matters much.

# Agentic statement

I found the error and the cause. I asked cursor to create a test to see if it failed. I implemented a fix, which I asked cursor to check. We argued about what fix was more pythonic and I relented to a subclass approach. 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `predict_tile(..., dataloader_strategy="batch")` tracks image/window indices across dataloader batches, which can affect how predictions are attributed to image paths. Scope is limited to the batch tiling workflow and is covered by a new regression test.
> 
> **Overview**
> Fixes a bug in `predict_tile`’s `dataloader_strategy="batch"` where predictions could be assigned the wrong `image_path` because batch collation used *batch position* rather than the *global dataset index*.
> 
> `MultiImage` now wraps each image’s crop list in `_IndexedCrops` to carry the dataset index through `collate_fn`, emits `batch_indices` instead of `sublist_lengths`, and `postprocess` uses those indices to format results with the correct image/window metadata. A new test asserts that batching across multiple identical images yields one unique `image_path` per input file.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 55cb4c9eabc6d5e4ad28cdd96738e9c0da679a8d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->