### PR TITLE
add shapefile export in predict CLI script

### DIFF
--- a/src/deepforest/scripts/predict.py
+++ b/src/deepforest/scripts/predict.py
@@ -2,6 +2,7 @@ import os
 
 from omegaconf import DictConfig
 
+from deepforest import utilities
 from deepforest.main import deepforest
 from deepforest.visualize import plot_results
 
@@ -26,7 +27,9 @@ def predict(
         output_path (Optional[str]): Path to save the prediction results.
         plot (Optional[bool]): Whether to plot the results.
         root_dir (Optional[str]): Root directory containing images when input_path is a CSV file.
-        mode (Optional[str]): Prediction mode: 'single' for single image, 'tile' for tiled image prediction, 'csv' for batch prediction from CSV file. Defaults to 'single'.
+        mode (Optional[str]): Prediction mode: 'single' for single image, 'tile'
+            for tiled image prediction, 'csv' for batch prediction from CSV file.
+            Defaults to 'single'.
 
     Returns:
         None
@@ -72,7 +75,11 @@ def predict(
     if output_path is not None:
         if os.path.dirname(output_path):
             os.makedirs(os.path.dirname(output_path), exist_ok=True)
-        res.to_csv(output_path, index=False)
+        if output_path.endswith(".shp") or output_path.endswith(".gpkg"):
+            geo = utilities.image_to_geo_coordinates(res)
+            geo.to_file(output_path)
+        else:
+            res.to_csv(output_path, index=False)
 
     if plot:
         plot_results(res)


### PR DESCRIPTION
## Description

- Add automatic shapefile export to the `deepforest predict` tool
- If the output file is ends with .shp/.gpkg, output a shapefile instead of a CSV. This is very handy for raster prediction so you can quickly review results in QGIS.
- We have an existing method for this (`image_to_geo_coordinates`), so very light change

e.g. `deepforest predict <some_raster.tif> -o predictions.shp`

## AI-Assisted Development

- [ ] I used AI tools (e.g., GitHub Copilot, ChatGPT, etc.) in developing this PR
- [X] I understand all the code I'm submitting
- [ ] I have reviewed and validated all AI-generated code

**AI tools used (if applicable):**
N/A
