### PR TITLE
allow custom image normalization in CropModel

### DIFF
--- a/src/deepforest/conf/config.yaml
+++ b/src/deepforest/conf/config.yaml
@@ -117,5 +117,11 @@ cropmodel:
     resize:
         - 224
         - 224
+    # Image normalization. Defaults to ImageNet stats when null.
+    # Set to false to disable, or provide custom mean/std:
+    #   normalize:
+    #       mean: [0.5, 0.5, 0.5]
+    #       std: [0.5, 0.5, 0.5]
+    normalize:
     # Number of pixels to expand bbox crop windows for better prediction context.
     expand: 0

--- a/src/deepforest/conf/schema.py
+++ b/src/deepforest/conf/schema.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass, field
+from typing import Any
 
 from omegaconf import DictConfig, OmegaConf
 
@@ -107,6 +108,7 @@ class CropModelConfig:
     scheduler: SchedulerConfig = field(default_factory=SchedulerConfig)
     balance_classes: bool = False
     resize: list[int] = field(default_factory=lambda: [224, 224])
+    normalize: Any = None
     expand: int = 0
 
 

--- a/src/deepforest/datasets/cropmodel.py
+++ b/src/deepforest/datasets/cropmodel.py
@@ -13,12 +13,14 @@ from torch.utils.data import Dataset
 from torchvision import transforms
 
 
-def bounding_box_transform(augmentations=None, resize=None):
+def bounding_box_transform(augmentations=None, resize=None, normalize=None):
     """Create transform pipeline for bounding box data.
 
     Args:
         augmentations: Augmentation configuration (str, list, or dict)
         resize: Optional list of [height, width] for resizing. Defaults to [224, 224]
+        normalize: Normalization transform. None uses ImageNet defaults,
+            False disables normalization, or pass a transforms.Normalize instance.
 
     Returns:
         Composed transform pipeline
@@ -28,7 +30,10 @@ def bounding_box_transform(augmentations=None, resize=None):
 
     data_transforms = []
     data_transforms.append(transforms.ToTensor())
-    data_transforms.append(resnet_normalize)
+    if normalize is None:
+        data_transforms.append(resnet_normalize)
+    elif normalize is not False:
+        data_transforms.append(normalize)
     data_transforms.append(transforms.Resize(resize))
     if augmentations:
         data_transforms.append(transforms.RandomHorizontalFlip(0.5))
@@ -64,13 +69,14 @@ class BoundingBoxDataset(Dataset):
         transform=None,
         augmentations=None,
         resize=None,
+        normalize=None,
         expand: int = 0,
     ):
         self.df = df
 
         if transform is None:
             self.transform = bounding_box_transform(
-                augmentations=augmentations, resize=resize
+                augmentations=augmentations, resize=resize, normalize=normalize
             )
         else:
             self.transform = transform

--- a/src/deepforest/model.py
+++ b/src/deepforest/model.py
@@ -317,7 +317,8 @@ class CropModel(LightningModule, PyTorchModelHubMixin):
                 or None if normalization is disabled.
 
         Raises:
-            ValueError: If only one of ``mean`` or ``std`` is provided.
+            ValueError: If ``mean`` or ``std`` is missing from the
+                normalize mapping.
         """
         norm_cfg = self.config["cropmodel"].get("normalize", None)
 
@@ -331,10 +332,11 @@ class CropModel(LightningModule, PyTorchModelHubMixin):
 
         has_mean = "mean" in norm_cfg
         has_std = "std" in norm_cfg
