### PR TITLE
Add balanced hard-negative batch sampling for detection training.

### DIFF
--- a/docs/user_guide/11_training.md
+++ b/docs/user_guide/11_training.md
@@ -243,6 +243,14 @@ myimage.png, 0,0,0,0,"Tree"
 
 Excessive use of negative samples may have a negative impact on model performance, but when used sparingly, they can increase precision.
 
+When hard negatives greatly outnumber annotated images, uniform shuffling can put mostly empty frames in every batch and destabilize training. Set `train.positive_batch_fraction` (for example `0.75`) to fix how many images in each batch contain real annotations; the remainder are drawn at random from the negative pool. One training epoch then covers each annotated image once, while negatives are subsampled rather than fully repeated every epoch.
+
+```python
+m.config.train.positive_batch_fraction = 0.75
+```
+
+Or from the command line: `train.positive_batch_fraction=0.75`. Leave unset (`null`) to keep the default uniform shuffle.
+
 ### Model checkpoints
 
 Model checkpoints are the output of training. They represent the learned weights that can be distributed and used by anyone with DeepForest installed to perform prediction or fine-tuning. There are two main types of checkpoint that we work with:

--- a/src/deepforest/conf/config.yaml
+++ b/src/deepforest/conf/config.yaml
@@ -83,6 +83,10 @@ train:
             min_lr: 0
             eps: 0.00000001
 
+    # Fraction of each training batch with annotated images (remainder are hard negatives).
+    # null keeps uniform shuffle over all images in the CSV.
+    positive_batch_fraction:
+
     # How many epochs to run for
     epochs: 1
     # Useful debugging flag in pytorch lightning, set to True to get a single batch of training to test settings.

--- a/src/deepforest/conf/schema.py
+++ b/src/deepforest/conf/schema.py
@@ -83,6 +83,7 @@ class TrainConfig:
     preload_images: bool = False
     validate_coordinates: bool = True
     augmentations: list[str] | None = field(default_factory=lambda: ["HorizontalFlip"])
+    positive_batch_fraction: float | None = None
 
 
 @dataclass

--- a/src/deepforest/datasets/training.py
+++ b/src/deepforest/datasets/training.py
@@ -13,7 +13,7 @@ import torch
 import torchvision
 from kornia.constants import DataKey
 from PIL import Image
-from torch.utils.data import Dataset
+from torch.utils.data import Dataset, Sampler
 from torchvision.datasets import ImageFolder
 
 from deepforest import utilities
@@ -70,6 +70,9 @@ class TrainingDataset(Dataset):
         self._validate_labels()
         if validate_coordinates:
             self._validate_coordinates()
+        self.positive_indices, self.negative_indices = (
+            self._build_annotation_index_pools()
+        )
 
         # Pin data to memory if desired
         if self.preload_images:
@@ -104,6 +107,25 @@ class TrainingDataset(Dataset):
         are found.
         """
 
+    def _image_is_empty(self, image_path: str) -> bool:
+        """True when all annotation rows for the image use the empty-frame
+        sentinel."""
+        rows = self.annotations[self.annotations.image_path == image_path]
+        coords = rows[["xmin", "ymin", "xmax", "ymax"]].values
+        return np.sum(coords) == 0
+
+    def _build_annotation_index_pools(self) -> tuple[list[int], list[int]]:
+        """Split dataset indices into annotated (positive) and empty (negative)
+        images."""
+        positive_indices = []
+        negative_indices = []
+        for idx, image_path in enumerate(self.image_names):
+            if self._image_is_empty(image_path):
+                negative_indices.append(idx)
+            else:
+                positive_indices.append(idx)
+        return positive_indices, negative_indices
+
     def __len__(self) -> int:
         """Dataset length is the number of unique images."""
         return len(self.image_names)
@@ -133,6 +155,69 @@ class TrainingDataset(Dataset):
     def __getitem__(self, index) -> tuple:
         """Return a single item from the dataset."""
         pass
+
+
+class BalancedDetectionBatchSampler(Sampler[list[int]]):
+    """Batch sampler that fixes the fraction of annotated vs hard-negative
+    images.
+
+    One epoch covers each positive index once (in shuffled order).
+    Negatives are drawn at random with replacement from the negative
+    pool each batch.
+    """
+
+    def __init__(
+        self,
+        positive_indices: list[int],
+        negative_indices: list[int],
+        batch_size: int,
+        positive_batch_fraction: float,
+        generator: torch.Generator | None = None,
+    ):
+        if not 0 < positive_batch_fraction <= 1:
+            raise ValueError(
+                "positive_batch_fraction must be in (0, 1], "
+                f"got {positive_batch_fraction}"
+            )
+        if not positive_indices:
+            raise ValueError("positive_indices must not be empty")
+        if not negative_indices:
+            raise ValueError("negative_indices must not be empty")
+
+        self.positive_indices = positive_indices
+        self.negative_indices = negative_indices
+        self.batch_size = batch_size
+        self.positive_batch_fraction = positive_batch_fraction
+        self.generator = generator
+
+        self.n_positive = min(
+            batch_size, max(1, round(batch_size * positive_batch_fraction))
+        )
+        self.n_negative = batch_size - self.n_positive
+
+    def __len__(self) -> int:
+        return math.ceil(len(self.positive_indices) / self.n_positive)
+
+    def __iter__(self):
+        perm = torch.randperm(
+            len(self.positive_indices), generator=self.generator
+        ).tolist()
+        pos_pool = [self.positive_indices[i] for i in perm]
+        pos_i = 0
+
+        for _ in range(len(self)):
+            batch = []
+            for _ in range(self.n_positive):
+                batch.append(pos_pool[pos_i % len(pos_pool)])
+                pos_i += 1
+
+            neg_draws = torch.randint(
+                len(self.negative_indices),
+                (self.n_negative,),
+                generator=self.generator,
+            )
+            batch.extend(self.negative_indices[i] for i in neg_draws.tolist())
+            yield batch
 
 
 class BoxDataset(TrainingDataset):

--- a/src/deepforest/main.py
+++ b/src/deepforest/main.py
@@ -341,6 +341,7 @@ class deepforest(pl.LightningModule):
         preload_images=False,
         validate_coordinates=True,
         batch_size=1,
+        positive_batch_fraction=None,
     ):
         """Create a dataset for inference or training.
 
@@ -357,6 +358,9 @@ class deepforest(pl.LightningModule):
             preload_images: if True, preload the images into memory
             validate_coordinates: if True, check annotation coordinates fall within image bounds
             augmentations: augmentation configuration (str, list, or dict)
