### PR TITLE
[WIP]: Improve predict_tile memory use and windowed raster inference 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "deepforest"
 version = "2.0.1dev0"
 description = "Platform for individual detection from airborne remote sensing including trees, birds, and livestock. Supports multiple detection models, adding models for species classification, and easy fine tuning to particular ecosystems."
 readme = "README.md"
-requires-python = ">=3.10,<3.13"
+requires-python = ">=3.10,<3.14"
 license = {text = "MIT"}
 keywords = ["deep-learning", "forest", "ecology", "computer-vision"]
 classifiers = [

--- a/src/deepforest/datasets/prediction.py
+++ b/src/deepforest/datasets/prediction.py
@@ -74,6 +74,8 @@ def _ensure_rgb_chw_float32(image: np.ndarray) -> np.ndarray:
             )
         if max_val > 1.0:
             if max_val <= 255.0:
+                if np.shares_memory(chw, image):
+                    chw = chw.copy()
                 chw /= 255.0
             else:
                 raise ValueError(

--- a/src/deepforest/main.py
+++ b/src/deepforest/main.py
@@ -241,6 +241,26 @@ class deepforest(pl.LightningModule):
 
         self.trainer = pl.Trainer(**trainer_args)
 
+        # Helpful warning: CUDA visible but trainer not using it.
+        # This commonly happens if accelerator/devices were overridden to CPU, or
+        # if the trainer wasn't recreated after changing config.
+        try:
+            accel_name = type(self.trainer.accelerator).__name__.lower()
+        except Exception:
+            accel_name = ""
+
+        requested_accel = str(trainer_args.get("accelerator", "")).lower()
+        if torch.cuda.is_available() and requested_accel in {"auto", "gpu", "cuda"}:
+            if "cuda" not in accel_name and "gpu" not in accel_name:
+                warnings.warn(
+                    "CUDA appears to be available, but the Lightning trainer is not "
+                    f"using a GPU accelerator (accelerator={trainer_args.get('accelerator')}, "
+                    f"devices={trainer_args.get('devices')}). "
+                    "To force GPU inference, call create_trainer(accelerator='gpu', devices=1) "
+                    "or set config.accelerator='gpu' and config.devices=1, then recreate the trainer.",
+                    stacklevel=2,
+                )
+
     def on_fit_start(self):
         if self.config.train.csv_file is None:
             raise AttributeError(

--- a/src/deepforest/main.py
+++ b/src/deepforest/main.py
@@ -606,23 +606,24 @@ class deepforest(pl.LightningModule):
                         patch_size=patch_size,
                     )
 
-                dataloader = self.predict_dataloader(ds)
-                batched_results = self.trainer.predict(self, dataloader)
+                try:
+                    dataloader = self.predict_dataloader(ds)
+                    batched_results = self.trainer.predict(self, dataloader)
 
-                # Flatten list from batched prediction
-                # Track global window index across batches
-                global_window_idx = 0
-                for _idx, batch in enumerate(batched_results):
-                    for _window_idx, window_result in enumerate(batch):
-                        formatted_result = ds.postprocess(
-                            window_result, global_window_idx
-                        )
-                        image_results.append(formatted_result)
-                        global_window_idx += 1
-
-                # Ensure raster datasets are closed promptly
-                if hasattr(ds, "close"):
-                    ds.close()
+                    # Flatten list from batched prediction
+                    # Track global window index across batches
+                    global_window_idx = 0
+                    for _idx, batch in enumerate(batched_results):
+                        for _window_idx, window_result in enumerate(batch):
+                            formatted_result = ds.postprocess(
+                                window_result, global_window_idx
+                            )
+                            image_results.append(formatted_result)
+                            global_window_idx += 1
+                finally:
+                    # Ensure raster datasets are closed even if predict/postprocess raises
+                    if hasattr(ds, "close"):
+                        ds.close()
 
             if not image_results:
                 results = pd.DataFrame()

--- a/src/deepforest/main.py
+++ b/src/deepforest/main.py
@@ -600,6 +600,10 @@ class deepforest(pl.LightningModule):
                         image_results.append(formatted_result)
                         global_window_idx += 1
 
+                # Ensure raster datasets are closed promptly
+                if hasattr(ds, "close"):
+                    ds.close()
+
             if not image_results:
                 results = pd.DataFrame()
             else:
@@ -895,8 +899,7 @@ class deepforest(pl.LightningModule):
 
         self.model.eval()
         with torch.no_grad():
-            preds = self.model.forward(images)
-        return preds
+            return self.model.forward(images)
 
     def predict_batch(self, images, preprocess_fn=None):
         """Predict a batch of images with the deepforest model.

--- a/tests/hpc_multi_gpu_train.py
+++ b/tests/hpc_multi_gpu_train.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+"""HPC-only multi-GPU training smoke test (DDP).
+
+Run with:
+  torchrun --nproc_per_node=2 tests/hpc_multi_gpu_train.py
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import torch
+
+from deepforest import get_data
+from deepforest.main import deepforest
+
+
+def _require_hpc() -> None:
+    if os.environ.get("GITHUB_ACTIONS") or os.environ.get("CI"):
+        raise SystemExit("CI environment detected; skip HPC-only test.")
+    if not os.environ.get("HIPERGATOR") and not os.environ.get("SLURM_JOB_ID"):
+        raise SystemExit(
+            "This script is intended for HPC use only. "
+            "Set HIPERGATOR=1 or run under SLURM."
+        )
+
+
+def _require_ddp() -> None:
+    if "LOCAL_RANK" not in os.environ and "RANK" not in os.environ:
+        raise SystemExit(
+            "DDP environment not detected. Run with:\n"
+            "  torchrun --nproc_per_node=2 tests/hpc_multi_gpu_train.py"
+        )
+
+
+def main() -> int:
+    _require_hpc()
+    _require_ddp()
+
+    if torch.cuda.device_count() < 2:
+        raise SystemExit("Need at least 2 GPUs for this test.")
+
+    m = deepforest()
+    m.config.workers = 0
+    m.config.batch_size = 1
+    m.config.num_classes = 1
+    m.config.label_dict = {"Tree": 0}
+    train_csv = get_data("example.csv")
+    m.config.train.csv_file = train_csv
+    m.config.train.root_dir = os.path.dirname(train_csv)
+    m.config.validation.csv_file = train_csv
+    m.config.validation.root_dir = os.path.dirname(train_csv)
+    m.create_model(initialize_model=True)
+
+    # Keep this fast but avoid fast_dev_run's zero-length warning in DDP.
+    m.create_trainer(
+        accelerator="gpu",
+        devices=2,
+        strategy="ddp",
+        fast_dev_run=False,
+        max_epochs=1,
+        limit_train_batches=2,
+        limit_val_batches=2,
+        log_every_n_steps=1,
+    )
+    m.trainer.fit(m)
+
+    # Multi-GPU evaluation pass (uses same example.csv)
+    m.trainer.validate(m)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_datasets_prediction.py
+++ b/tests/test_datasets_prediction.py
@@ -47,6 +47,34 @@ def test_valid_array():
     test_data = np.random.randint(0, 256, (300,300,3)).astype(np.uint8)
     SingleImage(image=test_data)
 
+
+def test_single_image_float32_0_255_consistent_normalization():
+    """Float32 [0, 255] crops must be normalized uniformly from full-image decision.
+
+    A dark crop (all pixels <= 1.0) would be misclassified as [0, 1] by the
+    per-crop heuristic; with the fix, we use the full-image max to decide once.
+    """
+    # Image: left half dark (0.5), right half bright (128). Full max > 1.
+    h, w = 200, 400
+    img = np.zeros((h, w, 3), dtype=np.float32)
+    img[:, : w // 2, :] = 0.5  # Dark region
+    img[:, w // 2 :, :] = 128.0  # Bright region
+    # CHW for preprocess.compute_windows
+    img = np.moveaxis(img, -1, 0)
+
+    ds = SingleImage(image=img, patch_size=100, patch_overlap=0)
+    assert len(ds) >= 2
+
+    # First crop(s) from dark region: max=0.5. Should be divided by 255 -> max ~0.002
+    dark_crop = ds[0]
+    assert dark_crop.shape == (3, 100, 100)
+    assert dark_crop.max().item() < 0.01, "Dark crop should be /255, not left as [0,1]"
+
+    # Crop from bright region: max=128. Should be divided by 255 -> max ~0.5
+    bright_idx = len(ds) - 1
+    bright_crop = ds[bright_idx]
+    assert bright_crop.max().item() > 0.4
+
 def test_MultiImage():
     ds = MultiImage(paths=[get_data("OSBS_029.png"), get_data("OSBS_029.png")],
                     patch_size=300,

--- a/tests/test_gpu_inference_uses_cuda.py
+++ b/tests/test_gpu_inference_uses_cuda.py
@@ -1,0 +1,39 @@
+import os
+
+import pytest
+import torch
+
+from deepforest import get_data
+from deepforest.main import deepforest
+
+
+@pytest.mark.skipif(
+    not os.environ.get("HIPERGATOR"),
+    reason="Only run on HIPERGATOR (requires GPU + model downloads).",
+)
+@pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="CUDA not available in this test environment.",
+)
+def test_predict_tile_uses_cuda_when_requested():
+    """Ensure predict_tile runs on CUDA when accelerator/devices request GPU.
+
+    This is a regression test to catch silent CPU fallbacks on GPU nodes.
+    """
+    m = deepforest(config_args={"accelerator": "gpu", "devices": 1, "workers": 0})
+    m.load_model(model_name="weecology/deepforest-tree", revision="main")
+    m.create_trainer(accelerator="gpu", devices=1)
+
+    results = m.predict_tile(
+        path=get_data("OSBS_029.png"),
+        patch_size=400,
+        patch_overlap=0.0,
+        iou_threshold=0.15,
+        dataloader_strategy="single",
+    )
+    assert results is not None and not results.empty
+
+    # Assert trainer is actually using a GPU accelerator (no silent CPU fallback).
+    assert m.trainer is not None
+    accel_name = type(m.trainer.accelerator).__name__.lower()
+    assert "cuda" in accel_name or "gpu" in accel_name


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of what this PR does -->

## Related Issue(s)

<!-- Link to related issues using: Closes #123, Fixes #456, Related to #789 -->
<!-- If no issue exists, explain why this change is needed -->


## AI-Assisted Development

<!-- Be transparent about AI tool usage -->

- [x] I used AI tools (e.g., GitHub Copilot, ChatGPT, etc.) in developing this PR
- [x] I understand all the code I'm submitting
- [x] I have reviewed and validated all AI-generated code

**AI tools used (if applicable):**
<!-- List AI tools used, if any -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core inference data loading/normalization and raster IO lifecycle, which can affect prediction correctness and performance on large tiles. Added guards/tests reduce risk but edge cases around raster windowing and multiprocessing still warrant review.
> 
> **Overview**
> Improves `predict_tile`/prediction datasets by making image preprocessing stricter and more consistent (shared RGB/CHW + dtype/range normalization) and preventing crop views from being mutated in-place (`SingleImage.get_crop()` now clones).
> 
> Hardens windowed raster inference (`TiledRaster`) by keeping a single raster handle open with explicit `close()`/pickle-safe reopen, warning (not failing) on non-tiled rasters, filtering/guarding against out-of-bounds/zero-size windows, and ensuring the handle is always closed via a `try/finally` in `predict_tile`.
> 
> Adds a warning when CUDA is available/requested but the Lightning `Trainer` isn’t actually using a GPU accelerator, plus new GPU/HPC-only regression tests for CUDA usage and multi-GPU DDP training; also bumps supported Python to `<3.14`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d847701d5c380e8d785bd63beda8a4accec9ad7c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->