-        if has_mean != has_std:
+        if not (has_mean and has_std):
+            missing = [k for k, v in [("mean", has_mean), ("std", has_std)] if not v]
             raise ValueError(
                 "Both 'mean' and 'std' must be provided for custom normalization, "
-                f"got only {'mean' if has_mean else 'std'}."
+                f"missing: {missing}."
             )
 
         return transforms.Normalize(

--- a/src/deepforest/model.py
+++ b/src/deepforest/model.py
@@ -1,6 +1,7 @@
 # Model - common class
 import json
 import os
+from collections.abc import Mapping
 
 import cv2
 import numpy as np
@@ -329,6 +330,12 @@ class CropModel(LightningModule, PyTorchModelHubMixin):
 
         if norm_cfg is False:
             return None
+
+        if not isinstance(norm_cfg, Mapping):
+            raise ValueError(
+                f"'normalize' must be null, false, or a mapping with 'mean' and 'std', "
+                f"got {type(norm_cfg).__name__}."
+            )
 
         has_mean = "mean" in norm_cfg
         has_std = "std" in norm_cfg

--- a/src/deepforest/model.py
+++ b/src/deepforest/model.py
@@ -208,7 +208,9 @@ class CropModel(LightningModule, PyTorchModelHubMixin):
         """
         data_transforms = []
         data_transforms.append(transforms.ToTensor())
-        data_transforms.append(self.normalize())
+        norm = self.normalize()
+        if norm is not None:
+            data_transforms.append(norm)
 
         # Get resize dimensions from config, default to [224, 224] if not specified
         resize_dims = self.config["cropmodel"].get("resize", [224, 224])
@@ -308,7 +310,36 @@ class CropModel(LightningModule, PyTorchModelHubMixin):
                 cv2.imwrite(img_path, img)
 
     def normalize(self):
-        return transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])
+        """Build the normalization transform from config.
+
+        Returns:
+            transforms.Normalize or None: The normalization transform,
+                or None if normalization is disabled.
+
+        Raises:
+            ValueError: If only one of ``mean`` or ``std`` is provided.
+        """
+        norm_cfg = self.config["cropmodel"].get("normalize", None)
+
+        if norm_cfg is None:
+            return transforms.Normalize(
+                mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]
+            )
+
+        if norm_cfg is False:
+            return None
+
+        has_mean = "mean" in norm_cfg
+        has_std = "std" in norm_cfg
+        if has_mean != has_std:
+            raise ValueError(
+                "Both 'mean' and 'std' must be provided for custom normalization, "
+                f"got only {'mean' if has_mean else 'std'}."
+            )
+
+        return transforms.Normalize(
+            mean=list(norm_cfg["mean"]), std=list(norm_cfg["std"])
+        )
 
     def forward(self, x):
         if self.model is None:

--- a/src/deepforest/predict.py
+++ b/src/deepforest/predict.py
@@ -281,15 +281,14 @@ def _predict_crop_model_(
     normalize = None
     expand = 0
     if transform is None and hasattr(crop_model, "config"):
-        resize = crop_model.config.get("cropmodel", {}).get("resize", [224, 224])
-        norm_cfg = crop_model.config.get("cropmodel", {}).get("normalize", None)
-        if norm_cfg is False:
+        cropmodel_cfg = crop_model.config.get("cropmodel", {})
+        resize = cropmodel_cfg.get("resize", [224, 224])
+        norm_transform = crop_model.normalize()
+        if norm_transform is None:
             normalize = False
-        elif norm_cfg is not None and "mean" in norm_cfg and "std" in norm_cfg:
-            normalize = transforms.Normalize(
-                mean=list(norm_cfg["mean"]), std=list(norm_cfg["std"])
-            )
-        expand = crop_model.config.get("cropmodel", {}).get("expand", 0)
+        else:
+            normalize = norm_transform
+        expand = cropmodel_cfg.get("expand", 0)
 
     # Create dataset
     bounding_box_dataset = cropmodel.BoundingBoxDataset(

--- a/src/deepforest/predict.py
+++ b/src/deepforest/predict.py
@@ -4,6 +4,7 @@ import os
 import numpy as np
 import pandas as pd
 import torch
+from torchvision import transforms
 from torchvision.ops import nms
 
 from deepforest import utilities
@@ -275,11 +276,19 @@ def _predict_crop_model_(
     results = results[results.xmin != results.xmax]
     results = results[results.ymin != results.ymax]
 
-    # Get resize dimensions from crop_model config if not using custom transform
+    # Get config from crop_model if not using custom transform
     resize = None
+    normalize = None
     expand = 0
     if transform is None and hasattr(crop_model, "config"):
         resize = crop_model.config.get("cropmodel", {}).get("resize", [224, 224])
+        norm_cfg = crop_model.config.get("cropmodel", {}).get("normalize", None)
+        if norm_cfg is False:
+            normalize = False
+        elif norm_cfg is not None and "mean" in norm_cfg and "std" in norm_cfg:
+            normalize = transforms.Normalize(
+                mean=list(norm_cfg["mean"]), std=list(norm_cfg["std"])
+            )
         expand = crop_model.config.get("cropmodel", {}).get("expand", 0)
 
     # Create dataset
@@ -289,6 +298,7 @@ def _predict_crop_model_(
         transform=transform,
         augmentations=augmentations,
         resize=resize,
+        normalize=normalize,
         expand=expand,
     )
 

--- a/src/deepforest/predict.py
+++ b/src/deepforest/predict.py
@@ -4,7 +4,6 @@ import os
 import numpy as np
 import pandas as pd
 import torch
-from torchvision import transforms
 from torchvision.ops import nms
 
 from deepforest import utilities

--- a/tests/test_crop_model.py
+++ b/tests/test_crop_model.py
@@ -10,6 +10,7 @@ import numpy as np
 from deepforest import get_data
 from deepforest import model
 from deepforest.model import CropModel
+from deepforest.datasets.cropmodel import bounding_box_transform
 
 # The model object is architecture agnostic container.
 def test_model_no_args(config):
@@ -205,3 +206,89 @@ def test_crop_model_val_dataset_confusion(tmp_path, crop_model, crop_model_data)
     # There was just one batch in the fast_dev_run
     assert len(labels) ==37
     assert len(predictions) == 37
+
+def test_crop_model_default_normalization(crop_model):
+    """Test that default normalization uses ImageNet stats."""
+    norm = crop_model.normalize()
+    assert norm is not None
+    assert list(norm.mean) == pytest.approx([0.485, 0.456, 0.406])
+    assert list(norm.std) == pytest.approx([0.229, 0.224, 0.225])
+
+    transform = crop_model.get_transform(augmentations=None)
+    norm_transforms = [
+        t for t in transform.transforms if isinstance(t, transforms.Normalize)
+    ]
+    assert len(norm_transforms) == 1
+
+def test_crop_model_custom_normalization():
+    """Test that custom normalization stats are used when configured."""
+    custom_mean = [0.5, 0.5, 0.5]
+    custom_std = [0.25, 0.25, 0.25]
+    custom_model = model.CropModel(
+        config_args={"normalize": {"mean": custom_mean, "std": custom_std}}
+    )
+    custom_model.create_model(num_classes=2)
+
+    norm = custom_model.normalize()
+    assert norm is not None
+    assert list(norm.mean) == pytest.approx(custom_mean)
+    assert list(norm.std) == pytest.approx(custom_std)
+
+    transform = custom_model.get_transform(augmentations=None)
+    norm_transforms = [
+        t for t in transform.transforms if isinstance(t, transforms.Normalize)
+    ]
+    assert len(norm_transforms) == 1
+    assert list(norm_transforms[0].mean) == pytest.approx(custom_mean)
+
+def test_crop_model_disabled_normalization():
+    """Test that normalization can be disabled with normalize: false."""
+    no_norm_model = model.CropModel(config_args={"normalize": False})
+    no_norm_model.create_model(num_classes=2)
+
+    norm = no_norm_model.normalize()
+    assert norm is None
+
+    transform = no_norm_model.get_transform(augmentations=None)
+    norm_transforms = [
+        t for t in transform.transforms if isinstance(t, transforms.Normalize)
+    ]
+    assert len(norm_transforms) == 0
+
+def test_crop_model_normalize_missing_mean_or_std():
+    """Test that providing only mean or only std raises ValueError."""
+    mean_only = model.CropModel(
+        config_args={"normalize": {"mean": [0.5, 0.5, 0.5]}}
+    )
+    mean_only.create_model(num_classes=2)
+    with pytest.raises(ValueError, match="Both 'mean' and 'std'"):
+        mean_only.normalize()
+
+    std_only = model.CropModel(
+        config_args={"normalize": {"std": [0.25, 0.25, 0.25]}}
+    )
+    std_only.create_model(num_classes=2)
+    with pytest.raises(ValueError, match="Both 'mean' and 'std'"):
+        std_only.normalize()
+
+def test_bounding_box_transform_normalize():
+    """Test bounding_box_transform respects normalize parameter."""
+    default_t = bounding_box_transform()
+    norm_default = [
+        t for t in default_t.transforms if isinstance(t, transforms.Normalize)
+    ]
+    assert len(norm_default) == 1
+
+    custom_norm = transforms.Normalize(mean=[0.5, 0.5, 0.5], std=[0.25, 0.25, 0.25])
+    custom_t = bounding_box_transform(normalize=custom_norm)
+    norm_custom = [
+        t for t in custom_t.transforms if isinstance(t, transforms.Normalize)
+    ]
+    assert len(norm_custom) == 1
+    assert list(norm_custom[0].mean) == pytest.approx([0.5, 0.5, 0.5])
+
+    no_norm_t = bounding_box_transform(normalize=False)
+    norm_none = [
+        t for t in no_norm_t.transforms if isinstance(t, transforms.Normalize)
+    ]
+    assert len(norm_none) == 0

--- a/tests/test_crop_model.py
+++ b/tests/test_crop_model.py
@@ -271,6 +271,11 @@ def test_crop_model_normalize_missing_mean_or_std():
     with pytest.raises(ValueError, match="Both 'mean' and 'std'"):
         std_only.normalize()
 
+    empty_norm = model.CropModel(config_args={"normalize": {}})
+    empty_norm.create_model(num_classes=2)
+    with pytest.raises(ValueError, match="Both 'mean' and 'std'"):
+        empty_norm.normalize()
+
 def test_bounding_box_transform_normalize():
     """Test bounding_box_transform respects normalize parameter."""
     default_t = bounding_box_transform()


### PR DESCRIPTION
## Desc
- `bounding_box_transform()` and `CropModel.normalize()` both hardcode ImageNet normalization (`mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]`) with no way for the user to override.
- A user passing a custom model via `CropModel(model=my_model)` that expects different preprocessing gets silently wrong results.
- Followed the threading pattern from #1313 (`resize_interpolation`) — adding an optional config parameter and passing it through both the training and prediction pipelines.

### Solution

The `normalize` config parameter supports three modes:

```yaml
# Default (null): ImageNet normalization
normalize:

# Disabled: skip normalization
normalize: false

# Custom: user-provided values
normalize:
    mean: [0.5, 0.5, 0.5]
    std: [0.5, 0.5, 0.5]
```

**1. Config.** Added `normalize` field (defaults to `null`) in [config.yaml](https://github.com/musaqlain/DeepForest/blob/allow-custom-norm-weights/src/deepforest/conf/config.yaml#L120-L126) and [schema.py](https://github.com/musaqlain/DeepForest/blob/allow-custom-norm-weights/src/deepforest/conf/schema.py#L110). The field is typed as `Any` since OmegaConf does not support unions of containers (`dict | bool`); validation happens in code.

**2. Training path.** [CropModel.normalize()](https://github.com/musaqlain/DeepForest/blob/allow-custom-norm-weights/src/deepforest/model.py#L312-L343) now reads from config instead of returning hardcoded ImageNet values. [CropModel.get_transform()](https://github.com/musaqlain/DeepForest/blob/allow-custom-norm-weights/src/deepforest/model.py#L198-L226) handles the case where `normalize()` returns `None` (disabled).

**3. Prediction path.** [bounding_box_transform()](https://github.com/musaqlain/DeepForest/blob/allow-custom-norm-weights/src/deepforest/datasets/cropmodel.py#L16-L40) accepts an optional `normalize` parameter — `None` defaults to `resnet_normalize`, `False` skips it, or a `transforms.Normalize` instance is used directly. Threaded through [BoundingBoxDataset](https://github.com/musaqlain/DeepForest/blob/allow-custom-norm-weights/src/deepforest/datasets/cropmodel.py#L60-L74) and [_predict_crop_model_()](https://github.com/musaqlain/DeepForest/blob/allow-custom-norm-weights/src/deepforest/predict.py#L285-L292).

**4. Validation.** `CropModel.normalize()` raises a `ValueError` if only one of `mean` or `std` is provided, preventing silent misconfiguration.

**5. Tests.** 5 new tests added in [test_crop_model.py](https://github.com/musaqlain/DeepForest/blob/allow-custom-norm-weights/tests/test_crop_model.py#L210-L295):
- `test_crop_model_default_normalization` — verifies ImageNet stats when no config is set
- `test_crop_model_custom_normalization` — verifies custom `mean`/`std` are applied
- `test_crop_model_disabled_normalization` — verifies `normalize: false` skips normalization
- `test_crop_model_normalize_missing_mean_or_std` — verifies `ValueError` on incomplete config
- `test_bounding_box_transform_normalize` — verifies the prediction-path transform handles all three modes

**Breaking changes:** None. Default is `null` which applies ImageNet normalization, identical to the previous hardcoded behavior.

### Discussion points

1. **`normalize: Any` in schema.py.** OmegaConf's structured configs do not support unions like `dict | bool | None`. Using `Any` is the pragmatic choice here — it allows `null`, `false`, and `{mean, std}` to all pass through correctly, while validation is handled explicitly in `CropModel.normalize()`. Open to other approaches if preferred.

2. **Validation test for missing `mean` or `std`.** I added a test that verifies a `ValueError` is raised when a user provides `mean` without `std` (or vice versa). This felt worth catching early rather than letting it fail deeper in the transform pipeline with an unclear error. Let me know if this is considered unnecessary overhead.

## Related Issue(s)

Closes #1347

**How AI was used:**
- Understanding PR #1313's code changes and the threading pattern for `resize_interpolation`
- Breaking down the issue into sub-problems (identifying the two independent normalization sites, tracing call chains)
- Learning how OmegaConf handles structured configs and union types
- Code review and improving overall code quality after I proposed and implemented the change flow

I studied the issue and #1313 to understand the full context, proposed the threading approach and config interface myself, then used AI to review my implementation and catch edge cases (like the OmegaConf `DictConfig` vs `dict` issue and the missing `mean`/`std` validation).