+            positive_batch_fraction: If set with shuffle=True, each batch contains
+                this fraction of annotated images and the rest hard negatives.
+                None uses uniform shuffle over all images.
         Returns:
             ds: a pytorch dataset
         """
@@ -400,13 +404,44 @@ class deepforest(pl.LightningModule):
                 f"Dataset from {csv_file} is empty. Check CSV for valid entries and columns."
             )
 
-        data_loader = torch.utils.data.DataLoader(
-            ds,
-            batch_size=batch_size,
-            shuffle=shuffle,
-            collate_fn=ds.collate_fn,
-            num_workers=self.config.workers,
-        )
+        use_balanced_sampler = False
+        if positive_batch_fraction is not None:
+            if not 0 < positive_batch_fraction <= 1:
+                raise ValueError(
+                    "positive_batch_fraction must be in (0, 1], "
+                    f"got {positive_batch_fraction}"
+                )
+            if shuffle and ds.positive_indices and ds.negative_indices:
+                use_balanced_sampler = True
+            else:
+                warnings.warn(
+                    "positive_batch_fraction is set but balanced sampling was not "
+                    "applied (requires shuffle=True and both annotated and empty "
+                    "images in the CSV). Using uniform shuffle.",
+                    stacklevel=2,
+                )
+
+        if use_balanced_sampler:
+            batch_sampler = training.BalancedDetectionBatchSampler(
+                positive_indices=ds.positive_indices,
+                negative_indices=ds.negative_indices,
+                batch_size=batch_size,
+                positive_batch_fraction=positive_batch_fraction,
+            )
+            data_loader = torch.utils.data.DataLoader(
+                ds,
+                batch_sampler=batch_sampler,
+                collate_fn=ds.collate_fn,
+                num_workers=self.config.workers,
+            )
+        else:
+            data_loader = torch.utils.data.DataLoader(
+                ds,
+                batch_size=batch_size,
+                shuffle=shuffle,
+                collate_fn=ds.collate_fn,
+                num_workers=self.config.workers,
+            )
 
         return data_loader
 
@@ -428,6 +463,7 @@ class deepforest(pl.LightningModule):
             shuffle=True,
             transforms=self.transforms,
             batch_size=self.config.batch_size,
+            positive_batch_fraction=self.config.train.positive_batch_fraction,
         )
 
         return loader

--- a/tests/test_balanced_detection_sampler.py
+++ b/tests/test_balanced_detection_sampler.py
@@ -1,0 +1,141 @@
+"""Tests for balanced hard-negative batch sampling during detection training."""
+
+import math
+import os
+import shutil
+
+import pandas as pd
+import pytest
+import torch
+from torch.utils.data import DataLoader
+
+from deepforest import get_data
+from deepforest.datasets.training import BalancedDetectionBatchSampler, BoxDataset
+
+
+def _make_mixed_csv(tmp_path, n_positive: int, n_negative: int) -> tuple[str, str]:
+    """Build a CSV with n_positive annotated images and n_negative empty images."""
+    root_dir = str(tmp_path / "images")
+    os.makedirs(root_dir, exist_ok=True)
+    source_image = get_data("OSBS_029.png")
+    rows = []
+    for i in range(n_positive):
+        image_name = f"positive_{i}.png"
+        shutil.copy(source_image, os.path.join(root_dir, image_name))
+        rows.append(
+            pd.DataFrame(
+                {
+                    "image_path": [image_name],
+                    "xmin": [10],
+                    "ymin": [10],
+                    "xmax": [50],
+                    "ymax": [50],
+                    "label": ["Tree"],
+                }
+            )
+        )
+    for i in range(n_negative):
+        image_name = f"negative_{i}.png"
+        shutil.copy(source_image, os.path.join(root_dir, image_name))
+        rows.append(
+            pd.DataFrame(
+                {
+                    "image_path": [image_name],
+                    "xmin": [0],
+                    "ymin": [0],
+                    "xmax": [0],
+                    "ymax": [0],
+                    "label": ["Tree"],
+                }
+            )
+        )
+    df = pd.concat(rows, ignore_index=True)
+    csv_path = str(tmp_path / "mixed.csv")
+    df.to_csv(csv_path, index=False)
+    return csv_path, root_dir
+
+
+def test_balanced_batch_sampler_composition(tmp_path):
+    """Each batch has a fixed positive/negative count for the given fraction."""
+    csv_path, root_dir = _make_mixed_csv(tmp_path, n_positive=4, n_negative=20)
+    ds = BoxDataset(csv_file=csv_path, root_dir=root_dir, label_dict={"Tree": 0})
+    batch_size = 8
+    fraction = 0.75
+    generator = torch.Generator().manual_seed(0)
+    sampler = BalancedDetectionBatchSampler(
+        positive_indices=ds.positive_indices,
+        negative_indices=ds.negative_indices,
+        batch_size=batch_size,
+        positive_batch_fraction=fraction,
+        generator=generator,
+    )
+    n_positive = min(batch_size, max(1, round(batch_size * fraction)))
+    n_negative = batch_size - n_positive
+    positive_set = set(ds.positive_indices)
+    negative_set = set(ds.negative_indices)
+
+    for batch in sampler:
+        assert len(batch) == batch_size
+        assert sum(idx in positive_set for idx in batch) == n_positive
+        assert sum(idx in negative_set for idx in batch) == n_negative
+
+
+def test_balanced_sampler_caps_empty_per_batch(tmp_path):
+    """Balanced sampling limits empty images per batch under heavy negative skew."""
+    csv_path, root_dir = _make_mixed_csv(tmp_path, n_positive=1, n_negative=50)
+    ds = BoxDataset(csv_file=csv_path, root_dir=root_dir, label_dict={"Tree": 0})
+    batch_size = 8
+    fraction = 0.75
+    n_positive = min(batch_size, max(1, round(batch_size * fraction)))
+    max_empty_balanced = batch_size - n_positive
+
+    balanced = BalancedDetectionBatchSampler(
+        positive_indices=ds.positive_indices,
+        negative_indices=ds.negative_indices,
+        batch_size=batch_size,
+        positive_batch_fraction=fraction,
+        generator=torch.Generator().manual_seed(1),
+    )
+    negative_set = set(ds.negative_indices)
+    for batch in balanced:
+        empty_count = sum(idx in negative_set for idx in batch)
+        assert empty_count <= max_empty_balanced
+
+    max_empty_seen = 0
+    for _ in range(20):
+        perm = torch.randperm(len(ds), generator=torch.Generator().manual_seed(1))
+        for start in range(0, len(ds), batch_size):
+            batch_idx = perm[start : start + batch_size].tolist()
+            empty_count = sum(idx in negative_set for idx in batch_idx)
+            max_empty_seen = max(max_empty_seen, empty_count)
+    assert max_empty_seen > max_empty_balanced
+
+
+def test_balanced_sampler_epoch_length(tmp_path):
+    """Epoch length is one pass over positive images when balancing is enabled."""
+    csv_path, root_dir = _make_mixed_csv(tmp_path, n_positive=5, n_negative=30)
+    ds = BoxDataset(csv_file=csv_path, root_dir=root_dir, label_dict={"Tree": 0})
+    batch_size = 4
+    fraction = 0.75
+    sampler = BalancedDetectionBatchSampler(
+        positive_indices=ds.positive_indices,
+        negative_indices=ds.negative_indices,
+        batch_size=batch_size,
+        positive_batch_fraction=fraction,
+    )
+    n_positive = min(batch_size, max(1, round(batch_size * fraction)))
+    expected_len = math.ceil(len(ds.positive_indices) / n_positive)
+    assert len(sampler) == expected_len
+
+    loader = DataLoader(ds, batch_sampler=sampler)
+    assert len(loader) == expected_len
+
+
+def test_balanced_sampler_requires_both_pools():
+    with pytest.raises(ValueError, match="positive_indices must not be empty"):
+        BalancedDetectionBatchSampler(
+            positive_indices=[],
+            negative_indices=[0],
+            batch_size=4,
+            positive_batch_fraction=0.75,
+        )


### PR DESCRIPTION
Optional train.positive_batch_fraction fixes annotated vs empty images per batch and subsamples large negative pools.

## Description

<!-- Provide a clear and concise description of what this PR does -->

## Related Issue(s)

<!-- Link to related issues using: Closes #123, Fixes #456, Related to #789 -->
<!-- If no issue exists, explain why this change is needed -->


## AI-Assisted Development

<!-- Be transparent about AI tool usage -->

- [ ] I used AI tools (e.g., GitHub Copilot, ChatGPT, etc.) in developing this PR
- [ ] I understand all the code I'm submitting
- [ ] I have reviewed and validated all AI-generated code

**AI tools used (if applicable):**
<!-- List AI tools used, if any -->
