### PR TITLE
Add end-to-end polygon (Mask R-CNN) workflow

### DIFF
--- a/src/deepforest/conf/schema.py
+++ b/src/deepforest/conf/schema.py
@@ -148,12 +148,14 @@ class Config:
     Some parameters here are shared between dataloaders, for example the
     batch size, accelerator and number of workers.
 
-    Here we also set the architecture, which can be one of "retinanet"
-    or "DeformableDetr" currently. If you modify the number of classes
-    or label dict from what is loaded from the hub, it's assumed that
-    you intend to fine-tune or otherwise train the model. In this case,
-    the model will be adapted to fit your configuration by, for example,
-    adjusting the number of classification heads.
+    Here we also set the architecture, which can be one of "retinanet",
+    "DeformableDetr" (box), "treeformer" (point), or "maskrcnn"
+    (polygon) currently. The model's task (box, point or polygon)
+    follows from the chosen architecture. If you modify the number of
+    classes or label dict from what is loaded from the hub, it's assumed
+    that you intend to fine-tune or otherwise train the model. In this
+    case, the model will be adapted to fit your configuration by, for
+    example, adjusting the number of classification heads.
 
     For most users the default setting of 1-class, "tree" should be
     sufficient.

--- a/src/deepforest/datasets/prediction.py
+++ b/src/deepforest/datasets/prediction.py
@@ -110,8 +110,11 @@ class PredictionDataset(Dataset):
 
     def determine_geometry_type(self, batched_result):
         """Determine the geometry type of the batched result."""
-        # Assumes that all geometries are the same in a batch
-        if "boxes" in batched_result.keys():
+        # Assumes that all geometries are the same in a batch. Mask R-CNN
+        # results contain both "masks" and "boxes"; masks take precedence.
+        if "masks" in batched_result.keys():
+            geom_type = "polygon"
+        elif "boxes" in batched_result.keys():
             geom_type = "box"
         elif "points" in batched_result.keys():
             geom_type = "point"

--- a/src/deepforest/datasets/training.py
+++ b/src/deepforest/datasets/training.py
@@ -584,10 +584,11 @@ class PointDataset(TrainingDataset):
 class PolygonDataset(TrainingDataset):
     """Dataset for instance segmentation with polygon masks.
 
-    Parallels :class:`BoxDataset` but additionally rasterizes each polygon
-    geometry into a binary instance mask. Targets contain ``boxes``
-    (the polygon bounds), ``labels`` and ``masks`` for use with Mask R-CNN.
-    Labels are zero-indexed to match the box and point workflows.
+    Parallels :class:`BoxDataset` but additionally rasterizes each
+    polygon geometry into a binary instance mask. Targets contain
+    ``boxes`` (the polygon bounds), ``labels`` and ``masks`` for use
+    with Mask R-CNN. Labels are zero-indexed to match the box and point
+    workflows.
     """
 
     _data_keys = [DataKey.IMAGE, DataKey.BBOX_XYXY, DataKey.MASK]

--- a/src/deepforest/datasets/training.py
+++ b/src/deepforest/datasets/training.py
@@ -582,37 +582,25 @@ class PointDataset(TrainingDataset):
 
 
 class PolygonDataset(TrainingDataset):
+    """Dataset for instance segmentation with polygon masks.
+
+    Parallels :class:`BoxDataset` but additionally rasterizes each polygon
+    geometry into a binary instance mask. Targets contain ``boxes``
+    (the polygon bounds), ``labels`` and ``masks`` for use with Mask R-CNN.
+    Labels are zero-indexed to match the box and point workflows.
+    """
+
     _data_keys = [DataKey.IMAGE, DataKey.BBOX_XYXY, DataKey.MASK]
 
-    def __init__(
-        self,
-        annotation_file,
-        root_dir,
-        transforms=None,
-        augmentations=None,
-        label_dict=None,
-        preload_images=None,
-        validate_coordinates=True,
-    ):
-        super().__init__(
-            csv_file=annotation_file,
-            root_dir=root_dir,
-            transforms=transforms,
-            augmentations=augmentations,
-            label_dict=label_dict,
-            preload_images=preload_images,
-            validate_coordinates=validate_coordinates,
-        )
-
     def _validate_coordinates(self) -> None:
-        """Validate that all points occur within the image.
+        """Validate that all polygons are valid and within the image.
 
         Raises:
-            ValueError: If any point occurs outside the image
+            ValueError: If any polygon is invalid or exceeds image bounds.
         """
         errors = []
-        for _, row in self.annotations.iterrows():
-            img_path = os.path.join(self.root_dir, row["image_path"])
+        for image_path, group in self.annotations.groupby("image_path"):
+            img_path = os.path.join(self.root_dir, image_path)
             try:
                 with Image.open(img_path) as img:
                     width, height = img.size
@@ -620,201 +608,194 @@ class PolygonDataset(TrainingDataset):
                 errors.append(f"Failed to open image {img_path}: {e}")
                 continue
 
-            self._validate_segmentation_coordinates(row, errors, img_path, width, height)
-            self._validate_box_coordinates(row, errors, img_path, width, height)
+            for _idx, row in group.iterrows():
+                geom = row["geometry"]
+                if geom is None or geom.is_empty:
+                    errors.append(f"Empty polygon geometry for image {img_path}")
+                    continue
+
+                if geom.area == 0:
+                    errors.append(f"Polygon has zero area for image {img_path}")
+                if not geom.is_valid:
+                    errors.append(f"Invalid polygon (self-intersecting) for {img_path}")
+
+                xmin, ymin, xmax, ymax = geom.bounds
+                oob_issues = []
+                if xmin < 0:
+                    oob_issues.append(f"xmin ({xmin}) < 0")
+                if xmax > width:
+                    oob_issues.append(f"xmax ({xmax}) > image width ({width})")
+                if ymin < 0:
+                    oob_issues.append(f"ymin ({ymin}) < 0")
+                if ymax > height:
+                    oob_issues.append(f"ymax ({ymax}) > image height ({height})")
+
+                if oob_issues:
+                    errors.append(
+                        f"Polygon, ({xmin}, {ymin}, {xmax}, {ymax}) exceeds image "
+                        f"dimensions, ({width}, {height}) for {img_path}. "
+                        f"Issues: {', '.join(oob_issues)}."
+                    )
 
         if errors:
             raise ValueError("\n".join(errors))
 
-    def _validate_segmentation_coordinates(self, row, errors, img_path, width, height):
-        coords = []
-        oob_issues = []
-        geom = row["geometry"]
+    def generate_mask(self, geom, width, height) -> np.typing.NDArray[np.uint8]:
+        """Rasterize a Shapely polygon into a binary instance mask.
 
-        if geom.area == 0:
-            errors.append(f"Polygon has zero area for image {img_path}")
+        Args:
+            geom: A Shapely Polygon/MultiPolygon (or its WKT string).
+            width: Mask width in pixels.
+            height: Mask height in pixels.
 
