### PR TITLE
disable PIL DecompressionBombError for large rasters in predict_tile

### DIFF
--- a/src/deepforest/main.py
+++ b/src/deepforest/main.py
@@ -11,6 +11,9 @@ import torch
 from lightning_fabric.utilities.exceptions import MisconfigurationException
 from omegaconf import DictConfig, OmegaConf
 from PIL import Image
+
+Image.MAX_IMAGE_PIXELS = None
+
 from pytorch_lightning.callbacks import LearningRateMonitor
 from torch import optim
 from torchmetrics.classification import BinaryAccuracy


### PR DESCRIPTION
When processing large orthomosaics via `predict_tile`, DeepForest triggers a `PIL.Image.DecompressionBombError` (or warning). This occurs because Pillow hardcodes a safety limit of ~89.5 million pixels to prevent DoS attacks, which standard drone imagery effortlessly exceeds.

**Technical Implementation**
* Added `Image.MAX_IMAGE_PIXELS = None` to the module initialization block in `src/deepforest/main.py`.

**AI usage acknowledgement**
- AI is used to pull knowledge from internet only. Fixes #1324.