### PR TITLE
fix: add device param for DDP compatibility + refactor calculate_empty_frame_accuracy to evaluate.py (#1316)

### DIFF
--- a/src/deepforest/main.py
+++ b/src/deepforest/main.py
@@ -774,65 +774,21 @@ class deepforest(pl.LightningModule):
         self.predictions = []
 
     def calculate_empty_frame_accuracy(self, ground_df, predictions_df):
-        """Calculate accuracy for empty frames (frames with no objects).
+        """Wrapper for evaluate.calculate_empty_frame_accuracy."""
+        from deepforest import evaluate
 
-        Args:
-            ground_df (pd.DataFrame): Ground truth dataframe containing image paths and bounding boxes.
-                Must have columns 'image_path', 'xmin', 'ymin', 'xmax', 'ymax'.
-            predictions_df (pd.DataFrame): Model predictions dataframe containing image paths and predicted boxes.
-                Must have column 'image_path'.
-
-        Returns:
-            float or None: Accuracy score for empty frame detection. A score of 1.0 means the model correctly
-                identified all empty frames (no false positives), while 0.0 means it predicted objects
-                in all empty frames (all false positives). Returns None if there are no empty frames.
-        """
-        # Find images that are marked as empty in ground truth (all coordinates are 0)
-        empty_images = ground_df.loc[
-            (ground_df.xmin == 0)
-            & (ground_df.ymin == 0)
-            & (ground_df.xmax == 0)
-            & (ground_df.ymax == 0),
-            "image_path",
-        ].unique()
-
-        if len(empty_images) == 0:
+        # Check if model has empty_frame_accuracy metric
+        if not hasattr(self, "empty_frame_accuracy"):
             return None
 
-        if predictions_df.empty:
-            # Empty predictions with empty ground truth = 100% accuracy
-            empty_accuracy = 1
-        else:
-            # Get non-empty predictions for empty images
-            non_empty_predictions = predictions_df.loc[predictions_df.xmin.notnull()]
-            predictions_for_empty_images = non_empty_predictions.loc[
-                non_empty_predictions.image_path.isin(empty_images)
-            ]
-
-            # Create prediction tensor - 1 if model predicted objects, 0 if predicted empty
-            predictions = torch.zeros(len(empty_images))
-            for index, image in enumerate(empty_images):
-                if (
-                    len(
-                        predictions_for_empty_images.loc[
-                            predictions_for_empty_images.image_path == image
-                        ]
-                    )
-                    > 0
-                ):
-                    predictions[index] = 1
-
-            # Ground truth tensor - all zeros since these are empty frames
-            gt = torch.zeros(len(empty_images))
-            predictions = torch.tensor(predictions)
-
-            # Calculate accuracy using metric
-            self.empty_frame_accuracy.update(predictions, gt)
-            empty_accuracy = self.empty_frame_accuracy.compute()
-            self.empty_frame_accuracy.reset()
+        device = next(self.parameters()).device
+        empty_accuracy = evaluate.calculate_empty_frame_accuracy(
+            ground_df, predictions_df, self.empty_frame_accuracy, device
+        )
 
         # Log empty frame accuracy
-        self.log("empty_frame_accuracy", empty_accuracy)
+        if empty_accuracy is not None:
+            self.log("empty_frame_accuracy", empty_accuracy)
 
         return empty_accuracy
 


### PR DESCRIPTION
## Description

Addresses the DDP device mismatch error in `calculate_empty_frame_accuracy` where `torch.zeros` tensors were created on CPU, causing `RuntimeError: No backend type associated with device type cpu` during distributed `all_gather`.

**Changes:**
1. **Device fix:** Added `device = next(self.parameters()).device` so tensors are created on the correct device for DDP compatibility
2. **Refactor:** Moved core logic from `main.py` to `evaluate.py` as a standalone function, keeping a thin wrapper in `main.py` for `self.log()` and metric access
3. **Safety check:** Added `hasattr` guard for models initialized without `empty_frame_accuracy` metric

## Related Issue(s)

Fixes #1316

Steps completed from the issue roadmap:
- [x] Step 1: Confirmed existing empty frame tests pass on CPU (25 passed)
- [x] Step 3: Set device on torch tensors
- [x] Step 4: Moved function logic to `evaluate.py`, clean wrapper in `main.py`
- [ ] Step 2: GPU/DDP testing — @musaqlain will handle this on multi-GPU cluster

## AI-Assisted Development

- [x] I used AI tools (e.g., GitHub Copilot, ChatGPT, etc.) in developing this PR
- [x] I understand all the code I'm submitting
- [x] I have reviewed and validated all AI-generated code

**AI tools used (if applicable):**
Used LLM for initial guidance on understanding the DDP device handling pattern. All implementation decisions, code changes, and testing done manually.