### PR TITLE
refactor recall_precision metric for better DDP support

### DIFF
--- a/src/deepforest/main.py
+++ b/src/deepforest/main.py
@@ -12,7 +12,6 @@ from PIL import Image
 from pytorch_lightning.callbacks import LearningRateMonitor
 from pytorch_lightning.loggers import CSVLogger
 from torch import optim
-from torchmetrics.classification import BinaryAccuracy
 from torchmetrics.detection import IntersectionOverUnion, MeanAveragePrecision
 
 from deepforest import predict, utilities
@@ -99,11 +98,8 @@ class deepforest(pl.LightningModule):
         )
         self.mAP_metric = MeanAveragePrecision(backend="faster_coco_eval")
 
-        # Empty frame accuracy
-        self.empty_frame_accuracy = BinaryAccuracy()
-
         self.precision_recall_metric = RecallPrecision(
-            csv_file=self.config.validation.csv_file,
+            iou_threshold=self.config.validation.iou_threshold,
             label_dict=self.label_dict,
         )
 
@@ -732,33 +728,19 @@ class deepforest(pl.LightningModule):
         with torch.no_grad():
             preds = self.model.forward(images, targets)
 
-        if len(targets) > 0:
-            # Remove empty targets and corresponding predictions
-            filtered_preds = []
-            filtered_targets = []
+        # Compute precision, recall and empty frame metrics.
+        self.precision_recall_metric.update(preds, targets, image_names)
 
-            for i, target in enumerate(targets):
-                # Empty frame accuracy
-                is_empty_frame = target["boxes"].numel() == 0 or torch.all(
-                    target["boxes"] == 0
-                )
-                if is_empty_frame:
-                    # 0 indicates empty frame or predication
-                    device = target["boxes"].device
-                    self.empty_frame_accuracy.update(
-                        torch.tensor([min(len(preds[i]["boxes"]), 1)], device=device),
-                        torch.tensor([0.0], device=device),
-                    )
-                else:
-                    # Non-empty frames go to all metrics
-                    filtered_preds.append(preds[i])
-                    filtered_targets.append(target)
+        # Filter out empty frames for IoU/mAP metrics. pred + target
+        non_empty_pred = []
+        non_empty_target = []
+        for pred, target in zip(preds, targets, strict=True):
+            if not (target["boxes"].numel() == 0 or torch.all(target["boxes"] == 0)):
+                non_empty_pred.append(pred)
+                non_empty_target.append(target)
 
-            # IoU and mAP metrics need preds/targets to exist
-            self.iou_metric.update(filtered_preds, filtered_targets)
-            self.mAP_metric.update(filtered_preds, filtered_targets)
-            # Precision recall metric can handle empty frames internally
-            self.precision_recall_metric.update(preds, image_names)
+        self.iou_metric.update(non_empty_pred, non_empty_target)
+        self.mAP_metric.update(non_empty_pred, non_empty_target)
 
         # Log the predictions if you want to use them for evaluation logs
         for i, result in enumerate(preds):
@@ -792,10 +774,6 @@ class deepforest(pl.LightningModule):
         # Box recall/precision
         metrics.update(self.precision_recall_metric.compute())
 
-        # Empty frame accuracy
-        if self.empty_frame_accuracy.update_called:
-            metrics["empty_frame_accuracy"] = self.empty_frame_accuracy.compute()
-
         return metrics
 
     def on_validation_epoch_end(self):
@@ -814,7 +792,6 @@ class deepforest(pl.LightningModule):
         self.precision_recall_metric.reset()
         self.iou_metric.reset()
         self.mAP_metric.reset()