-        if not geom.is_valid:
-            errors.append("Invalid polygon (self-intersecting)")
-
-        if geom.geom_type == "Polygon":
-            coords.extend(list(geom.exterior.coords))
-        elif geom.geom_type == "MultiPolygon":
-            for poly in geom.geoms:
-                coords.extend(list(poly.exterior.coords))
-
-        if len(set(coords)) < 3:
-            errors.append("Polygon has fewer than 3 unique points")
-
-        for x, y in coords:
-            if x < 0:
-                oob_issues.append(f"x ({x}) < 0")
-            if x > width:
-                oob_issues.append(f"x ({x}) > image width ({width})")
-            if y < 0:
-                oob_issues.append(f"y ({y}) < 0")
-            if y > height:
-                oob_issues.append(f"y ({y}) > image height ({height})")
-
-            if oob_issues:
-                errors.append(
-                    f"Point, ({x}, {y}) exceeds image dimensions, ({width}, {height}) for {img_path}. Issues: {', '.join(oob_issues)}."
-                )
-
-    def _validate_box_coordinates(self, row, errors, img_path, width, height):
-        xmin, ymin, xmax, ymax = row["xmin"], row["ymin"], row["xmax"], row["ymax"]
-        oob_issues = []
-        if xmin < 0:
-            oob_issues.append(f"xmin ({xmin}) < 0")
-        if xmax > width:
-            oob_issues.append(f"xmax ({xmax}) > image width ({width})")
-        if ymin < 0:
-            oob_issues.append(f"ymin ({ymin}) < 0")
-        if ymax > height:
-            oob_issues.append(f"ymax ({ymax}) > image height ({height})")
-        if oob_issues:
-            errors.append(
-                f"Box, ({xmin}, {ymin}, {xmax}, {ymax}) exceeds image dimensions, ({width}, {height}) for {img_path}. Issues: {', '.join(oob_issues)}."
-            )
-
-    def generate_mask(self, image_annotation, width, height):
+        Returns:
+            A ``(height, width)`` uint8 array with the polygon interior set.
+        """
         mask = np.zeros((height, width), dtype=np.uint8)
-        geom = image_annotation["geometry"]
 
         if isinstance(geom, str):
             geom = shapely.wkt.loads(geom)
 
-        # -------------------------
-        # POLYGON
-        # -------------------------
         if geom.geom_type == "Polygon":
             coords = np.array(geom.exterior.coords, dtype=np.int32)
-            cv2.fillPoly(mask, [coords], color=255)
-
-        # -------------------------
-        # MULTIPOLYGON
-        # -------------------------
+            cv2.fillPoly(mask, [coords], color=1)
         elif geom.geom_type == "MultiPolygon":
             for poly in geom.geoms:
                 if not poly.is_empty:
                     coords = np.array(poly.exterior.coords, dtype=np.int32)
-                    cv2.fillPoly(mask, [coords], color=255)
+                    cv2.fillPoly(mask, [coords], color=1)
+
         return mask
 
-    def annotations_for_path(self, image_name, image_path, return_tensor=False):
-        try:
-            print("opening image")
-            with Image.open(image_path) as img:
-                width, height = img.size
-        except Exception as e:
-            print(f"Failed to open image {image_path}: {e}")
-            return
-        image_annotations = self.annotations[self.annotations.image_path == image_name]
-        targets = {}
-        boxes = []
-        labels = []
-        masks = []
-        iscrowd = []
-        area = []
+    def annotations_for_path(self, image_path, return_tensor=False) -> dict:
+        """Construct target dictionary for a given image path.
 
