### PR TITLE
Add regression test for HuggingFace model label_dict loading

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1172,3 +1172,25 @@ def test_custom_log_root(m, tmpdir):
 
     version_dir = version_dirs[0]
     assert version_dir.join("hparams.yaml").exists(), "hparams.yaml not found"
+
+def test_huggingface_model_loads_correct_label_dict():
+    """Regression test for #1286:
+    HuggingFace models should load correct label_dict from config.json.
+    """
+    from deepforest import main
+
+    m = main.deepforest()
+    m.load_model(model_name="weecology/everglades-bird-species-detector")
+
+    expected = {
+        "Anhinga",
+        "Great Blue Heron",
+        "Great Egret",
+        "Roseate Spoonbill",
+        "Snowy Egret",
+        "White Ibis",
+        "Wood Stork",
+    }
+
+    actual = set(m.label_dict.keys())
+    assert actual == expected, f"Expected {expected}, got {actual}"


### PR DESCRIPTION
## Description

Adds a regression test to ensure HuggingFace models load the correct `label_dict` from their config.json instead of defaulting to `['Tree']`.

The test verifies that `weecology/everglades-bird-species-detector` loads all 7 expected bird species labels.

## Related Issue(s)

Fixes #1286

## Testing

- Test passes locally on dev branch
- Uses exact set comparison for strong regression coverage

## AI-Assisted Development

- [x] I used AI tools (e.g., GitHub Copilot, ChatGPT, etc.) in developing this PR
- [x] I understand all the code I'm submitting
- [x] I have reviewed and validated all AI-generated code

**AI tools used (if applicable):**
Used for guidance on test structure