-        self.empty_frame_accuracy.reset()
 
     def predict_step(self, batch, batch_idx):
         """Predict a batch of images with the deepforest model. If batch is a
@@ -980,7 +957,27 @@ class deepforest(pl.LightningModule):
         self.create_trainer()
         self.trainer.validate(self)
 
-        # Read back the full results stashed by RecallPrecision.compute()
-        results = self.precision_recall_metric.results
+        # Gather predictions from all ranks in multi-GPU settings
+        if self.trainer.world_size > 1:
+            all_predictions = [None] * self.trainer.world_size
+            torch.distributed.all_gather_object(all_predictions, self.predictions)
+            self.predictions = [pred for preds in all_predictions for pred in preds]
+
+        # Concat prediction dataframes and convert numeric labels to strings
+        if len(self.predictions) > 0:
+            self.predictions = pd.concat(self.predictions, ignore_index=True)
+            if "label" in self.predictions.columns:
+                self.predictions["label"] = self.predictions["label"].map(
+                    lambda x: self.numeric_to_label_dict.get(int(x), x)
+                    if pd.notna(x)
+                    else x
+                )
+        else:
+            self.predictions = pd.DataFrame()
+
+        results = {}
+        results.update(self.trainer.logged_metrics)
+        results["predictions"] = self.predictions
+        results["results"] = self.precision_recall_metric.get_results()
 
         return results

--- a/src/deepforest/metrics.py
+++ b/src/deepforest/metrics.py
@@ -1,152 +1,219 @@
-import warnings
-
-import geopandas as gpd
 import pandas as pd
 import torch
 from torch import Tensor
 from torchmetrics import Metric
 
 from deepforest import utilities
-from deepforest.evaluate import __evaluate_wrapper__
+from deepforest.evaluate import compute_class_recall, match_predictions
 
 
 class RecallPrecision(Metric):
     """DeepForest box recall and precision metric.
 
     This class is a thin wrapper around evaluate_boxes to compute box
-    recall and precision during validation. In multi-GPU environments,
-    each rank runs evaluation on the full (gathered) dataset.
+    recall and precision during validation.
     """
 
-    boxes: list[Tensor]
-    labels: list[Tensor]
-    scores: list[Tensor]
-    image_indices: list[Tensor]
+    image_indices: list
 
     def __init__(
         self,
-        csv_file: str,
-        label_dict: dict,
         task="box",
         iou_threshold: float = 0.4,
+        label_dict: dict | None = None,
         **kwargs,
     ) -> None:
         """This metric performs DeepForest's box recall and precision
         evaluation.
 
         Args:
-            csv_file (str): Path to CSV file with ground truth boxes.
-            label_dict (dict): Dictionary mapping string labels to numeric labels.
+            task (str, optional): The type of task to evaluate. Defaults to "box".
             iou_threshold (float, optional): IOU threshold for evaluation. Defaults to 0.4.
