### PR TITLE
fix: move predict_image input tensor to the model's device

### DIFF
--- a/src/deepforest/predict.py
+++ b/src/deepforest/predict.py
@@ -35,6 +35,10 @@ def _predict_image_(
     """
     image = torch.tensor(image).permute(2, 0, 1)
     image = image / 255
+    try:
+        image = image.to(next(model.parameters()).device)
+    except StopIteration:
+        pass
 
     with torch.no_grad():
         prediction = model(image.unsqueeze(0))

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -411,6 +411,19 @@ def test_predict_image_fromfile(m):
     assert not prediction.empty
 
 
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_predict_image_on_cuda(m):
+    """Regression: model on CUDA must not raise a device mismatch in predict_image."""
+    m.model.to("cuda")
+    try:
+        prediction = m.predict_image(
+            path=get_data(path="2019_YELL_2_528000_4978000_image_crop2.png")
+        )
+    finally:
+        m.model.to("cpu")
+    assert isinstance(prediction, pd.DataFrame)
+
+
 def test_predict_image_fromarray(m):
     image_path = get_data(path="2019_YELL_2_528000_4978000_image_crop2.png")
 


### PR DESCRIPTION
## Summary

Fixes #1390.

`deepforest.predict._predict_image_` builds the input tensor on CPU and never moves it to the model's device, so any caller that has placed the model on CUDA (`model.model.to('cuda')`, or a Lightning trainer that has trained on GPU) gets:

```
RuntimeError: Input type (torch.FloatTensor) and weight type (torch.cuda.FloatTensor)
should be the same or input should be a MKLDNN tensor and weight is a dense tensor
```

This PR moves the input tensor to `next(model.parameters()).device` before the forward pass. Guarded with `try/except StopIteration` to handle the (unrealistic) case of a parameter-less model gracefully.

## Repro

```python
from deepforest import main
m = main.deepforest()
m.load_model(model_name='weecology/deepforest-tree', revision='main')
m.model.to('cuda')
m.predict_image(path='some_rgb.tif')
# before this PR: RuntimeError as above
# after this PR: returns a DataFrame of detections
```

## Changes

- `src/deepforest/predict.py`: move the input tensor to the model's device inside `_predict_image_`.
- `tests/test_main.py`: add `test_predict_image_on_cuda` regression test, skipped when CUDA is unavailable.

## Test plan

- [x] `ruff format --check` and `ruff check` on the changed source files (clean, using the version pinned in `.pre-commit-config.yaml`).
- [ ] CI: existing CPU `predict_image` tests should still pass; new CUDA test is auto-skipped on CPU-only runners.
- [ ] Verified locally that the workaround applied downstream in [opengeos/geoai#746](https://github.com/opengeos/geoai/pull/746) becomes unnecessary once this lands.