### PR TITLE
fix : open each image once in _validate_coordinates via groupby (#1341)

### DIFF
--- a/src/deepforest/datasets/training.py
+++ b/src/deepforest/datasets/training.py
@@ -109,8 +109,8 @@ class BoxDataset(Dataset):
             ValueError: If any bounding box coordinate occurs outside the image
         """
         errors = []
-        for _idx, row in self.annotations.iterrows():
-            img_path = os.path.join(self.root_dir, row["image_path"])
+        for image_path, group in self.annotations.groupby("image_path"):
+            img_path = os.path.join(self.root_dir, image_path)
             try:
                 with Image.open(img_path) as img:
                     width, height = img.size
@@ -118,35 +118,36 @@ class BoxDataset(Dataset):
                 errors.append(f"Failed to open image {img_path}: {e}")
                 continue
 
-            # Extract bounding box
-            geom = row["geometry"]
-            xmin, ymin, xmax, ymax = geom.bounds
+            for _idx, row in group.iterrows():
+                # Extract bounding box
+                geom = row["geometry"]
+                xmin, ymin, xmax, ymax = geom.bounds
 
-            # All coordinates equal to zero is how we code empty frames.
-            # Therefore these are valid coordinates even though they would
-            # fail other checks.
-            if xmin == 0 and ymin == 0 and xmax == 0 and ymax == 0:
-                continue
+                # All coordinates equal to zero is how we code empty frames.
+                # Therefore these are valid coordinates even though they would
+                # fail other checks.
+                if xmin == 0 and ymin == 0 and xmax == 0 and ymax == 0:
+                    continue
 
-            # Check if box is valid
-            oob_issues = []
-            if not geom.equals(shapely.envelope(geom)):
-                oob_issues.append(f"geom ({geom}) is not a valid bounding box")
-            if xmin < 0:
-                oob_issues.append(f"xmin ({xmin}) < 0")
-            if xmax > width:
-                oob_issues.append(f"xmax ({xmax}) > image width ({width})")
-            if ymin < 0:
-                oob_issues.append(f"ymin ({ymin}) < 0")
-            if ymax > height:
-                oob_issues.append(f"ymax ({ymax}) > image height ({height})")
-            if math.isclose(geom.area, 1):
-                oob_issues.append("area of bounding box is a single pixel")
+                # Check if box is valid
+                oob_issues = []
+                if not geom.equals(shapely.envelope(geom)):
+                    oob_issues.append(f"geom ({geom}) is not a valid bounding box")
+                if xmin < 0:
+                    oob_issues.append(f"xmin ({xmin}) < 0")
+                if xmax > width:
+                    oob_issues.append(f"xmax ({xmax}) > image width ({width})")
+                if ymin < 0:
+                    oob_issues.append(f"ymin ({ymin}) < 0")
+                if ymax > height:
+                    oob_issues.append(f"ymax ({ymax}) > image height ({height})")
+                if math.isclose(geom.area, 1):
+                    oob_issues.append("area of bounding box is a single pixel")
 
-            if oob_issues:
-                errors.append(
-                    f"Box, ({xmin}, {ymin}, {xmax}, {ymax}) exceeds image dimensions, ({width}, {height}). Issues: {', '.join(oob_issues)}."
-                )
+                if oob_issues:
+                    errors.append(
+                        f"Box, ({xmin}, {ymin}, {xmax}, {ymax}) exceeds image dimensions, ({width}, {height}). Issues: {', '.join(oob_issues)}."
+                    )
 
         if errors:
             raise ValueError("\n".join(errors))


### PR DESCRIPTION
## Summary

`_validate_coordinates` in `BoxDataset` (`src/deepforest/datasets/training.py`) iterated every annotation row using `.iterrows()` and called `Image.open()` per row. For a dataset with **N** bounding boxes across **M** images, this opened image files **N times instead of M times**.

This PR refactors the method to use `self.annotations.groupby('image_path')`, opening each unique image **exactly once** and validating all its boxes against the cached dimensions.

## Changes

- Replaced the flat `iterrows()` loop with a `groupby('image_path')` outer loop
- Each unique image is opened once; boxes are validated in an inner loop
- All validation checks and error messages are **unchanged**

## Impact

- For 10,000 annotations across 100 images: **100 file opens instead of 10,000** (100x reduction)
- No functional change — all existing tests pass

## Tests Verified

- `test_BoxDataset_validate_coordinates` 
- `test_validate_BoxDataset_missing_image` 
- `test_BoxDataset_validate_non_rectangular_polygon` 
- All 16 tests in `test_datasets_training.py` pass

## Related Issues
closes issue #1341 

## AI-Assisted Development

<!-- Be transparent about AI tool usage -->

- [x] I used AI tools (e.g., GitHub Copilot, ChatGPT, etc.) in developing this PR
- [x] I understand all the code I'm submitting
- [x] I have reviewed and validated all AI-generated code

**AI tools used (if applicable):**
<!-- List AI tools used, if any -->
AI used for understanding initial codebase better. All code was verified manually.
