### PR TITLE
security mitigation for lightning compromise

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     "pandas",
     "pillow>6.2.0",
     "psutil",
-    "pytorch-lightning>=2.6.0,<3.0.0",
+    "pytorch-lightning<=2.6.1",
     "pyyaml>=5.1.0",
     "rasterio",
     "safetensors<0.6.0",
@@ -64,6 +64,9 @@ dependencies = [
     "transformers!=5.1.0,!=4.57",
     "xmltodict",
 ]
+
+[tool.uv]
+exclude-newer = "1 week"
 
 [project.urls]
 Documentation = "http://deepforest.readthedocs.io/en/latest/"


### PR DESCRIPTION
## Description

Pytorch Lightning 2.6.2 and 2.6.3 (at least) have been compromised.

This PR bounds versions to <= 2.6.1 which is currently marked as "safe" and also adds a [cooldown](https://docs.astral.sh/uv/concepts/resolution/#dependency-cooldowns) for `uv` so that packages are only updated if the release is more than a week old. Users may need to update uv (uv self update).

## Related Issue(s)

https://github.com/Lightning-AI/pytorch-lightning/security/advisories/GHSA-w37p-236h-pfx3