### PR TITLE
Handle empty DataFrame in convert_to_sv_format (#1346)

### DIFF
--- a/src/deepforest/visualize.py
+++ b/src/deepforest/visualize.py
@@ -147,6 +147,10 @@ def convert_to_sv_format(
     Returns:
         sv.Detections | sv.KeyPoints: Object type depends on geometry.
     """
+    # Handle empty DataFrame gracefully (fixes #1346)
+    if df.empty:
+        return sv.Detections.empty()
+
     geom_type = determine_geometry_type(df)
 
     if geom_type == "box":

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -212,3 +212,24 @@ def test_check_float_image_non_unitary():
 def test_image_empty():
     image = visualize._load_image()
     assert image is not None
+
+
+def test_convert_to_sv_format_empty_dataframe():
+    """Test that convert_to_sv_format handles empty DataFrame gracefully.
+
+    Regression test for https://github.com/weecology/DeepForest/issues/1346
+    """
+    import supervision as sv
+
+    # Create empty GeoDataFrame
+    empty_df = gpd.GeoDataFrame({
+        'geometry': [],
+        'label': [],
+        'score': []
+    })
+
+    # Should return empty Detections, not crash
+    result = visualize.convert_to_sv_format(empty_df)
+
+    assert isinstance(result, sv.Detections)
+    assert len(result) == 0


### PR DESCRIPTION
## Description

Fixes #1346 - `convert_to_sv_format()` now handles empty DataFrames gracefully by returning `sv.Detections.empty()` instead of crashing.

### Problem

When `convert_to_sv_format()` receives an empty DataFrame (e.g., when model detects 0 objects), it calls `determine_geometry_type(df)` which crashes with:
IndexError: index 0 is out of bounds for axis 0 with size 0

at `utilities.py` line 331: `df.geometry.type.unique()[0]`

### Solution

Added an early return check in `convert_to_sv_format()`:

```python
if df.empty:
    return sv.Detections.empty()
```

This prevents the crash and returns a valid empty sv.Detections object, which is the expected behavior for zero detections.

###Test
Added test_convert_to_sv_format_empty_dataframe() in test_visualize.py to verify:

Empty GeoDataFrame input returns sv.Detections type
Result length is 0

###Related Issue(s)
Closes #1346

AI-Assisted Development
 [x] I used AI tools (e.g., GitHub Copilot, ChatGPT, etc.) in developing this PR
 [x] I understand all the code I'm submitting
 [x] I have reviewed and validated all AI-generated code
**AI tools used (if applicable):**
AI tools used for initial research and code review. Fix and test were verified manually.