### PR TITLE
fix indentation error in viz

### DIFF
--- a/src/deepforest/callbacks.py
+++ b/src/deepforest/callbacks.py
@@ -156,12 +156,12 @@ class ImagesCallback(Callback):
         else:
             selected_images = df.image_path.unique()[: self.prediction_samples]
 
-            # Ensure color is correctly assigned
-            if self.color is None:
-                num_classes = len(df["label"].unique())
-                results_color = sv.ColorPalette.from_matplotlib("viridis", num_classes)
-            else:
-                results_color = self.color
+        # Ensure color is correctly assigned
+        if self.color is None:
+            num_classes = len(df["label"].unique())
+            results_color = sv.ColorPalette.from_matplotlib("viridis", num_classes)
+        else:
+            results_color = self.color
 
         for image_name in selected_images:
             pred_df = df[df.image_path == image_name]

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -151,6 +151,17 @@ def test_log_images_no_dataset(m, tmp_path):
     assert not (tmp_path / "train_sample").exists()
     assert not (tmp_path / "validation_sample").exists()
 
+def test_log_images_random(m, tmp_path):
+    """Test random image selection"""
+    im_callback = callbacks.ImagesCallback(
+        save_dir=tmp_path, every_n_epochs=1, prediction_samples=1, select_random=True
+    )
+
+    m.create_trainer(callbacks=[im_callback], fast_dev_run=False)
+    m.trainer.fit(m)
+
+    assert (tmp_path / "predictions").exists()
+
 def test_log_image_empty_annotations(m, tmp_path):
     """Test that images with no annotations are logged without error"""
     im_callback = callbacks.ImagesCallback(save_dir=tmp_path, every_n_epochs=1, prediction_samples=1)


### PR DESCRIPTION
## Description

When the image logging callback triggers, we assign a color to each class label. This code block was incorrectly indented and was in part of an unrelated conditional statement. It would only run on the `else` branch (non random image selection), when it needs to always run.

```
line 182, in _log_last_predictions
    results_color=results_color,
                  ^^^^^^^^^^^^^
UnboundLocalError: cannot access local variable 'results_color' where it is not associated with a value
```

We never tested for `select_random=True`, the unit test here adds that coverage and would have failed before.

## Related Issue(s)

@henrykironde this is what crashed your failed training run.