### PR TITLE
Document frozen vs trained layers in fine-tuning

### DIFF
--- a/docs/user_guide/11_training.md
+++ b/docs/user_guide/11_training.md
@@ -75,6 +75,58 @@ m = main.deepforest(config_args{"num_classes": 3,
 
 which will create an initialized RetinaNet model with 3 classes, ready for training. You must always specify your class count and label map.
 
+## What is trained during fine-tuning
+
+DeepForest uses a RetinaNet with a ResNet-50 backbone. The backbone has 5 layer groups (`conv1` and `layer1` through `layer4`). By default, `conv1` and `layer1` are frozen — the remaining layers, FPN, and detection heads are all trained.
+
+During fine-tuning the following components are updated:
+
+- `layer2`, `layer3`, `layer4` of the ResNet-50 backbone
+- Feature Pyramid Network (FPN)
+- Regression head
+- Classification head
+
+### Multi-class transfer learning
+
+To adapt a pretrained model to new classes, copy the backbone and regression head weights into your new model:
+
+```python
+from deepforest import main
+
+m = main.deepforest(
+    num_classes=2,
+    label_dict={"Alive": 0, "Dead": 1}
+)
+
+pretrained = main.deepforest()
+pretrained.load_model(
+    "weecology/deepforest-tree"
+)
+
+m.model.backbone.load_state_dict(
+    pretrained.model.backbone.state_dict()
+)
+m.model.head.regression_head.load_state_dict(
+    pretrained.model.head.regression_head.state_dict()
+)
+```
+
+Nothing is frozen here — all layers will be trained. This takes longer but allows the model to adapt to your domain and new classes.
+
+### Manual layer freezing
+
+To freeze specific layers:
+
+```python
+# Freeze the backbone
+m.model.backbone.requires_grad_(False)
+
+# You may also want to freeze the FPN
+m.model.fpn.requires_grad_(False)
+```
+
+Freezing layers speeds up training and can help when data is limited, at the cost of reduced adaptability to your target domain.
+
 ## Custom datasets with other classes
 
 If you need to re-train a "tree" detection model to work in your specific survey area or ecosystem, you don't need to do anything. Models themselves have no understanding of the label "tree", they output predictions corresponding to numerical class IDs (starting at 0). By default, the `label_dict` in the config is populated when the model is pulled from the hub (or a local checkpoint), which is `{ Tree: 0 }`.


### PR DESCRIPTION
## Description

Documents which layers are frozen vs trained during fine-tuning.

## Background

Issue #397 pointed out that the docs don't explain which parts of the model are actually being updated during fine-tuning. Discussion in #394 confirmed the behavior:

- First 2 backbone layer groups frozen  (`conv1`, `layer1`)
- Last 3 trained (`layer2`, `layer3`,  `layer4`)
- FPN + detection heads trained

I verified this by loading a model and checking `named_parameters()` `conv1` and `layer1` show `requires_grad=False`.

## Changes

Added a new section to `docs/user_guide/11_training.md`:

- Explains the 5 ResNet-50 layer groups and default freezing behavior
- Shows how multi-class transfer learning works (load pretrained backbone + regression head)
- Includes code for manual layer freezing

## Related Issue(s)

Closes #397

## AI-Assisted Development

- [x] I used AI tools in developing  this PR
- [x] I understand all the code  I'm submitting
- [x] I have reviewed and validated all AI-generated code

**AI tools used:**  
Used for initial research. Layer behavior verified directly from code using `model.named_parameters()` and checked against #394 discussion.