### PR TITLE
Update loaded GitHub Actions and pin to hash

### DIFF
--- a/.github/workflows/automate-waiting-labels.yml
+++ b/.github/workflows/automate-waiting-labels.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Remove label
-      uses: actions/github-script@v5
+      uses: actions/github-script@9513afd82fbc900d13362cdd4fcdab0538f5124e
       with:
         script: |
           const issueNumber = context.issue.number || context.pull_request.number;

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd"
 
       - name: Install opencv dependencies
         run: |
@@ -43,7 +43,7 @@ jobs:
           sudo apt-get install -y pandoc
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -57,7 +57,7 @@ jobs:
         run: uv run pytest -v --cov=src/deepforest --cov-report=xml --cov-report=term-missing -o tmp_path_retention=none tests/
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de
         with:
           file: ./coverage.xml
           flags: unittests

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     if: "!contains(github.ref, '-dev')"
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.11"
       
@@ -22,7 +22,7 @@ jobs:
           python -m build
 
       - name: Publish to Test PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e
         with:
           password: ${{ secrets.TEST_PYPI_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
@@ -34,8 +34,8 @@ jobs:
     if: "!contains(github.ref, '-dev')"  # Skip dev versions
     needs: [test-pypi]  # Wait for test-pypi to succeed
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.11"
 
@@ -45,7 +45,7 @@ jobs:
           python -m build
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e
         with:
           password: ${{ secrets.PYPI_TOKEN }}
           skip-existing: true


### PR DESCRIPTION
This updates the GitHub Actions we load to the newest release and pins those releases to a specific hash. Pinning to a specific hash is considered a security best practice for avoiding upstream compromises of the actions we use:

https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions

This PR eliminates the High threats indicated by zizmor

## AI-Assisted Development

None