### PR TITLE
Fix: syntax errors in utility function validations

### DIFF
--- a/src/deepforest/utilities.py
+++ b/src/deepforest/utilities.py
@@ -224,13 +224,27 @@ def shapefile_to_annotations(
     convert_point: bool = False,
     label: str | None = None,
 ) -> gpd.GeoDataFrame:
-    raise DeprecationWarning(
-        "shapefile_to_annotations is deprecated, use read_file instead"
+    warnings.warn(
+        "shapefile_to_annotations is deprecated, use read_file instead",
+        DeprecationWarning,
+        stacklevel=2,
     )
 
     if buffer_size is not None and convert_point:
-        raise DeprecationWarning(
-            "buffer_size argument is deprecated, use convert_point_to_bbox instead"
+        warnings.warn(
+            "buffer_size argument is deprecated, use convert_point_to_bbox instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+    if isinstance(shapefile, str):
+        shapefile_path = shapefile
+        shapefile = gpd.read_file(shapefile_path)
+        shapefile = DeepForest_DataFrame(shapefile)
+        shapefile = __assign_image_path__(shapefile, image_path=rgb)
+        shapefile = __check_and_assign_label__(shapefile, label=label)
+        shapefile = __assign_root_dir__(
+            input=shapefile_path, gdf=shapefile, root_dir=root_dir
         )
 
     return __shapefile_to_annotations__(shapefile)
@@ -247,12 +261,13 @@ def __assign_image_path__(gdf, image_path: str) -> str:
             pass
     else:
         if "image_path" in gdf.columns:
-            existing_image_path = gdf.image_path.unique()[0]
-            if len(existing_image_path) > 1:
+            existing_image_paths = gdf.image_path.unique()
+            if len(existing_image_paths) > 1:
                 warnings.warn(
-                    f"Multiple image_paths found in dataframe: {existing_image_path}, overriding and assigning {image_path} to all rows!",
+                    f"Multiple image_paths found in dataframe: {existing_image_paths}, overriding and assigning {image_path} to all rows!",
                     stacklevel=2,
                 )
+            existing_image_path = existing_image_paths[0]
             if existing_image_path != image_path:
                 warnings.warn(
                     f"Image path {existing_image_path} found in dataframe, overriding and assigning {image_path} to all rows!",

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -155,6 +155,47 @@ def test_read_file_shapefile_without_image_path(tmp_path):
     assert "label" in result.columns
     assert hasattr(result, "root_dir")
 
+def test_shapefile_to_annotations_deprecation_warning(tmp_path):
+    """shapefile_to_annotations should emit DeprecationWarning, not raise it."""
+    import warnings
+    sample_geometry = [geometry.Point(404211.9 + 10, 3285102 + 20)]
+    labels = ["Tree"]
+    df = pd.DataFrame({"geometry": sample_geometry, "label": labels})
+    gdf = gpd.GeoDataFrame(df, geometry="geometry", crs="EPSG:32617")
+    gdf["geometry"] = [geometry.box(left, bottom, right, top) for left, bottom, right, top in
+                       gdf.geometry.buffer(0.5).bounds.values]
+    gdf["image_path"] = os.path.basename(get_data("OSBS_029.tif"))
+    shp_path = str(tmp_path / "annotations.shp")
+    gdf.to_file(shp_path)
+
+    with pytest.warns(DeprecationWarning, match="shapefile_to_annotations is deprecated"):
+        result = utilities.shapefile_to_annotations(shp_path, root_dir=os.path.dirname(get_data("OSBS_029.tif")))
+    assert result is not None
+
+def test_assign_image_path_warns_on_override():
+    """__assign_image_path__ should warn when overriding an existing image_path."""
+    import warnings
+    sample_geometry = [geometry.box(0, 0, 1, 1)]
+    df = pd.DataFrame({"geometry": sample_geometry, "label": ["Tree"], "image_path": ["old_image.tif"]})
+    gdf = gpd.GeoDataFrame(df, geometry="geometry")
+
+    with pytest.warns(UserWarning, match="overriding and assigning"):
+        utilities.__assign_image_path__(gdf, image_path="new_image.tif")
+
+def test_assign_image_path_warns_multiple_paths():
+    """__assign_image_path__ should warn when multiple image_paths exist."""
+    import warnings
+    sample_geometry = [geometry.box(0, 0, 1, 1), geometry.box(2, 2, 3, 3)]
+    df = pd.DataFrame({
+        "geometry": sample_geometry,
+        "label": ["Tree", "Tree"],
+        "image_path": ["image_a.tif", "image_b.tif"]
+    })
+    gdf = gpd.GeoDataFrame(df, geometry="geometry")
+
+    with pytest.warns(UserWarning, match="Multiple image_paths found"):
+        utilities.__assign_image_path__(gdf, image_path="override.tif")
+
 def test_shapefile_to_annotations_invalid_epsg(tmp_path):
     sample_geometry = [geometry.Point(404211.9 + 10, 3285102 + 20), geometry.Point(404211.9 + 20, 3285102 + 20)]
     labels = ["Tree", "Tree"]


### PR DESCRIPTION
### Description
This PR addresses bugs in `src/deepforest/utilities.py` where validation checks would either crash the program or execute incorrect string length logic.

**Changes:**
- **Deprecation Warnings**: Replaced `raise DeprecationWarning(...)` with `warnings.warn(..., DeprecationWarning)`. The previous implementation threw an exception and killed the process, effectively making the functions unreachable.
- **String Length Check**: Fixed a logic bug in `__assign_image_path__` where `len()` was evaluated on the first character of the image path string instead of on the array of unique existing paths. This prevented false-positive warnings from firing on valid string paths.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
nge which fixes an issue)

## AI-Assisted Development

<!-- Be transparent about AI tool usage -->

- [x] I used AI tools (e.g., GitHub Copilot, ChatGPT, etc.) in developing this PR
- [x] I understand all the code I'm submitting
- [x] I have reviewed and validated all AI-generated code

**AI tools used (if applicable):**
<!-- List AI tools used, if any -->
AI tools were initially used to understand the codebase better. but  code was written and verified manually.
