### PR TITLE
Remove outdated evaluate code and just use trainer.validate.

### DIFF
--- a/src/deepforest/metrics.py
+++ b/src/deepforest/metrics.py
@@ -121,6 +121,8 @@ class RecallPrecision(Metric):
             numeric_to_label_dict=numeric_to_label_dict,
         )
 
+        self.results = results
+
         filtered_results = {}
 
         # Extract per-class recall/precision for multi class prediction only.

--- a/src/deepforest/scripts/cli.py
+++ b/src/deepforest/scripts/cli.py
@@ -104,10 +104,7 @@ def main():
         "--root-dir",
         help="Root directory containing images. Defaults to CSV directory if not specified.",
     )
-    evaluate_parser.add_argument(
-        "--predictions",
-        help="Path to existing predictions CSV file. If not provided, predictions will be generated.",
-    )
+
     evaluate_parser.add_argument(
         "--save-predictions",
         help="Path to save generated predictions CSV (only used when --predictions is not provided)",
@@ -165,7 +162,6 @@ def main():
             cfg,
             ground_truth=args.csv_file,
             root_dir=args.root_dir,
-            predictions=args.predictions,
             output_path=args.output,
             save_predictions=args.save_predictions,
         )

--- a/src/deepforest/scripts/evaluate.py
+++ b/src/deepforest/scripts/evaluate.py
@@ -11,7 +11,6 @@ def evaluate(
     config: DictConfig,
     ground_truth: str | None = None,
     root_dir: str | None = None,
-    predictions: str | None = None,
     output_path: str | None = None,
     save_predictions: str | None = None,
 ) -> None:
@@ -33,7 +32,6 @@ def evaluate(
         config (DictConfig): DeepForest configuration
         ground_truth (Optional[str]): Path to ground truth CSV file with annotations. If None, uses config.validation.csv_file.
         root_dir (Optional[str]): Root directory containing images. If None, uses config value or directory of csv_file.
-        predictions (Optional[str]): Path to existing predictions CSV file. If None, generates predictions.
         output_path (Optional[str]): Path to save evaluation metrics summary CSV.
         save_predictions (Optional[str]): Path to save generated predictions CSV. Only used when predictions is None.
 
@@ -53,18 +51,13 @@ def evaluate(
     if root_dir is None:
         root_dir = config.validation.root_dir
 
-    # TODO: Use trainer.validate in future?
-    if predictions:
-        predictions = pd.read_csv(predictions)
-
-    results = m.__evaluate__(
+    results = m.evaluate(
         csv_file=ground_truth,
         root_dir=root_dir,
-        predictions=predictions,
     )
 
     # Save generated predictions if requested and they were generated (not loaded from file)
-    if save_predictions is not None and predictions is None:
+    if save_predictions is not None:
         predictions_df = results.get("predictions")
         if predictions_df is not None and not predictions_df.empty:
             if os.path.dirname(save_predictions):
@@ -76,11 +69,6 @@ def evaluate(
                 "Warning: No predictions to save (predictions dataframe is empty)",
                 stacklevel=2,
             )
-    elif save_predictions is not None and predictions is not None:
-        warn(
-            "--save-predictions is ignored when --predictions is provided (predictions already exist)",
-            stacklevel=2,
-        )
 
     # Print results to console
     m.print("Evaluation Results:")

--- a/tests/test_cli_evaluate.py
+++ b/tests/test_cli_evaluate.py
@@ -102,31 +102,6 @@ def test_evaluate_saves_predictions(tmp_path):
     assert len(predictions) > 0
 
 
-def test_evaluate_with_existing_predictions(tmp_path):
-    csv_file = get_data("OSBS_029.csv")
-    root_dir = os.path.dirname(csv_file)
-    config = load_config()
-
-    predictions_path = tmp_path / "predictions.csv"
-    evaluate(
-        config,
-        ground_truth=csv_file,
-        root_dir=root_dir,
-        save_predictions=str(predictions_path),
-    )
-    assert predictions_path.exists()
-
-    output_path = tmp_path / "eval_results.csv"
-    evaluate(
-        config,
-        ground_truth=csv_file,
-        root_dir=root_dir,
-        predictions=str(predictions_path),
-        output_path=str(output_path),
-    )
-    assert output_path.exists()
-
-
 def test_cli_evaluate_subcommand(tmp_path):
     csv_file = get_data("OSBS_029.csv")
     root_dir = os.path.dirname(csv_file)

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -98,7 +98,7 @@ def test_evaluate_empty(m, tmp_path):
                                      "label_dict": {"Tree": 0},
                                      "num_classes": 1})
     csv_file = get_data("OSBS_029.csv")
-    results = m.evaluate(csv_file, iou_threshold=0.4, root_dir=os.path.dirname(csv_file))
+    results = m.evaluate(csv_file, root_dir=os.path.dirname(csv_file))
 
     # Does this make reasonable predictions, we know the model works.
     assert np.isnan(results["box_precision"])

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -554,7 +554,7 @@ def test_predict_tile_from_array(m, path):
 
 def test_evaluate(m):
     csv_file = get_data("OSBS_029.csv")
-    results = m.evaluate(csv_file, iou_threshold=0.4)
+    results = m.evaluate(csv_file)
 
     assert np.round(results["box_precision"], 2) > 0.5
     assert np.round(results["box_recall"], 2) > 0.5


### PR DESCRIPTION
This PR 

* Removes ``__evaluate__`` and calculate_empty_frame accuracy
* uses trainer.evaluate in main.evaluate()
* Keeps the output structure that user is used to 
* stashes the .results object in the trainer.

closes #1316 

and simplifies the code.

Thanks to @jveitchmichaelis for his idea here. 
