### PR TITLE
Fix dictionary key type mismatch causing KeyError during metrics eval

### DIFF
--- a/src/deepforest/metrics.py
+++ b/src/deepforest/metrics.py
@@ -94,7 +94,7 @@ class RecallPrecision(Metric):
         """Computes the recall/precision metrics."""
 
         ground_df = utilities.read_file(self.csv_file)
-        numeric_to_label_dict = {v: k for k, v in self.label_dict.items()}
+        numeric_to_label_dict = {int(v): k for k, v in self.label_dict.items()}
         ground_df["label"] = ground_df.label.apply(lambda x: self.label_dict[x])
 
         predictions = pd.DataFrame()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1173,6 +1173,31 @@ def test_custom_log_root(m, tmpdir):
     version_dir = version_dirs[0]
     assert version_dir.join("hparams.yaml").exists(), "hparams.yaml not found"
 
+def test_recall_precision_string_label_dict(tmp_path):
+    """Test that RecallPrecision handles string-based numeric values in label_dict."""
+    from deepforest.metrics import RecallPrecision
+    import torch
+
+    ground_df = pd.read_csv(get_data("example.csv"))
+    csv_file = tmp_path / "ground_truth.csv"
+    ground_df.to_csv(csv_file, index=False)
+
+    # Initialize with string '0' instead of int 0
+    metric = RecallPrecision(csv_file=str(csv_file), label_dict={"Tree": "0"})
+
+    preds = [{
+        'boxes': torch.tensor([[0.0, 0.0, 10.0, 10.0]]),
+        'scores': torch.tensor([1.0]),
+        'labels': torch.tensor([0])
+    }]
+
+    image_name = ground_df.image_path.iloc[0]
+    metric.update(preds, [image_name])
+
+    results = metric.compute()
+    assert "box_precision" in results
+    assert "box_recall" in results
+
 def test_huggingface_model_loads_correct_label_dict():
     """Regression test for #1286:
     HuggingFace models should load correct label_dict from config.json.


### PR DESCRIPTION
### Description
This PR fixes a bug in `src/deepforest/metrics.py` where evaluating predictions resulted in a `KeyError` due to dictionary type mismatches.

**Changes:**
- In the `RecallPrecision.compute()` method, the `numeric_to_label_dict` generation now casts the keys (the `numeric` value from `label_dict`) to `int`. 
- Previously, if the original `label_dict` contained string-based integer values (e.g. `{"Tree": "0"}`), the model outputs (which are proper integers) failed to map backward to their corresponding labels during the evaluation metrics calculation.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issue
closes #1344 

## AI-Assisted Development

<!-- Be transparent about AI tool usage -->

- [x] I used AI tools (e.g., GitHub Copilot, ChatGPT, etc.) in developing this PR
- [x] I understand all the code I'm submitting
- [x] I have reviewed and validated all AI-generated code