+            label_dict (dict | None): Mapping of class name to numeric ID. When
+                provided and more than one class is present, per-class recall and
+                precision are included in the ``compute()`` output.
         """
         super().__init__(**kwargs)
 
-        self.csv_file = csv_file
         self.iou_threshold = iou_threshold
-        self.label_dict = label_dict
+        self.task = task
+        self.label_dict = label_dict or {}
+        self.numeric_to_label_dict = {v: k for k, v in self.label_dict.items()}
 
         if task != "box":
             raise NotImplementedError("Only 'box' task is currently supported.")
 
-        # Create image path index mappings. This is necessary
-        # as we can't sync strings across multiple GPUs by default.
-        ground_df = utilities.read_file(csv_file)
-        unique_paths = sorted(ground_df["image_path"].unique())
-        self.path_to_index = {path: idx for idx, path in enumerate(unique_paths)}
-        self.index_to_path = {idx: path for path, idx in self.path_to_index.items()}
-
-        self.add_state("boxes", default=[], dist_reduce_fx=None)
-        self.add_state("labels", default=[], dist_reduce_fx=None)
-        self.add_state("scores", default=[], dist_reduce_fx=None)
-        self.add_state("image_indices", default=[], dist_reduce_fx=None)
-
-    def update(self, preds: list[dict[str, Tensor]], image_names: list[str]) -> None:
-        """Update the metric with new predictions.
-
-        Args:
-            preds (list[dict[str, Tensor]]): List of prediction dictionaries from the model.
-            image_names (list): List of image names corresponding to the predictions.
-        """
-        for pred, image_name in zip(preds, image_names, strict=True):
-            # Look up image index; skip if not in ground truth
-            if image_name not in self.path_to_index:
-                warnings.warn(
-                    f"Image '{image_name}' not found in ground truth CSV. Skipping.",
-                    stacklevel=2,
-                )
-                continue
-
-            image_idx = self.path_to_index[image_name]
-            num_boxes = len(pred["boxes"])
-
-            # Store predictions and image indices as tensors
-            self.boxes.append(pred["boxes"].detach())
-            self.labels.append(pred["labels"].detach())
-            self.scores.append(pred["scores"].detach())
-            # Create a 1D tensor with one index per box
-            self.image_indices.append(
-                torch.full((num_boxes,), image_idx, dtype=torch.long).to(
-                    pred["boxes"].device
-                )
-            )
-
-    def compute(self) -> dict[str, float]:
-        """Computes the recall/precision metrics."""
-
-        ground_df = utilities.read_file(self.csv_file)
-        numeric_to_label_dict = {v: k for k, v in self.label_dict.items()}
-        ground_df["label"] = ground_df.label.apply(lambda x: self.label_dict[x])
-
-        predictions = pd.DataFrame()
-        if self.boxes:
-            combined = {
-                "boxes": torch.cat(self.boxes),
-                "labels": torch.cat(self.labels),
-                "scores": torch.cat(self.scores),
-            }
-            predictions = utilities.format_geometry(combined)
-            if predictions is None:
-                predictions = pd.DataFrame()  # Reset to empty DataFrame
-            else:
-                # Expand image names to one entry per box
-                predictions["image_path"] = [
-                    self.index_to_path[int(idx.item())]
-                    for idx in torch.cat(self.image_indices)
-                ]
-
-        results = __evaluate_wrapper__(
-            predictions=predictions,
-            ground_df=ground_df,
-            iou_threshold=self.iou_threshold,
-            numeric_to_label_dict=numeric_to_label_dict,
+        self.add_state("precision", default=torch.tensor(0.0), dist_reduce_fx="sum")
+        self.add_state("recall", default=torch.tensor(0.0), dist_reduce_fx="sum")
+        self.add_state("num_images", default=torch.tensor(0), dist_reduce_fx="sum")
+        self.add_state(
+            "num_images_with_predictions", default=torch.tensor(0), dist_reduce_fx="sum"
+        )
+        self.add_state("num_empty_frames", default=torch.tensor(0), dist_reduce_fx="sum")
+        self.add_state(
+            "correct_empty_predictions", default=torch.tensor(0), dist_reduce_fx="sum"
         )
 
-        self.results = results
+        # Accumulated per-image match results for class_recall (not a metric
+        # state since string labels cannot be stored as tensors)
+        self.results: list[pd.DataFrame] = []
+        self._all_results: pd.DataFrame = pd.DataFrame()
 
-        filtered_results = {}
+    def update(
+        self,
+        preds: list[dict[str, Tensor]],
+        targets: list[dict[str, Tensor]],
+        image_names: list[str] | None = None,
+    ) -> None:
+        """Update the metric with a batch of predictions and targets.
 
