### PR TITLE
Edge cases for empty frames + test with non-empty frames.

### DIFF
--- a/src/deepforest/metrics.py
+++ b/src/deepforest/metrics.py
@@ -63,6 +63,11 @@ class RecallPrecision(Metric):
         )
         self.add_state("num_empty_frames", default=torch.tensor(0), dist_reduce_fx="sum")
         self.add_state(
+            "num_images_with_ground_truth",
+            default=torch.tensor(0),
+            dist_reduce_fx="sum",
+        )
+        self.add_state(
             "correct_empty_predictions", default=torch.tensor(0), dist_reduce_fx="sum"
         )
 
@@ -110,6 +115,8 @@ class RecallPrecision(Metric):
                 # Predictions in an empty frame are all FP: precision = 0
                 self.num_images_with_predictions += 1
             return
+
+        self.num_images_with_ground_truth += 1
 
         if n_pred == 0:
             # No predictions but ground truth exists: recall=0, precision undefined
@@ -198,7 +205,11 @@ class RecallPrecision(Metric):
                 if self.num_images_with_predictions > 0
                 else torch.tensor(float("nan"))
             ),
-            f"{self.task}_recall": self.recall.float() / self.num_images.float(),
+            f"{self.task}_recall": (
+                self.recall.float() / self.num_images_with_ground_truth.float()
+                if self.num_images_with_ground_truth > 0
+                else torch.tensor(float("nan"))
+            ),
         }
 
         # Only log class metrics if multi-class targets

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,98 @@
+import math
+
+import torch
+
+from deepforest.metrics import RecallPrecision
+
+
+def _perfect_match_pair():
+    """Prediction and target with a single matching box."""
+    box = torch.tensor([[10.0, 10.0, 50.0, 50.0]], dtype=torch.float32)
+    pred = {
+        "boxes": box,
+        "labels": torch.tensor([0], dtype=torch.int64),
+        "scores": torch.tensor([0.9]),
+    }
+    target = {"boxes": box, "labels": torch.tensor([0], dtype=torch.int64)}
+    return pred, target
+
+
+def _empty_frame_pair():
+    """Empty ground truth with no predictions."""
+    return (
+        {
+            "boxes": torch.zeros((0, 4), dtype=torch.float32),
+            "labels": torch.tensor([], dtype=torch.int64),
+            "scores": torch.tensor([], dtype=torch.float32),
+        },
+        {
+            "boxes": torch.zeros((0, 4), dtype=torch.float32),
+            "labels": torch.tensor([], dtype=torch.int64),
+        },
+    )
+
+
+def _gt_without_predictions_pair():
+    """Ground truth with boxes but no predictions (per-image recall should be 0)."""
+    target = {
+        "boxes": torch.tensor([[10.0, 10.0, 50.0, 50.0]], dtype=torch.float32),
+        "labels": torch.tensor([0], dtype=torch.int64),
+    }
+    pred = {
+        "boxes": torch.zeros((0, 4), dtype=torch.float32),
+        "labels": torch.tensor([], dtype=torch.int64),
+        "scores": torch.tensor([], dtype=torch.float32),
+    }
+    return pred, target
+
+
+def test_box_recall_excludes_empty_frames_from_average():
+    """Empty frames should not lower mean recall.
+
+    One image with perfect recall and one empty frame should average to 1.0,
+    not 0.5 from dividing by all images passed to update.
+    """
+    metric = RecallPrecision(label_dict={"Tree": 0})
+    pred, target = _perfect_match_pair()
+    empty_pred, empty_target = _empty_frame_pair()
+
+    metric.update(
+        [pred, empty_pred],
+        [target, empty_target],
+        ["with_trees.jpg", "empty.jpg"],
+    )
+    results = metric.compute()
+
+    assert metric.num_images == 2
+    assert metric.num_empty_frames == 1
+    assert math.isclose(results["box_recall"], 1.0, rel_tol=1e-5), (
+        f"box_recall={results['box_recall']:.2f}, expected 1.0 when averaging "
+        "only over images with ground truth"
+    )
+
+
+def test_box_recall_counts_gt_images_without_predictions_as_zero():
+    """Images with ground truth but no predictions should count as recall 0.
+
+    Mean recall should be over images with non-empty ground truth. One perfect
+    image and one image with missed detections should average to 0.5 even when
+    an empty frame is also in the batch (empty frames must not enter the mean).
+    """
+    metric = RecallPrecision(label_dict={"Tree": 0})
+    pred, target = _perfect_match_pair()
+    missed_pred, missed_target = _gt_without_predictions_pair()
+    empty_pred, empty_target = _empty_frame_pair()
+
+    metric.update(
+        [pred, missed_pred, empty_pred],
+        [target, missed_target, empty_target],
+        ["matched.jpg", "missed.jpg", "empty.jpg"],
+    )
+    results = metric.compute()
+
+    assert metric.num_images == 3
+    assert metric.num_empty_frames == 1
+    assert math.isclose(results["box_recall"], 0.5, rel_tol=1e-5), (
+        f"box_recall={results['box_recall']:.2f}, expected 0.5 (mean of 1.0 and 0.0 "
+        "over two images with ground truth, excluding the empty frame)"
+    )


### PR DESCRIPTION
In the BOEM workflow I found a funny edge case where if the test dataset has both empty frames and non-empty frames, it produces a non-intuitive results. It was mathematically correct, but just confusing and too literal. We were dividing the recalls by the total number of images, so the average box_recall score was (number of matches/total number of images), but given that some of those images are empty, it produces a strange result. So if you had two images, 1 with one ground truth, correctly matched, and one that was empty, the average box_recall was 0.5, when it really should be 1 match /1 image with GT + empty image, not 1 match / (2 images). 


## AI-Assisted Development

I have coalesced around a cursor strategy where I identify errors, discuss with the agent. I then have cursor develop failing tests, which then I implement a correction for and then we all agree its passing. This feels reasonable since there is an adversarial element to it. 