### PR TITLE
add option to skip predictions on empty/uniform frames

### DIFF
--- a/src/deepforest/conf/config.yaml
+++ b/src/deepforest/conf/config.yaml
@@ -41,6 +41,9 @@ annotations_xml:
 rgb_dir:
 path_to_rgb:
 
+# Skip prediction on tiles that are either all black/white, or nodata
+skip_empty: true
+
 log_root: ./lightning_logs
 
 train:

--- a/src/deepforest/conf/schema.py
+++ b/src/deepforest/conf/schema.py
@@ -212,6 +212,9 @@ class Config:
     rgb_dir: str | None = None
     path_to_rgb: str | None = None
 
+    # Skip prediction on tiles that are all black/white or nodata
+    skip_empty: bool = True
+
     train: TrainConfig = field(default_factory=TrainConfig)
     validation: ValidationConfig = field(default_factory=ValidationConfig)
     predict: PredictConfig = field(default_factory=PredictConfig)

--- a/src/deepforest/main.py
+++ b/src/deepforest/main.py
@@ -1037,6 +1037,14 @@ class deepforest(pl.LightningModule):
             images = batch
             metadata = None
 
+        # filter batch to drop empty images
+        if self.config.skip_empty:
+            images, metadata = utilities.drop_empty_images(images, metadata)
+
+        # break early on empty batches
+        if len(images) == 0:
+            return []
+
         self.model.eval()
         with torch.no_grad():
             preds = self.model.forward(images)

--- a/src/deepforest/utilities.py
+++ b/src/deepforest/utilities.py
@@ -978,6 +978,34 @@ def collate_fn(batch):
     return tuple(zip(*batch, strict=False))
 
 
+def drop_empty_images(images, metadata=None):
+    """Drop images that are all black, white or nodata from a batch.
+
+    An image is deemed empty when all its pixels share the same value.
+    When metadata is provided, the corresponding entries are dropped too
+    so the two stay aligned.
+
+    Args:
+        images: a list of image tensors or a stacked (B, C, H, W) tensor.
+        metadata: optional list of per-image metadata to filter alongside images.
+
+    Returns:
+        Tuple of (images, metadata) with empty images removed. metadata is None
+        if not supplied.
+    """
+    non_empty = [not torch.isclose(img.min(), img.max()) for img in images]
+
+    if isinstance(images, torch.Tensor):
+        images = images[torch.tensor(non_empty)]
+    else:
+        images = [img for img, keep in zip(images, non_empty, strict=True) if keep]
+
+    if metadata is not None:
+        metadata = [m for m, keep in zip(metadata, non_empty, strict=True) if keep]
+
+    return images, metadata
+
+
 def density_to_points(
     density_map,
     score_thresh: float = 0.1,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -526,6 +526,47 @@ def test_predict_tile(m, path, dataloader_strategy):
     plot_results(prediction, show=False)
 
 
+@pytest.fixture()
+def batch_with_empty_image():
+    """A prediction batch with one real image and one empty (all-black) image."""
+    return {
+        "images": [torch.rand(3, 100, 100), torch.zeros(3, 100, 100)],
+        "metadata": [
+            {"image_path": "real.png", "window_bounds": (0, 0, 100, 100)},
+            {"image_path": "empty.png", "window_bounds": (100, 0, 100, 100)},
+        ],
+    }
+
+
+def test_predict_step_skips_empty_images(m, batch_with_empty_image):
+    m.config.skip_empty = True
+    results = m.predict_step(batch_with_empty_image, 0)
+
+    # Expect one result dataframe for the real image.
+    assert len(results) == 1
+
+
+def test_predict_step_keeps_empty_images_when_disabled(m, batch_with_empty_image):
+    m.config.skip_empty = False
+    results = m.predict_step(batch_with_empty_image, 0)
+
+    assert len(results) == len(batch_with_empty_image["images"])
+
+
+def test_predict_step_all_empty_returns_empty(m):
+    m.config.skip_empty = True
+    batch = {
+        "images": [torch.zeros(3, 100, 100), torch.ones(3, 100, 100)],
+        "metadata": [
+            {"image_path": "a.png", "window_bounds": (0, 0, 100, 100)},
+            {"image_path": "b.png", "window_bounds": (0, 0, 100, 100)},
+        ],
+    }
+
+    # Every image is empty, we also shouldn't crash
+    assert m.predict_step(batch, 0) == []
+
+
 # Add predict_tile for serial single dataloader strategy
 def test_predict_tile_serial_single(m):
     path1 = get_data("OSBS_029.png")

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -844,3 +844,35 @@ def test_read_file_column_names():
     assert "image_path" in result.columns
     assert "label" in result.columns
     assert hasattr(result, "root_dir")
+
+
+def test_drop_empty_images():
+    real = torch.rand(3, 8, 8)
+    images = [real, torch.zeros(3, 8, 8), torch.ones(3, 8, 8), torch.full((3, 8, 8), 0.5)]
+    metadata = ["real", "black", "white", "gray"]
+
+    filtered_images, filtered_metadata = utilities.drop_empty_images(images, metadata)
+
+    # Black, white and uniform-value images are dropped.
+    assert len(filtered_images) == 1
+    assert torch.equal(filtered_images[0], real)
+    assert filtered_metadata == ["real"]
+
+
+def test_drop_empty_images_preserves_tensor_type():
+    images = torch.stack([torch.rand(3, 8, 8), torch.zeros(3, 8, 8)])
+    filtered_images, filtered_metadata = utilities.drop_empty_images(images)
+
+    assert isinstance(filtered_images, torch.Tensor)
+    assert filtered_images.shape[0] == 1
+    assert filtered_metadata is None
+
+
+def test_drop_empty_images_tolerates_tiny_variation():
+    # A difference below floating point tolerance still counts as empty.
+    near_uniform = torch.full((3, 8, 8), 0.5)
+    near_uniform[0, 0, 0] = 0.5 + 1e-6
+
+    filtered_images, _ = utilities.drop_empty_images([near_uniform])
+
+    assert len(filtered_images) == 0


### PR DESCRIPTION
## Description

Adds support to optionally skip frames that empty. `non-empty` is defined as `(image.min() != image.max())` which conveniently covers all black or all white data (as well as anything in-between) and works whether or not the image is normalized. I don't think there is a case where we'd want predictions on a uniform image. The real check is made with `close()` to avoid float comparison issues.

Filtering is applied in `predict_step` which should affect almost all prediction paths. I deliberately did not apply this to `predict_image` or `_predict_image` but we could add it there if necessary. And this is also future-compatible to moving predict_image to use the Lightning path.

## Related Issue(s)

Implements https://github.com/weecology/DeepForest/issues/1402
Would be used by https://github.com/weecology/DeepForest/pull/1398

## AI-Assisted Development

<!-- Be transparent about AI tool usage -->

- [X] I used AI tools (e.g., GitHub Copilot, ChatGPT, etc.) in developing this PR
- [X] I understand all the code I'm submitting
- [X] I have reviewed and validated all AI-generated code

**AI tools used (if applicable):**
Claude Opus with a lot of feedback.