-        # Extract per-class recall/precision for multi class prediction only.
-        if len(self.label_dict) > 1:
-            if "class_recall" in results and results["class_recall"] is not None:
-                for _, row in results["class_recall"].iterrows():
-                    filtered_results[
-                        "{}_Recall".format(numeric_to_label_dict[row["label"]])
-                    ] = row["recall"]
-                    filtered_results[
-                        "{}_Precision".format(numeric_to_label_dict[row["label"]])
-                    ] = row["precision"]
+        Args:
+            preds: List of prediction dicts (keys: ``boxes``, ``labels``, ``scores``).
+            targets: List of target dicts (keys: ``boxes``, ``labels``).
+            image_names: Optional list of image path strings, one per image.
+        """
+        if image_names is None:
+            image_names = ["unknown"] * len(preds)
+        for pred, target, image_path in zip(preds, targets, image_names, strict=True):
+            self._update_single(pred, target, image_path)
 
-        # Filter out values that cannot be logged
-        for key, value in results.items():
-            if isinstance(value, (pd.DataFrame, gpd.GeoDataFrame)):
-                pass
-            elif value is None:
-                pass
+    def _update_single(
+        self,
+        pred: dict[str, Tensor],
+        target: dict[str, Tensor],
+        image_path: str = "unknown",
+    ) -> None:
+        """Update metric state for a single image."""
+        self.num_images += 1
+
+        n_pred = len(pred["boxes"])
+        n_target = len(target["boxes"])
+
+        # Early exit for prediction/target base cases.
+        is_empty_frame = n_target == 0 or torch.all(target["boxes"] == 0)
+        if is_empty_frame:
+            self.num_empty_frames += 1
+            if n_pred == 0:
+                self.correct_empty_predictions += 1
             else:
-                filtered_results[key] = value
+                # Predictions in an empty frame are all FP: precision = 0
+                self.num_images_with_predictions += 1
+            return
 
-        return filtered_results
+        if n_pred == 0:
+            # No predictions but ground truth exists: recall=0, precision undefined
+            return
+
+        self.num_images_with_predictions += 1
+
+        # Note: format_geometry handles detach + CPU. IoU == 0 represents not matched.
+        ground_df = utilities.format_geometry(target, scores=False)
+        pred_df = utilities.format_geometry(pred, scores=True)
+        ground_df["image_path"] = image_path
+        pred_df["image_path"] = image_path
+        result = match_predictions(
+            predictions=pred_df,
+            ground_df=ground_df,
+            task=self.task,
+        )
+        result["image_path"] = image_path
+
+        if self.task == "box" or self.task == "polygon":
+            result["match"] = result.IoU > self.iou_threshold
+        elif self.task == "point":
+            result["match"] = result.distance < self.distance_threshold
+
+        # Compute per-image precision + recall
+        result["match"] = result["match"].fillna(False)
+        true_positive = sum(result["match"])
+        recall = true_positive / result.shape[0]
+        precision = true_positive / n_pred
+
+        self.recall += recall
+        self.precision += precision
+        self.results.append(result)
+
+    def _sync_dist(self, dist_sync_fn=None, process_group=None) -> None:
+        """Sync metric states and gather non-tensor results list across
+        ranks."""
+        super()._sync_dist(dist_sync_fn=dist_sync_fn, process_group=process_group)
+
+        # Gather results dataframes
+        if torch.distributed.is_available() and torch.distributed.is_initialized():
+            world_size = torch.distributed.get_world_size(group=process_group)
+            torch.distributed.barrier(group=process_group)
+            gathered = [None] * world_size
+            torch.distributed.all_gather_object(
+                gathered, self.results, group=process_group
+            )
+            self.results = [df for rank_results in gathered for df in rank_results]
+
+    def compute(self) -> dict:
+        """Computes the recall/precision metrics.
+
+        DataFrames (match results and class recall) are stored as instance
+        attributes ``_all_results`` and ``_class_recall`` for callers that
+        need them. Only loggable scalar/tensor values are returned.
+        Per-class recall and precision are included when more than one class
+        is present in ``label_dict``.
+        """
+
+        # Map numeric label IDs to strings
+        if self.results:
+            self._all_results = pd.concat(self.results, ignore_index=True)
+            # Free up memory once converted to single dataframe
+            self.results = []
+            for col in ["predicted_label", "true_label"]:
+                if col in self._all_results.columns:
+                    self._all_results[col] = self._all_results[col].map(
+                        lambda x: self.numeric_to_label_dict.get(int(x), x)
+                        if pd.notna(x)
+                        else x
+                    )
+            self._class_recall = compute_class_recall(
+                self._all_results[self._all_results["match"]]
+            )
+        else:
+            self._all_results = pd.DataFrame()
+            self._class_recall = None
+
+        # Reduce precision and recall to per-image
+        output = {
+            f"{self.task}_precision": (
+                self.precision.float() / self.num_images_with_predictions.float()
+                if self.num_images_with_predictions > 0
+                else torch.tensor(float("nan"))
+            ),
+            f"{self.task}_recall": self.recall.float() / self.num_images.float(),
+        }
+
+        # Only log class metrics if multi-class targets
+        if len(self.label_dict) > 1 and self._class_recall is not None:
+            for _, row in self._class_recall.iterrows():
+                output[f"{row['label']}_Recall"] = row["recall"]
+                output[f"{row['label']}_Precision"] = row["precision"]
+
+        # Empty frame accuracy, undefined if no empty frames are present
+        if self.num_empty_frames > 0:
+            output["empty_frame_accuracy"] = (
+                self.correct_empty_predictions.float() / self.num_empty_frames.float()
+            )
+
+        return output
+
+    def get_results(self) -> pd.DataFrame:
+        """Return the full per-box match results from the last ``compute()``
+        call.
+
+        Returns:
+            DataFrame with columns ``truth_id``, ``prediction_id``,
+            ``predicted_label``, ``true_label``, ``match``, ``IoU``,
+            ``score``, ``geometry``, and ``image_path``. Empty if
+            ``compute()`` has not been called.
+        """
+        return self._all_results
 
     def reset(self) -> None:
         """Reset metric state."""
         super().reset()
+        self.results = []

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -554,16 +554,26 @@ def test_predict_tile_from_array(m, path):
 
 def test_evaluate(m):
     csv_file = get_data("OSBS_029.csv")
+    df = pd.read_csv(csv_file)
     results = m.evaluate(csv_file)
 
+    # Metrics are sane
     assert np.round(results["box_precision"], 2) > 0.5
     assert np.round(results["box_recall"], 2) > 0.5
+
+    # Class names are correct
     assert len(results["results"].predicted_label.dropna().unique()) == 1
     assert results["results"].predicted_label.dropna().unique()[0] == "Tree"
     assert results["predictions"].shape[0] > 0
     assert results["predictions"].label.dropna().unique()[0] == "Tree"
 
-    df = pd.read_csv(csv_file)
+    # Image path matches the CSV
+    assert "image_path" in results["results"].columns
+    assert results["results"]["image_path"].notna().all()
+    expected_images = df["image_path"].unique()
+    assert all(im in expected_images for im in results["results"]["image_path"].unique())
+
+    # Check we have match results for every ground truth box
     assert results["results"].shape[0] == df.shape[0]
 
 
@@ -983,7 +993,7 @@ def test_epoch_evaluation_end(m, tmp_path):
     m.config.validation.root_dir = str(tmp_path)
     # Recreate metrics after changing validation csv_file
     m.setup_metrics()
-    m.precision_recall_metric.update(preds, ["test"])
+    m.precision_recall_metric.update(preds, targets)
 
     with mock.patch.object(m, 'log_dict') as mock_log:
         m.on_validation_epoch_end()


### PR DESCRIPTION
## Description

- Refactors the RecallPrecision metric to use (mostly) the same `update` signature as other metrics.
- Ground truth/pred matching is performed eagerly during `update` so that the final reduction stage doesn't time-out the sync between ranks during DDP joining.
- This should be faster on multi node machines, because each rank will only perform 1/N of the work. There are maybe some tiny benefits from not having to search the dataframe for image_path <> preds/gt. The `it/s` during eval might be a bit slower, but there won't be a big chunk of compute at the end.
- The metric has to keep track of the matching results so it can be accessed later, which is a little awkward, but I've tried to keep it clean (at least to users...)
- I moved empty frame accuracy here too, since we have to handle those checks during evaluation anyway and it make main a bit cleaner.
- The metrics are calculated against the dataset targets directly (instead of loading the CSV and passing that raw). This has the benefit that adding geometric augmentation to the validation dataset (if we did that for some reason) wouldn't break eval.

Tests:
- Added a sanity check in `test_main::test_evaluate` to confirm that the output dataframe is what we expect + some comments on the assertions.
- One fixup in tests for the new metric.update signature.

## Related Issue(s)

- Fixes https://github.com/weecology/DeepForest/issues/1073
- Should also fix https://github.com/weecology/DeepForest/issues/1232

## AI-Assisted Development

Rewrote most of the metric and then got CC to check some of the logic and the test suite.

- [X] I used AI tools (e.g., GitHub Copilot, ChatGPT, etc.) in developing this PR
- [X] I understand all the code I'm submitting
- [X] I have reviewed and validated all AI-generated code

**AI tools used (if applicable):**
Claude Code Opus/Sonnet 4.6