-        for _, ann in image_annotations.iterrows():
-            boxes.append([ann["xmin"], ann["ymin"], ann["xmax"], ann["ymax"]])
-            labels.append(self.label_dict[ann["label"]])
-            mask = self.generate_mask(ann, width, height)
-            masks.append(mask)
-            iscrowd.append(ann["iscrowd"])
-            area.append(ann["area"])
+        Args:
+            image_path (str): Path to image, expected to be in dataframe
+            return_tensor (bool): If true, convert fields from numpy to tensor
+
+        Returns:
+            target dictionary with boxes, labels and geometry entries
+        """
+        image_annotations = self.annotations[self.annotations.image_path == image_path]
+        targets = {}
+
+        # Polygon bounds give the enclosing box used by Mask R-CNN.
+        targets["boxes"] = np.array(
+            [
+                x.bounds if hasattr(x, "bounds") else shapely.wkt.loads(x).bounds
+                for x in image_annotations.geometry
+            ]
+        ).astype("float32")
+
+        targets["labels"] = image_annotations.label.apply(
+            lambda x: self.label_dict[x]
+        ).values.astype(np.int64)
+
+        # Keep geometry so __getitem__ can rasterize masks at image size.
+        targets["geometry"] = image_annotations.geometry.values
 
         if return_tensor:
-            boxes = torch.as_tensor(boxes, dtype=torch.float32)
-            labels = torch.as_tensor(labels, dtype=torch.int64)
-            if len(masks) > 0:
-                masks = np.stack(masks)
-                masks = (masks > 0).astype(np.uint8)
-                masks = torch.as_tensor(masks, dtype=torch.uint8)
-            else:
-                masks = torch.zeros((0, height, width), dtype=torch.uint8)
-            iscrowd = torch.as_tensor(iscrowd, dtype=torch.bool)
-            area = torch.as_tensor(area)
-
-        image_id = image_annotations.iloc[0]["image_id"]
-
-        targets = {
-            "image_id": image_id,
-            "boxes": boxes,
-            "labels": labels,
-            "masks": masks,
-            "iscrowd": iscrowd,
-            "area": area,
-        }
+            targets["boxes"] = torch.from_numpy(targets["boxes"])
+            targets["labels"] = torch.from_numpy(targets["labels"])
 
         return targets
 
-    def __getitem__(self, index):
-        image_id = self.image_names[index]
-        image_path = os.path.join(self.root_dir, image_id)
-        image = Image.open(image_path).convert("RGB")
-        width, height = image.size
-
-        targets = self.annotations_for_path(self.image_names[index], image_path)
-
-        # Apply augmentations
-        np_image = np.array(image)
-        image_tensor = (
-            torch.from_numpy(np_image).permute(2, 0, 1).unsqueeze(0).float() / 255.0
-        )
-        boxes_tensor = torch.as_tensor(targets["boxes"], dtype=torch.float32).unsqueeze(0)
-        masks = targets["masks"]
-        if len(masks) > 0:
-            masks = np.stack(masks)
-            masks = (masks > 0).astype(np.uint8)
-            masks = torch.as_tensor(masks, dtype=torch.uint8).unsqueeze(0)
+    def __getitem__(self, idx) -> tuple:
+        # Read image if not in memory
+        if self.preload_images:
+            image = self.image_dict[idx]
         else:
-            masks = torch.zeros((0, height, width), dtype=torch.uint8).unsqueeze(0)
+            image = self.load_image(idx)
 
+        height, width = image.shape[:2]
+        targets = self.annotations_for_path(self.image_names[idx])
+
+        boxes = targets["boxes"]
+        labels = targets["labels"]
+        geometries = targets["geometry"]
+
+        # If image has no annotations, add a dummy empty frame
+        if boxes.size == 0 or np.sum(boxes) == 0:
+            boxes = np.zeros((0, 4), dtype=np.float32)
+            labels = np.zeros(0, dtype=np.int64)
+            geometries = []
+
+        # Rasterize each polygon into a binary instance mask
+        if len(geometries) > 0:
+            masks = np.stack(
+                [self.generate_mask(geom, width, height) for geom in geometries]
+            ).astype(np.uint8)
+        else:
+            masks = np.zeros((0, height, width), dtype=np.uint8)
+
+        # Apply augmentations jointly to image, boxes and masks
+        image_tensor = torch.from_numpy(image).permute(2, 0, 1).unsqueeze(0).float()
+        boxes_tensor = torch.from_numpy(boxes).unsqueeze(0).float()
+        masks_tensor = torch.from_numpy(masks).unsqueeze(0).float()
         augmented_image, augmented_boxes, augmented_masks = self.transform(
-            image_tensor, boxes_tensor, masks
+            image_tensor, boxes_tensor, masks_tensor
         )
 
-        # Convert to tensor
-        image = augmented_image.squeeze()
-        boxes = augmented_boxes.squeeze()
-        masks = augmented_masks.squeeze()
-        labels = torch.as_tensor(targets["labels"], dtype=torch.int64)
-        iscrowd = torch.as_tensor(targets["iscrowd"], dtype=torch.bool)
-        area = torch.as_tensor(targets["area"])
-        image_id = targets["image_id"]
+        image = augmented_image.squeeze(0)
+        boxes = augmented_boxes.squeeze(0)
+        masks = augmented_masks.squeeze(0)
+        labels = torch.from_numpy(labels.astype(np.int64))
 
-        # Filter out-of-bounds boxes and sync with transformed
-        # segmentation masks
-        filter_w = min(image_tensor.shape[3], image.shape[2])
-        filter_h = min(image_tensor.shape[2], image.shape[1])
-        if boxes.dim() == 2 and boxes.shape[0] > 0:
-            boxes[:, 0] = torch.clamp(boxes[:, 0], min=0, max=filter_w)
-            boxes[:, 1] = torch.clamp(boxes[:, 1], min=0, max=filter_h)
-            boxes[:, 2] = torch.clamp(boxes[:, 2], min=0, max=filter_w)
-            boxes[:, 3] = torch.clamp(boxes[:, 3], min=0, max=filter_h)
-            box_w = boxes[:, 2] - boxes[:, 0]
-            box_h = boxes[:, 3] - boxes[:, 1]
-            valid = (box_w >= 1) & (box_h >= 1)
+        boxes, labels, masks = self.filter_masks(
+            boxes,
+            labels,
+            masks,
+            width=min(image_tensor.shape[3], image.shape[2]),
+            height=min(image_tensor.shape[2], image.shape[1]),
+        )
 
-            boxes = boxes[valid]
-            labels = labels[valid]
-            if masks.dim() == 3:
-                masks = masks[valid]
-            iscrowd = iscrowd[valid]
-            area = area[valid]
+        # Edge case if all labels were augmented away, keep the image
+        if len(boxes) == 0:
+            boxes = torch.zeros((0, 4), dtype=torch.float32)
+            labels = torch.zeros(0, dtype=torch.int64)
+            masks = torch.zeros((0, image.shape[1], image.shape[2]), dtype=torch.uint8)
 
         targets = {
-            "image_id": image_id,
             "boxes": boxes,
             "labels": labels,
-            "masks": masks,
-            "iscrowd": iscrowd,
-            "area": area,
+            "masks": masks.to(torch.uint8),
         }
 
-        return image, targets
+        return image, targets, self.image_names[idx]
+
+    def filter_masks(self, boxes, labels, masks, width, height, min_size=1) -> tuple:
+        """Clamp boxes to image bounds and filter boxes, labels and masks
+        together by minimum box dimension.
+
+        Args:
+            boxes (torch.Tensor): Bounding boxes of shape (N, 4) in xyxy format.
+            labels (torch.Tensor): Labels of shape (N,).
+            masks (torch.Tensor): Instance masks of shape (N, H, W).
+            width (int): Image width in pixels.
+            height (int): Image height in pixels.
+            min_size (int): Minimum box width/height in pixels. Defaults to 1.
+
+        Returns:
+            tuple: (filtered_boxes, filtered_labels, filtered_masks)
+        """
+        if boxes.dim() != 2 or boxes.shape[0] == 0:
+            return boxes, labels, masks
+
+        boxes[:, 0] = torch.clamp(boxes[:, 0], min=0, max=width)
+        boxes[:, 1] = torch.clamp(boxes[:, 1], min=0, max=height)
+        boxes[:, 2] = torch.clamp(boxes[:, 2], min=0, max=width)
+        boxes[:, 3] = torch.clamp(boxes[:, 3], min=0, max=height)
+
+        box_w = boxes[:, 2] - boxes[:, 0]
+        box_h = boxes[:, 3] - boxes[:, 1]
+        valid = (box_w >= min_size) & (box_h >= min_size)
+
+        masks = masks > 0.5
+        if masks.dim() == 3:
+            masks = masks[valid]
+
+        return boxes[valid], labels[valid], masks
 
 
 # ---------- ImageFolder alignment utilities ----------

--- a/src/deepforest/main.py
+++ b/src/deepforest/main.py
@@ -118,9 +118,14 @@ class deepforest(pl.LightningModule):
             )
 
         # Segmentation metrics
-        if self.model.task == "polygon":
+        elif self.model.task == "polygon":
             self.mAP_metric = MeanAveragePrecision(
                 iou_type="segm", backend="faster_coco_eval"
+            )
+            self.precision_recall_metric = RecallPrecision(
+                iou_threshold=self.config.validation.iou_threshold,
+                label_dict=self.label_dict,
+                task=self.model.task,
             )
 
     def load_model(self, model_name=None, revision=None):
@@ -803,7 +808,7 @@ class deepforest(pl.LightningModule):
             preds = self.model.forward(images, targets)
 
         # Compute precision, recall and empty frame metrics.
-        if self.model.task == "box" or self.model.task == "point":
+        if self.model.task in ("box", "point", "polygon"):
             self.precision_recall_metric.update(preds, targets, image_names)
 
         if self.model.task == "box":
@@ -831,25 +836,36 @@ class deepforest(pl.LightningModule):
             )
             self.mae_metric.update(pred_counts, true_counts)
         elif self.model.task == "polygon":
-            non_empty_pred = []
-            non_empty_target = []
+            # Build boolean instance masks for segmentation mAP, skipping
+            # empty ground-truth frames.
+            map_preds = []
+            map_targets = []
             for pred, target in zip(preds, targets, strict=True):
-                if "masks" in pred:
-                    masks = pred["masks"].squeeze(1)
+                if target["labels"].numel() == 0:
+                    continue
 
-                    if masks.dtype.is_floating_point:
-                        masks = masks > 0.5
+                pred_masks = pred["masks"]
+                if pred_masks.ndim == 4:
+                    pred_masks = pred_masks.squeeze(1)
+                if pred_masks.is_floating_point():
+                    pred_masks = pred_masks > 0.5
 
-                    pred["masks"] = masks.to(torch.uint8)
+                map_preds.append(
+                    {
+                        "masks": pred_masks.to(torch.bool),
+                        "scores": pred["scores"],
+                        "labels": pred["labels"],
+                    }
+                )
+                map_targets.append(
+                    {
+                        "masks": target["masks"].to(torch.bool),
+                        "labels": target["labels"],
+                    }
+                )
 
-                if "masks" in target:
-                    target["masks"] = target["masks"].to(torch.uint8)
-
-                if len(target["labels"] > 0):
-                    non_empty_pred.append(pred)
-                    non_empty_target.append(target)
-
-            self.mAP_metric.update(non_empty_pred, non_empty_target)
+            if map_preds:
+                self.mAP_metric.update(map_preds, map_targets)
 
         # Log the predictions if you want to use them for evaluation logs
         for i, result in enumerate(preds):
@@ -888,6 +904,20 @@ class deepforest(pl.LightningModule):
             metrics["val_mae"] = self.mae_metric.compute()
             metrics.update(self.precision_recall_metric.compute())
 
+        elif self.model.task == "polygon":
+            # Segmentation mAP, only when non-empty ground truth was seen
+            n_non_empty = (
+                self.precision_recall_metric.num_images
+                - self.precision_recall_metric.num_empty_frames
+            )
+            if n_non_empty > 0:
+                output = self.mAP_metric.compute()
+                output = {
+                    key: value for key, value in output.items() if not key == "classes"
+                }
+                metrics.update(output)
+            metrics.update(self.precision_recall_metric.compute())
+
         return metrics
 
     def on_validation_epoch_end(self):
@@ -912,6 +942,7 @@ class deepforest(pl.LightningModule):
             self.precision_recall_metric.reset()
         elif self.model.task == "polygon":
             self.mAP_metric.reset()
+            self.precision_recall_metric.reset()
 
     def predict_step(self, batch, batch_idx):
         """Predict a batch of images with the deepforest model.
