### PR TITLE
fixup log paths in schema + tests

### DIFF
--- a/src/deepforest/conf/schema.py
+++ b/src/deepforest/conf/schema.py
@@ -57,8 +57,10 @@ class OptimizerConfig:
 
 @dataclass
 class TrainConfig:
-    """Main training configuration. The CSV file and root directory are
-    required to specify the location of the training dataset.
+    """Main training configuration.
+
+    The CSV file and root directory are required to specify the location
+    of the training dataset.
 
     The default learning rate may need to be changed for certain
     architectures, such as transformers-based models which sometimes
@@ -84,8 +86,10 @@ class TrainConfig:
 
 @dataclass
 class ValidationConfig:
-    """Main validation configuration. As with training data, it's required that
-    you set a CSV file and root directory.
+    """Main validation configuration.
+
+    As with training data, it's required that you set a CSV file and
+    root directory.
 
     Validation during training is important to identify if the model has
     converged or is overfitting.
@@ -127,9 +131,10 @@ class CropModelConfig:
 
 @dataclass
 class Config:
-    """General DeepForest configuration. Some parameters here are shared
-    between dataloaders, for example the batch size, accelerator and number of
-    workers.
+    """General DeepForest configuration.
+
+    Some parameters here are shared between dataloaders, for example the
+    batch size, accelerator and number of workers.
 
     Here we also set the architecture, which can be one of "retinanet"
     or "DeformableDetr" currently. If you modify the number of classes
@@ -159,7 +164,7 @@ class Config:
     topk_candidates: int = 1000
     model: ModelConfig = field(default_factory=ModelConfig)
 
-    log_root: str = "./"
+    log_root: str = "./lightning_logs"
 
     # Preprocessing
     path_to_raster: str | None = None

--- a/src/deepforest/scripts/predict.py
+++ b/src/deepforest/scripts/predict.py
@@ -33,6 +33,9 @@ def predict(
     """
     m = deepforest(config=config)
 
+    # Suppress logging
+    m.create_trainer(logger=False)
+
     if input_path is None:
         if config.validation.csv_file is None:
             raise ValueError(

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -96,7 +96,8 @@ def test_evaluate_empty(m, tmp_path):
     # Evaluate with an empty model which should return no predictions.
     m = main.deepforest(config_args={"model": {"name": None},
                                      "label_dict": {"Tree": 0},
-                                     "num_classes": 1})
+                                     "num_classes": 1,
+                                     "log_root": str(tmp_path)})
     csv_file = get_data("OSBS_029.csv")
     results = m.evaluate(csv_file, root_dir=os.path.dirname(csv_file))
 

--- a/tests/test_white_image_predictions.py
+++ b/tests/test_white_image_predictions.py
@@ -21,8 +21,8 @@ IOU_THRESH = 0.0
 
 
 @pytest.mark.parametrize("model_name", MODEL_NAMES)
-def test_white_image_no_predictions(model_name):
-    model = deepforest()
+def test_white_image_no_predictions(model_name, tmp_path):
+    model = deepforest(config_args={"log_root": str(tmp_path)})
     model.load_model(model_name=model_name)
     model.config.score_thresh = SCORE_THRESH
     if hasattr(model, "model") and hasattr(model.model, "score_thresh"):


### PR DESCRIPTION
## Description

Aligns the schema and config to use `lightning_logs` as the log dir. For some reason they got out of sync and you'll end up with logs in the repo root directory rather than a subfolder, which is annoying for testing.

Also suppresses Lightning logging for the prediction script (unnecessary) and fixes up a few test cases that didn't set temporary directories.

## AI-Assisted Development
- [X] I used AI tools (e.g., GitHub Copilot, ChatGPT, etc.) in developing this PR
- [X] I understand all the code I'm submitting
- [X] I have reviewed and validated all AI-generated code

**AI tools used (if applicable):**
Got Claude to bisect and figure out which tests were creating folders.
