### PR TITLE
Add support for Adam(W) and weight decay 

### DIFF
--- a/src/deepforest/conf/config.yaml
+++ b/src/deepforest/conf/config.yaml
@@ -46,6 +46,11 @@ train:
 
     # Optimizer initial learning rate
     lr: 0.001
+    optimizer:
+        type: SGD
+        weight_decay: 0.0
+        momentum: 0.9
+        betas: [0.9, 0.999]
 
     # Data augmentations for training
     # Augmentations must be a list of augmentation names, or a list

--- a/src/deepforest/conf/schema.py
+++ b/src/deepforest/conf/schema.py
@@ -46,6 +46,16 @@ class SchedulerConfig:
 
 
 @dataclass
+class OptimizerConfig:
+    """Configuration for the optimizer used during training."""
+
+    type: str = "SGD"
+    weight_decay: float = 0.0
+    momentum: float = 0.9
+    betas: list[float] = field(default_factory=lambda: [0.9, 0.999])
+
+
+@dataclass
 class TrainConfig:
     """Main training configuration. The CSV file and root directory are
     required to specify the location of the training dataset.
@@ -64,6 +74,7 @@ class TrainConfig:
     csv_file: str | None = None
     root_dir: str | None = None
     lr: float = 0.001
+    optimizer: OptimizerConfig = field(default_factory=OptimizerConfig)
     scheduler: SchedulerConfig = field(default_factory=SchedulerConfig)
     epochs: int = 1
     fast_dev_run: bool = False

--- a/src/deepforest/main.py
+++ b/src/deepforest/main.py
@@ -885,9 +885,33 @@ class deepforest(pl.LightningModule):
         return results
 
     def configure_optimizers(self):
-        optimizer = optim.SGD(
-            self.model.parameters(), lr=self.config.train.lr, momentum=0.9
-        )
+        opt_cfg = self.config.train.optimizer
+        lr = self.config.train.lr
+        if opt_cfg.type == "Adam":
+            optimizer = optim.Adam(
+                self.model.parameters(),
+                lr=lr,
+                betas=tuple(opt_cfg.betas),
+                weight_decay=opt_cfg.weight_decay,
+            )
+        elif opt_cfg.type == "AdamW":
+            optimizer = optim.AdamW(
+                self.model.parameters(),
+                lr=lr,
+                betas=tuple(opt_cfg.betas),
+                weight_decay=opt_cfg.weight_decay,
+            )
+        elif opt_cfg.type == "SGD":
+            optimizer = optim.SGD(
+                self.model.parameters(),
+                lr=lr,
+                momentum=opt_cfg.momentum,
+                weight_decay=opt_cfg.weight_decay,
+            )
+        else:
+            raise ValueError(
+                f"Unknown optimizer type '{opt_cfg.type}'. Choose from: SGD, Adam, AdamW."
+            )
 
         scheduler_config = self.config.train.scheduler
         scheduler_type = scheduler_config.type
@@ -897,7 +921,12 @@ class deepforest(pl.LightningModule):
         def lr_lambda(epoch):
             return eval(params.lr_lambda)
 
-        if scheduler_type == "cosine":
+        if scheduler_type is None or scheduler_type == "constantLR":
+            scheduler = torch.optim.lr_scheduler.ConstantLR(
+                optimizer, factor=1.0, total_iters=0
+            )
+
+        elif scheduler_type == "cosine":
             scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
                 optimizer, T_max=params.T_max, eta_min=params.eta_min
             )
@@ -925,7 +954,7 @@ class deepforest(pl.LightningModule):
                 optimizer, gamma=params.gamma
             )
 
-        else:
+        elif scheduler_type in ("ReduceLROnPlateau", "reduceLROnPlateau"):
             scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(
                 optimizer,
                 mode=params["mode"],
@@ -936,6 +965,13 @@ class deepforest(pl.LightningModule):
                 cooldown=params["cooldown"],
                 min_lr=params["min_lr"],
                 eps=params["eps"],
+            )
+
+        else:
+            raise ValueError(
+                f"Unknown scheduler type '{scheduler_type}'. Choose from: "
+                "constantLR, cosine, lambdaLR, multiplicativeLR, stepLR, multistepLR, "
+                "exponentialLR, ReduceLROnPlateau."
             )
 
         # Monitor learning rate if val data is used

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -116,3 +116,40 @@ def test_load_checkpoint_with_dictconfig(m, tmp_path):
     loaded.save_model(checkpoint_path)
     fixed = main.deepforest.load_from_checkpoint(checkpoint_path)
     assert fixed.config == m.config
+
+
+@pytest.mark.parametrize("optimizer_type,optimizer_class", [
+    ("Adam", "Adam"),
+    ("AdamW", "AdamW"),
+    ("SGD", "SGD"),
+])
+def test_configure_optimizer_types(optimizer_type, optimizer_class, tmp_path):
+    annotations_file = get_data("testfile_deepforest.csv")
+    root_dir = os.path.dirname(annotations_file)
+
+    m = main.deepforest(config_args={
+        "train": {
+            "csv_file": annotations_file,
+            "root_dir": root_dir,
+            "fast_dev_run": True,
+            "optimizer": {"type": optimizer_type},
+        },
+        "log_root": str(tmp_path),
+    })
+    result = m.configure_optimizers()
+    optimizer = result if not isinstance(result, dict) else result["optimizer"]
+    assert type(optimizer).__name__ == optimizer_class
+
+
+def test_configure_optimizers_unknown_optimizer():
+    m = main.deepforest()
+    m.config.train.optimizer.type = "unknown_optimizer"
+    with pytest.raises(ValueError, match="Unknown optimizer type"):
+        m.configure_optimizers()
+
+
+def test_configure_optimizers_unknown_scheduler():
+    m = main.deepforest()
+    m.config.train.scheduler.type = "unknown_scheduler"
+    with pytest.raises(ValueError, match="Unknown scheduler type"):
+        m.configure_optimizers()


### PR DESCRIPTION
## Description

Adds support for different optimizers in the config. Shouldn't break anything backwards as this was never exposed in older versions of DeepForest.

Fixes a small bug/footgun in the scheduler config where if you specified something not in the list, it would silently default to  ReduceLROnPlateau.

Adam/w is widely used for training transformer-based models, and also supports a weight_decay parameter. 

## Related Issue(s)

In support of newer models being added to DeepForest.

## AI-Assisted Development

<!-- Be transparent about AI tool usage -->

- [X] I used AI tools (e.g., GitHub Copilot, ChatGPT, etc.) in developing this PR
- [X] I understand all the code I'm submitting
- [X] I have reviewed and validated all AI-generated code

**AI tools used (if applicable):**

Claude