@@ -1136,7 +1167,7 @@ class deepforest(pl.LightningModule):
         results = {}
         results.update(self.trainer.logged_metrics)
         results["predictions"] = self.predictions
-        if self.model.task == "box" or self.model.task == "point":
+        if self.model.task in ("box", "point", "polygon"):
             results["results"] = self.precision_recall_metric.get_results()
 
         return results

--- a/src/deepforest/metrics.py
+++ b/src/deepforest/metrics.py
@@ -45,8 +45,10 @@ class RecallPrecision(Metric):
         self.label_dict = label_dict or {}
         self.numeric_to_label_dict = {v: k for k, v in self.label_dict.items()}
 
-        if task not in ("box", "point"):
-            raise ValueError(f"Unsupported task: {task}. Use 'box' or 'point'.")
+        if task not in ("box", "point", "polygon"):
+            raise ValueError(
+                f"Unsupported task: {task}. Use 'box', 'point' or 'polygon'."
+            )
 
         if self.task == "box":
             self.pred_key = "boxes"
@@ -54,6 +56,11 @@ class RecallPrecision(Metric):
         elif self.task == "point":
             self.pred_key = "points"
             self.geom_type = "point"
+        elif self.task == "polygon":
+            # Instance segmentation: count instances by their enclosing boxes,
+            # but match using polygon (mask) IoU.
+            self.pred_key = "boxes"
+            self.geom_type = "polygon"
 
         self.add_state("precision", default=torch.tensor(0.0), dist_reduce_fx="sum")
         self.add_state("recall", default=torch.tensor(0.0), dist_reduce_fx="sum")
@@ -183,7 +190,7 @@ class RecallPrecision(Metric):
                         else x
                     )
             # TODO Check why this fails for point predictions
-            if self.task == "box" and len(self.label_dict) > 1:
+            if self.task in ("box", "polygon") and len(self.label_dict) > 1:
                 self._class_recall = compute_class_recall(
                     self._all_results[self._all_results["match"]]
                 )

--- a/src/deepforest/models/maskrcnn.py
+++ b/src/deepforest/models/maskrcnn.py
@@ -15,12 +15,12 @@ class MaskRCNN(_TorchvisionMaskRCNN, PyTorchModelHubMixin):
     """Mask R-CNN extension that allows the use of the HF Hub API.
 
     DeepForest labels are zero-indexed foreground classes (e.g.
-    ``{"Tree": 0}``). torchvision detection models reserve class ``0`` for
-    background, so this wrapper builds the underlying model with
+    ``{"Tree": 0}``). torchvision detection models reserve class ``0``
+    for background, so this wrapper builds the underlying model with
     ``num_classes + 1`` outputs and transparently shifts labels by one:
-    targets are shifted up before training and predictions are shifted back
-    down. Callers therefore always see zero-indexed labels, matching the box
-    and point workflows.
+    targets are shifted up before training and predictions are shifted
+    back down. Callers therefore always see zero-indexed labels,
+    matching the box and point workflows.
     """
 
     task: str = "polygon"

