### PR TITLE
Expose detections_per_img and topk_candidates in config

### DIFF
--- a/src/deepforest/conf/config.yaml
+++ b/src/deepforest/conf/config.yaml
@@ -11,7 +11,8 @@ batch_size: 1
 architecture: 'retinanet'
 nms_thresh: 0.05
 score_thresh: 0.1
-
+detections_per_img: 300
+topk_candidates: 1000
 # Set model name to None to initialize from scratch
 model:
     name: 'weecology/deepforest-tree'

--- a/src/deepforest/conf/schema.py
+++ b/src/deepforest/conf/schema.py
@@ -144,6 +144,8 @@ class Config:
 
     nms_thresh: float = 0.05
     score_thresh: float = 0.1
+    detections_per_img: int = 300
+    topk_candidates: int = 1000
     model: ModelConfig = field(default_factory=ModelConfig)
 
     log_root: str = "./"

--- a/src/deepforest/models/retinanet.py
+++ b/src/deepforest/models/retinanet.py
@@ -201,6 +201,8 @@ class Model(BaseModel):
                 nms_thresh=self.config.nms_thresh,
                 score_thresh=self.config.score_thresh,
                 label_dict=label_dict,
+                detections_per_img=self.config.detections_per_img,
+                topk_candidates=self.config.topk_candidates,
             )
         else:
             # Pre 2.0 compatibility, the score_threshold used to be stored under retinanet.score_thresh
@@ -216,6 +218,8 @@ class Model(BaseModel):
                 label_dict=label_dict,
                 nms_thresh=self.config.nms_thresh,
                 score_thresh=self.config.score_thresh,
+                detections_per_img=self.config.detections_per_img,
+                topk_candidates=self.config.topk_candidates,
                 **hf_args,
             )
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1222,6 +1222,7 @@ def test_custom_log_root(m, tmpdir):
     version_dir = version_dirs[0]
     assert version_dir.join("hparams.yaml").exists(), "hparams.yaml not found"
 
+
 def test_huggingface_model_loads_correct_label_dict():
     """Regression test for #1286:
     HuggingFace models should load correct label_dict from config.json.
@@ -1243,6 +1244,7 @@ def test_huggingface_model_loads_correct_label_dict():
 
     actual = set(m.label_dict.keys())
     assert actual == expected, f"Expected {expected}, got {actual}"
+
 
 def test_existing_dataloader_end_to_end(tmp_path_factory):
     """Regression test for #1369 — verify training and validation
@@ -1283,3 +1285,24 @@ def test_existing_dataloader_end_to_end(tmp_path_factory):
 
     m.trainer.fit(m)
     m.trainer.validate(m)
+
+def test_detections_per_img_and_topk_candidates_config():
+    """Test that detections_per_img and topk_candidates can be configured
+    and are passed through to the underlying model."""
+    m = main.deepforest()
+
+    # Check default values
+    assert m.config.detections_per_img == 300
+    assert m.config.topk_candidates == 1000
+
+    # Test custom values
+    m.config.detections_per_img = 500
+    m.config.topk_candidates = 2000
+
+    assert m.config.detections_per_img == 500
+    assert m.config.topk_candidates == 2000
+
+    # Verify values are passed to actual model
+    m.create_model()
+    assert m.model.detections_per_img == 500
+    assert m.model.topk_candidates == 2000


### PR DESCRIPTION
This PR exposes `detections_per_img` and `topk_candidates` as configurable parameters so users can adjust them for dense scenes.

Currently, these values are hardcoded to the torchvision defaults (300 / 1000). In very dense imagery (e.g., large bird colonies or dense tree canopies), this limit can truncate valid detections.

### Changes
- Added `detections_per_img` and `topk_candidates` to `config.yaml` with current defaults.
- Passed these parameters through `Model.create_model()` → `RetinaNetHub()` → torchvision RetinaNet.
- Added tests in `test_main.py` to verify the parameters are correctly applied to the model.

### Backwards Compatibility
Defaults remain unchanged (300 / 1000), so existing workflows are unaffected.

### Benchmarks
See issue #1309 for details. On CPU, increasing the limit showed only modest overhead (~3–8%). The sample images in the repo did not reach the 300-detection cap, so I was not able to demonstrate detection differences locally. Happy to test further with denser imagery if available.

Fixes #1309

---

- [x] Used AI tools for guidance
- [x] I understand all submitted code
- [x] I reviewed and validated all AI-generated suggestions