--- a/src/deepforest/models/maskrcnn.py
+++ b/src/deepforest/models/maskrcnn.py
@@ -1,0 +1,201 @@
+import warnings
+from pathlib import Path
+
+import torch
+import torchvision
+from huggingface_hub import PyTorchModelHubMixin
+from torchvision.models.detection.faster_rcnn import FastRCNNPredictor
+from torchvision.models.detection.mask_rcnn import MaskRCNN as _TorchvisionMaskRCNN
+from torchvision.models.detection.mask_rcnn import MaskRCNNPredictor
+
+from deepforest.model import BaseModel
+
+
+class MaskRCNN(_TorchvisionMaskRCNN, PyTorchModelHubMixin):
+    """Mask R-CNN extension that allows the use of the HF Hub API.
+
+    DeepForest labels are zero-indexed foreground classes (e.g.
+    ``{"Tree": 0}``). torchvision detection models reserve class ``0`` for
+    background, so this wrapper builds the underlying model with
+    ``num_classes + 1`` outputs and transparently shifts labels by one:
+    targets are shifted up before training and predictions are shifted back
+    down. Callers therefore always see zero-indexed labels, matching the box
+    and point workflows.
+    """
+
+    task: str = "polygon"
+
+    def __init__(
+        self,
+        backbone_weights: str | None = None,
+        num_classes: int = 1,
+        nms_thresh: float = 0.05,
+        score_thresh: float = 0.5,
+        label_dict: dict = None,
+        **kwargs,
+    ):
+        backbone = torchvision.models.detection.maskrcnn_resnet50_fpn(
+            weights=backbone_weights
+        ).backbone
+
+        # torchvision reserves class 0 for background, so add one class.
+        super().__init__(
+            backbone=backbone,
+            num_classes=num_classes + 1,
+            box_nms_thresh=nms_thresh,
+            box_score_thresh=score_thresh,
+            **kwargs,
+        )
+
+        self.num_classes = num_classes
+        self.label_dict = label_dict
+        self.nms_thresh = nms_thresh
+        self.score_thresh = score_thresh
+        self.kwargs = kwargs
+
+        self.update_config()
+
+    @classmethod
+    def from_pretrained(
+        cls, pretrained_model_name_or_path, *, num_classes=None, label_dict=None, **kwargs
+    ):
+        """Override default from_pretrained to support changing the number of
+        classes in a pretrained model.
+
+        If the target num_classes differs from the model's num_classes,
+        the box and mask heads are reinitialized to compensate.
+        """
+        model = super().from_pretrained(pretrained_model_name_or_path, **kwargs)
+
+        # Override class info if specified
+        if num_classes is not None and label_dict is not None:
+            if len(label_dict) != num_classes:
+                raise ValueError(
+                    f"num_classes ({num_classes}) does not match the number of labels "
+                    f"in label_dict ({len(label_dict)})."
+                )
+
+            if num_classes != model.num_classes:
+                warnings.warn(
+                    f"The number of classes in your config differs "
+                    f"compared to the model checkpoint ({model.num_classes}-class)."
+                    f" If you are fine-tuning on a new dataset that "
+                    f"has {num_classes} then this is expected.",
+                    stacklevel=2,
+                )
+
+                model._adjust_classes(num_classes)
+
+            model.label_dict = label_dict
+            model.update_config()
+
+        return model
+
+    def _adjust_classes(self, num_classes):
+        """Rebuild the box and mask predictor heads for ``num_classes``
+        foreground classes (``num_classes + 1`` with background)."""
+        self.num_classes = num_classes
+
+        in_features = self.roi_heads.box_predictor.cls_score.in_features
+        self.roi_heads.box_predictor = FastRCNNPredictor(in_features, num_classes + 1)
+
+        in_features_mask = self.roi_heads.mask_predictor.conv5_mask.in_channels
+        hidden_layer = self.roi_heads.mask_predictor.conv5_mask.out_channels
+        self.roi_heads.mask_predictor = MaskRCNNPredictor(
+            in_features_mask, hidden_layer, num_classes + 1
+        )
+
+    def update_config(self):
+        # Stored as config on HF
+        self._hub_mixin_config = {
+            "num_classes": self.num_classes,
+            "nms_thresh": self.nms_thresh,
+            "score_thresh": self.score_thresh,
+            "label_dict": self.label_dict,
+            **self.kwargs,
+        }
+
+    def forward(self, images, targets=None):
+        """Shift labels between DeepForest (0-indexed) and torchvision
+        (background=0) conventions.
+
+        In training mode, target labels are shifted up by one. In eval
+        mode, predicted labels are shifted back down by one.
+        """
+        if self.training:
+            if targets is None:
+                raise ValueError("targets must be provided in training mode")
+            shifted_targets = []
+            for target in targets:
+                shifted = dict(target)
+                shifted["labels"] = target["labels"] + 1
+                shifted_targets.append(shifted)
+            return super().forward(images, shifted_targets)
+
+        outputs = super().forward(images)
+        for output in outputs:
+            output["labels"] = output["labels"] - 1
+        return outputs
+
+
+class Model(BaseModel):
+    """DeepForest model wrapper for Mask R-CNN instance segmentation.
+
+    Selected via ``config.architecture = "maskrcnn"`` with
+    ``config.model.task`` resolving to ``"polygon"``.
+    """
+
+    def create_model(
+        self,
+        pretrained: str | Path | None = None,
+        *,
+        revision: str | None = None,
+        map_location: str | torch.device | None = None,
+        **hf_args,
+    ) -> MaskRCNN:
+        """Create a Mask R-CNN model.
+
+        Args:
+            pretrained: If supplied, repository ID for weight download, otherwise use default COCO backbone weights
+            revision: Repository revision
+            map_location: Device to load weights onto
+            **hf_args: Any other arguments to load_pretrained
+        Returns:
+            model: a pytorch nn module
+        """
+        label_dict = dict(self.config.label_dict) if self.config.label_dict else None
+
+        if pretrained is None:
+            model = MaskRCNN(
+                backbone_weights="COCO_V1",
+                num_classes=self.config.num_classes,
+                nms_thresh=self.config.nms_thresh,
+                score_thresh=self.config.score_thresh,
+                label_dict=label_dict,
+                box_detections_per_img=self.config.detections_per_img,
+            )
+        else:
+            model = MaskRCNN.from_pretrained(
+                pretrained,
+                revision=revision,
+                num_classes=self.config.num_classes,
+                label_dict=label_dict,
+                nms_thresh=self.config.nms_thresh,
+                score_thresh=self.config.score_thresh,
+                box_detections_per_img=self.config.detections_per_img,
+                **hf_args,
+            )
+
+        return model.to(map_location)
+
+    def check_model(self) -> None:
+        """Validate the model returns instance-segmentation outputs."""
+        test_model = self.create_model()
+        test_model.eval()
+
+        x = [torch.rand(3, 300, 400), torch.rand(3, 500, 400)]
+        predictions = test_model(x)
+        assert len(predictions) == 2
+
+        model_keys = sorted(predictions[1].keys())
+        assert model_keys == ["boxes", "labels", "masks", "scores"]

--- a/src/deepforest/predict.py
+++ b/src/deepforest/predict.py
@@ -70,6 +70,7 @@ def translate_predictions(predictions: pd.DataFrame) -> pd.DataFrame:
     """
     predictions = predictions.copy()
     is_box = {"xmin", "ymin", "xmax", "ymax"}.issubset(predictions.columns)
+    is_point = {"x", "y"}.issubset(predictions.columns)
 
     predictions["geometry"] = [
         affinity.translate(geom, xoff=dx, yoff=dy)
@@ -84,10 +85,12 @@ def translate_predictions(predictions: pd.DataFrame) -> pd.DataFrame:
     if is_box:
         bounds = shapely.bounds(np.array(predictions["geometry"]))
         predictions[["xmin", "ymin", "xmax", "ymax"]] = bounds.astype(int)
-    else:
+    elif is_point:
         coords = shapely.get_coordinates(np.array(predictions["geometry"]))
         predictions["x"] = coords[:, 0]
         predictions["y"] = coords[:, 1]
+    # Polygons carry all positional information in the translated geometry,
+    # so no coordinate columns need updating.
 
     return predictions.drop(columns=["window_xmin", "window_ymin"]).reset_index(drop=True)
 
@@ -152,6 +155,39 @@ def reduce_points(predictions: pd.DataFrame, nms_thresh: float) -> pd.DataFrame:
     return predictions.iloc[np.flatnonzero(kept)].reset_index(drop=True)
 
 
+def reduce_polygons(predictions: pd.DataFrame, iou_threshold: float) -> pd.DataFrame:
+    """Reduce overlapping polygon predictions with NMS on polygon bounds.
+
+    Non-max suppression is computed on the axis-aligned bounding box of each
+    polygon (its envelope), which parallels :func:`reduce_boxes` and avoids the
+    cost of all-pairs polygon IoU.
+
+    Args:
+        predictions: DataFrame of image-space polygon predictions with a
+            ``geometry`` column.
+        iou_threshold: IoU threshold for NMS.
+
+    Returns:
+        DataFrame containing the filtered polygon predictions.
+    """
+    polygon_output_columns = ["geometry", "label", "score"]
+    if predictions.shape[0] <= 1:
+        return predictions[polygon_output_columns].reset_index(drop=True).copy()
+
+    print(
+        f"{predictions.shape[0]} predictions in overlapping windows, applying non-max suppression"
+    )
+
+    bounds = shapely.bounds(np.array(predictions.geometry))
+    boxes = torch.tensor(bounds, dtype=torch.float32)
+    scores = torch.tensor(predictions.score.values, dtype=torch.float32)
+    keep_idx = nms(boxes=boxes, scores=scores, iou_threshold=iou_threshold).numpy()
+
+    filtered_predictions = predictions.iloc[keep_idx].reset_index(drop=True)
+    print(f"{filtered_predictions.shape[0]} predictions kept after non-max suppression")
+    return filtered_predictions[polygon_output_columns].reset_index(drop=True).copy()
+
+
 def mosaic(
     predictions: pd.DataFrame,
     iou_threshold: float = 0.1,
@@ -180,7 +216,12 @@ def mosaic(
     if is_point_predictions:
         return reduce_points(translated_predictions, nms_thresh=nms_distance_thresh)
 
-    raise ValueError("Predictions must include either box or point coordinates.")
+    if "geometry" in predictions.columns:
+        return reduce_polygons(translated_predictions, iou_threshold=iou_threshold)
+
+    raise ValueError(
+        "Predictions must include box, point or polygon (geometry) coordinates."
+    )
 
 
 def across_class_nms(predicted_boxes, iou_threshold=0.15):

--- a/src/deepforest/utilities.py
+++ b/src/deepforest/utilities.py
@@ -2,6 +2,7 @@ import json
 import os
 import warnings
 
+import cv2
 import geopandas as gpd
 import numpy as np
 import pandas as pd
@@ -352,7 +353,11 @@ def determine_geometry_type(df):
             raise ValueError(f"Could not determine geometry type from columns {columns}")
 
     elif isinstance(df, dict):
-        if "boxes" in df.keys():
+        # Mask R-CNN predictions contain both "masks" and "boxes"; the masks
+        # take precedence and mark the result as a polygon (instance mask).
+        if "masks" in df.keys():
+            geometry_type = "polygon"
+        elif "boxes" in df.keys():
             geometry_type = "box"
         elif "polygon" in df.keys():
             geometry_type = "polygon"
@@ -384,7 +389,7 @@ def format_geometry(predictions, scores=True, geom_type=None):
     if geom_type == "box":
         df = format_boxes(predictions, scores=scores)
     elif geom_type == "polygon":
-        raise ValueError("Polygon predictions are not yet supported for formatting")
+        df = format_polygons(predictions, scores=scores)
     elif geom_type == "point":
         df = format_points(predictions, scores=scores)
 
@@ -416,6 +421,79 @@ def format_boxes(prediction, scores=True):
     df["geometry"] = df.apply(
         lambda x: shapely.geometry.box(x.xmin, x.ymin, x.xmax, x.ymax), axis=1
     )
+    return df
+
+
+def mask_to_polygon(mask: np.ndarray) -> shapely.geometry.Polygon:
+    """Convert a single binary instance mask to a Shapely polygon.
+
+    The largest external contour is used. Masks that do not contain a
+    valid contour (fewer than three vertices) return an empty polygon,
+    which downstream IoU code treats as a non-match.
+
+    Args:
+        mask: 2D array where non-zero pixels mark the instance.
+
+    Returns:
+        A Shapely Polygon of the instance boundary, or an empty Polygon.
+    """
+    mask = (mask > 0).astype(np.uint8)
+    contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+
+    if not contours:
+        return shapely.geometry.Polygon()
+
+    largest = max(contours, key=cv2.contourArea)
+    coords = largest.reshape(-1, 2)
+    if coords.shape[0] < 3:
+        return shapely.geometry.Polygon()
+
+    polygon = shapely.geometry.Polygon(coords)
+    if not polygon.is_valid:
+        polygon = polygon.buffer(0)
+
+    return polygon
+
+
+def format_polygons(prediction: dict, scores: bool = True) -> pd.DataFrame | None:
+    """Format an instance-segmentation prediction into a dataframe.
+
+    Converts each predicted mask into a Shapely polygon. Works for both
+    model predictions (float masks of shape ``(N, 1, H, W)`` with scores)
+    and training targets (uint8 masks of shape ``(N, H, W)`` without scores).
+
+    Args:
+        prediction: dict with ``"masks"`` and ``"labels"`` (and ``"scores"``
+            when ``scores`` is True).
+        scores: Whether the prediction includes a score per instance.
+
+    Returns:
+        DataFrame with ``label``, optional ``score``, and ``geometry``
+        columns, or ``None`` when there are no instances.
+    """
+    masks = prediction["masks"]
+    if len(masks) == 0:
+        return None
+
+    masks = masks.cpu().detach().numpy()
+    # Collapse the channel dimension of (N, 1, H, W) mask logits.
+    if masks.ndim == 4:
+        masks = masks[:, 0]
+
+    # Mask R-CNN emits soft masks in [0, 1]; binarize at 0.5. Target masks
+    # are already binary, so this is a no-op for them.
+    if np.issubdtype(masks.dtype, np.floating):
+        masks = masks > 0.5
+
+    geometries = [mask_to_polygon(mask) for mask in masks]
+
+    df = pd.DataFrame()
+    df["label"] = prediction["labels"].cpu().detach().numpy()
+
+    if scores:
+        df["score"] = prediction["scores"].cpu().detach().numpy()
+
+    df["geometry"] = geometries
     return df
 
 

--- a/tests/test_datasets_training_polygons.py
+++ b/tests/test_datasets_training_polygons.py
@@ -22,12 +22,12 @@ def polygon_root_dir():
 
 def test_polygon_dataset_basic(polygon_annotation_file, polygon_root_dir):
     ds = PolygonDataset(
-        annotation_file=polygon_annotation_file,
+        csv_file=polygon_annotation_file,
         root_dir=polygon_root_dir,
         label_dict={"tree": 0},
     )
 
-    image, targets = ds[0]
+    image, targets, image_name = ds[0]
 
     # Image checks
     assert torch.is_tensor(image)
@@ -35,22 +35,23 @@ def test_polygon_dataset_basic(polygon_annotation_file, polygon_root_dir):
     assert image.min() >= 0
     assert image.max() <= 1
 
-    # Targets checks
-    assert "boxes" in targets
-    assert "labels" in targets
-    assert "masks" in targets
-    assert "image_id" in targets
-    assert "iscrowd" in targets
-    assert "area" in targets
-
+    # Targets parallel the box workflow with an added masks entry
+    assert set(targets.keys()) == {"boxes", "labels", "masks"}
     assert targets["boxes"].shape[-1] == 4
     assert targets["labels"].dtype == torch.int64
     assert targets["masks"].dtype == torch.uint8
 
+    # One mask per instance, matching the augmented image size
+    assert targets["masks"].shape[0] == targets["boxes"].shape[0]
+    assert targets["masks"].shape[-2:] == image.shape[-2:]
+
+    # Labels are zero-indexed like the box and point workflows
+    assert targets["labels"].min() >= 0
+
 
 def test_generate_mask_polygon(polygon_annotation_file, polygon_root_dir):
     ds = PolygonDataset(
-        annotation_file=polygon_annotation_file,
+        csv_file=polygon_annotation_file,
         root_dir=polygon_root_dir,
         label_dict={"tree": 0},
     )
@@ -60,7 +61,7 @@ def test_generate_mask_polygon(polygon_annotation_file, polygon_root_dir):
 
     with Image.open(image_path) as img:
         width, height = img.size
-    mask = ds.generate_mask(row, width=width, height=height)
+    mask = ds.generate_mask(row["geometry"], width=width, height=height)
 
     assert mask.shape == (height, width)
     assert mask.dtype == np.uint8
@@ -69,22 +70,31 @@ def test_generate_mask_polygon(polygon_annotation_file, polygon_root_dir):
 
 def test_annotations_for_path_tensor(polygon_annotation_file, polygon_root_dir):
     ds = PolygonDataset(
-        annotation_file=polygon_annotation_file,
+        csv_file=polygon_annotation_file,
         root_dir=polygon_root_dir,
         label_dict={"tree": 0},
     )
 
     image_name = ds.image_names[0]
-    image_path = os.path.join(polygon_root_dir, image_name)
-
-    targets = ds.annotations_for_path(image_name, image_path, return_tensor=True)
+    targets = ds.annotations_for_path(image_name, return_tensor=True)
 
     assert torch.is_tensor(targets["boxes"])
     assert torch.is_tensor(targets["labels"])
-    assert torch.is_tensor(targets["masks"])
-
     assert targets["boxes"].shape[-1] == 4
-    assert targets["masks"].ndim == 3
+
+
+def test_polygon_dataset_collate(polygon_annotation_file, polygon_root_dir):
+    """Polygon batches collate like the box and point workflows."""
+    ds = PolygonDataset(
+        csv_file=polygon_annotation_file,
+        root_dir=polygon_root_dir,
+        label_dict={"tree": 0},
+    )
+    batch = [ds[0], ds[1]]
+    images, targets, image_names = ds.collate_fn(batch)
+
+    assert len(images) == len(targets) == len(image_names) == 2
+    assert all("masks" in t for t in targets)
 
 
 def test_polygon_oob_coordinates(tmp_path, polygon_root_dir):
@@ -111,7 +121,7 @@ def test_polygon_oob_coordinates(tmp_path, polygon_root_dir):
 
     with pytest.raises(ValueError):
         PolygonDataset(
-            annotation_file=str(json_path),
+            csv_file=str(json_path),
             root_dir=polygon_root_dir,
             label_dict={"tree": 0},
         )
@@ -141,7 +151,7 @@ def test_polygon_negative_coordinates(tmp_path, polygon_root_dir):
 
     with pytest.raises(ValueError):
         PolygonDataset(
-            annotation_file=str(json_path),
+            csv_file=str(json_path),
             root_dir=polygon_root_dir,
             label_dict={"tree": 0},
         )
@@ -172,13 +182,13 @@ def test_polygon_dataset_validate_coordinates_disabled(tmp_path, polygon_root_di
 
     with pytest.raises(ValueError):
         PolygonDataset(
-            annotation_file=str(json_path),
+            csv_file=str(json_path),
             root_dir=polygon_root_dir,
             label_dict={"tree": 0},
         )
 
     ds = PolygonDataset(
-        annotation_file=str(json_path),
+        csv_file=str(json_path),
         root_dir=polygon_root_dir,
         label_dict={"tree": 0},
         validate_coordinates=False,

--- a/tests/test_maskrcnn.py
+++ b/tests/test_maskrcnn.py
@@ -1,0 +1,151 @@
+# Test Mask R-CNN polygon (instance segmentation) workflow
+import os
+
+import numpy as np
+import pytest
+import torch
+
+from deepforest import get_data, main
+from deepforest.models import maskrcnn
+
+
+@pytest.fixture()
+def polygon_annotation_file():
+    return get_data("coco_sample_file.json")
+
+
+@pytest.fixture()
+def polygon_root_dir():
+    return os.path.dirname(get_data("coco_sample_file.json"))
+
+
+def build_model(score_thresh=0.5):
+    """Random-init Mask R-CNN (no weight download) with a small input size."""
+    return maskrcnn.MaskRCNN(
+        backbone_weights=None,
+        num_classes=1,
+        label_dict={"tree": 0},
+        score_thresh=score_thresh,
+        min_size=400,
+        max_size=512,
+    )
+
+
+def test_task_is_polygon():
+    assert maskrcnn.MaskRCNN.task == "polygon"
+
+
+def test_predict_outputs_masks():
+    model = build_model(score_thresh=0.0)
+    model.eval()
+    x = [torch.rand(3, 300, 400), torch.rand(3, 400, 300)]
+    predictions = model(x)
+
+    assert len(predictions) == 2
+    assert sorted(predictions[0].keys()) == ["boxes", "labels", "masks", "scores"]
+    # Labels are shifted back to the zero-indexed DeepForest convention
+    if len(predictions[0]["labels"]) > 0:
+        assert predictions[0]["labels"].min() >= 0
+
+
+def test_training_label_shift_does_not_mutate_targets():
+    model = build_model()
+    model.train()
+    images = [torch.rand(3, 200, 200)]
+    targets = [
+        {
+            "boxes": torch.tensor([[10, 10, 50, 50]], dtype=torch.float32),
+            "labels": torch.tensor([0], dtype=torch.int64),
+            "masks": torch.zeros((1, 200, 200), dtype=torch.uint8),
+        }
+    ]
+    targets[0]["masks"][0, 10:50, 10:50] = 1
+
+    loss_dict = model(images, targets)
+
+    assert "loss_mask" in loss_dict
+    # The caller's target labels must remain zero-indexed
+    assert targets[0]["labels"].tolist() == [0]
+
+
+def test_check_model():
+    model = maskrcnn.MaskRCNN(backbone_weights=None, num_classes=1)
+    model.eval()
+    x = [torch.rand(3, 300, 400), torch.rand(3, 500, 400)]
+    predictions = model(x)
+    assert sorted(predictions[1].keys()) == ["boxes", "labels", "masks", "scores"]
+
+
+def _make_polygon_model(tmp_path, polygon_annotation_file, polygon_root_dir):
+    model = build_model(score_thresh=0.0)
+    m = main.deepforest(
+        model=model,
+        config_args={"num_classes": 1, "label_dict": {"tree": 0}},
+    )
+    m.set_labels({"tree": 0})
+    m.config.train.csv_file = polygon_annotation_file
+    m.config.train.root_dir = polygon_root_dir
+    m.config.validation.csv_file = polygon_annotation_file
+    m.config.validation.root_dir = polygon_root_dir
+    m.config.train.fast_dev_run = True
+    m.config.validation.val_accuracy_interval = 1
+    m.config.log_root = str(tmp_path)
+    m.create_trainer()
+    return m
+
+
+def test_polygon_train_and_validate(
+    tmp_path, polygon_annotation_file, polygon_root_dir
+):
+    m = _make_polygon_model(tmp_path, polygon_annotation_file, polygon_root_dir)
+    assert m.model.task == "polygon"
+
+    m.trainer.fit(m)
+    m.trainer.validate(m)
+
+    # Segmentation mAP and polygon recall/precision are logged
+    logged = m.trainer.logged_metrics
+    assert any("polygon" in key for key in logged) or "map" in logged
+
+
+def test_polygon_predict_image(polygon_root_dir):
+    model = build_model(score_thresh=0.0)
+    m = main.deepforest(
+        model=model,
+        config_args={"num_classes": 1, "label_dict": {"tree": 0}},
+    )
+    m.set_labels({"tree": 0})
+
+    image = np.array(
+        torch.randint(0, 255, (200, 200, 3), dtype=torch.uint8)
+    ).astype("float32")
+    result = m.predict_image(image=image)
+
+    # Random weights may or may not produce detections; if they do, they must
+    # be polygons in the standard results schema.
+    if result is not None:
+        assert "geometry" in result.columns
+        assert "label" in result.columns
+        assert result.geometry.iloc[0].geom_type in ("Polygon", "MultiPolygon")
+
+
+def test_polygon_predict_tile():
+    """predict_tile tiles the image and routes each window through the model,
+    mosaicking polygon outputs across windows."""
+    model = build_model(score_thresh=0.0)
+    m = main.deepforest(
+        model=model,
+        config_args={"num_classes": 1, "label_dict": {"tree": 0}},
+    )
+    m.set_labels({"tree": 0})
+
+    image = np.array(
+        torch.randint(0, 255, (150, 150, 3), dtype=torch.uint8)
+    ).astype("float32")
+    result = m.predict_tile(
+        image=image, patch_size=100, patch_overlap=0.25, dataloader_strategy="single"
+    )
+
+    if result is not None:
+        assert "geometry" in result.columns
+        assert result.geometry.iloc[0].geom_type in ("Polygon", "MultiPolygon")

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -806,18 +806,38 @@ def test_format_geometry_point():
 
 
 def test_format_geometry_polygon():
-    """Test formatting polygon predictions"""
-    # Create a mock prediction with polygon coordinates
+    """Test formatting instance-segmentation (mask) predictions into polygons."""
+    # Two square instance masks in a 100x100 frame
+    masks = torch.zeros((2, 1, 100, 100), dtype=torch.float32)
+    masks[0, 0, 20:40, 10:30] = 1.0
+    masks[1, 0, 60:80, 50:70] = 1.0
+
     prediction = {
-        "polygon": torch.tensor([[[10, 20], [30, 20], [30, 40], [10, 40], [10, 20]],
-                               [[50, 60], [70, 60], [70, 80], [50, 80], [50, 60]]]),
+        "masks": masks,
+        "boxes": torch.tensor([[10, 20, 30, 40], [50, 60, 70, 80]], dtype=torch.float32),
         "labels": torch.tensor([0, 0]),
-        "scores": torch.tensor([0.9, 0.8])
+        "scores": torch.tensor([0.9, 0.8]),
     }
 
-    # Format geometry should raise ValueError since polygon predictions are not supported
-    with pytest.raises(ValueError, match="Polygon predictions are not yet supported for formatting"):
-        utilities.format_geometry(prediction, geom_type="polygon")
+    result = utilities.format_geometry(prediction, geom_type="polygon")
+
+    assert len(result) == 2
+    assert "geometry" in result.columns
+    assert "score" in result.columns
+    for geom in result.geometry:
+        assert isinstance(geom, shapely.geometry.Polygon)
+        assert geom.area > 0
+
+
+def test_determine_geometry_type_masks():
+    """A prediction dict with masks is detected as a polygon."""
+    prediction = {
+        "masks": torch.zeros((1, 1, 10, 10)),
+        "boxes": torch.tensor([[0, 0, 5, 5]], dtype=torch.float32),
+        "labels": torch.tensor([0]),
+        "scores": torch.tensor([0.9]),
+    }
+    assert utilities.determine_geometry_type(prediction) == "polygon"
 
 
 def test_read_file_column_names():


### PR DESCRIPTION
Implement instance segmentation paralleling the box and point workflows:
- Add Mask R-CNN model (task="polygon"), encapsulating the torchvision background-class convention by shifting labels in forward()
- Refactor PolygonDataset to mirror BoxDataset (csv_file, 3-tuple, joint image/box/mask augmentation)
- Support polygon prediction formatting and mask-based geometry detection
- Wire segmentation mAP and polygon recall/precision into validation
- Enable polygon mosaicking in predict_tile via reduce_polygons
- Add tests for the dataset, model, formatting, training and prediction

## Description

<!-- Provide a clear and concise description of what this PR does -->

## Related Issue(s)

<!-- Link to related issues using: Closes #123, Fixes #456, Related to #789 -->
<!-- If no issue exists, explain why this change is needed -->


## AI-Assisted Development

<!-- Be transparent about AI tool usage -->

- [ ] I used AI tools (e.g., GitHub Copilot, ChatGPT, etc.) in developing this PR
- [ ] I understand all the code I'm submitting
- [ ] I have reviewed and validated all AI-generated code

**AI tools used (if applicable):**
<!-- List AI tools used, if any -->
