### PR TITLE
remove unused batch indexing code

### DIFF
--- a/src/deepforest/datasets/prediction.py
+++ b/src/deepforest/datasets/prediction.py
@@ -1,7 +1,6 @@
 import os
 
 import numpy as np
-import pandas as pd
 import rasterio as rio
 import slidingwindow
 import torch
@@ -11,7 +10,7 @@ from torch.nn import functional as F
 from torch.utils.data import Dataset
 
 from deepforest import preprocess
-from deepforest.utilities import format_geometry, read_file
+from deepforest.utilities import read_file
 
 
 # Base prediction class
@@ -119,62 +118,11 @@ class PredictionDataset(Dataset):
         raise NotImplementedError("Subclasses must implement this method")
 
     def get_metadata(self, idx):
-        """Get metadata needed to postprocess a prediction item."""
+        """Get metadata needed to format a prediction item."""
         return {
             "image_path": self.get_image_basename(idx),
             "window_bounds": self.get_crop_bounds(idx),
         }
-
-    def determine_geometry_type(self, batched_result):
-        """Determine the geometry type of the batched result."""
-        # Assumes that all geometries are the same in a batch
-        if "boxes" in batched_result.keys():
-            geom_type = "box"
-        elif "points" in batched_result.keys():
-            geom_type = "point"
-        elif "polygons" in batched_result.keys():
-            geom_type = "polygon"
-        else:
-            raise ValueError(
-                f"Unknown geometry type, prediction keys are {batched_result.keys()}"
-            )
-
-        return geom_type
-
-    def format_batch(self, batch, idx, sub_idx=None):
-        """Format a single prediction dict into a dataframe with metadata.
-
-        Args:
-            batch: A single prediction dict (keys: boxes, labels, scores, etc.)
-            idx: The dataset index (image index for windowed datasets)
-            sub_idx: The sub-index (window index). If None, uses idx.
-        """
-        if sub_idx is None:
-            sub_idx = idx
-        geom_type = self.determine_geometry_type(batch)
-        result = format_geometry(batch, geom_type=geom_type)
-        if result is None:
-            return None
-
-        crop_bounds = self.get_crop_bounds(sub_idx)
-        if crop_bounds is not None:
-            result["window_xmin"] = crop_bounds[0]
-            result["window_ymin"] = crop_bounds[1]
-        result["image_path"] = self.get_image_basename(idx)
-
-        return result
-
-    def postprocess(self, batch, prediction_index):
-        """Postprocess a single prediction result into a dataframe.
-
-        Args:
-            batch: A single prediction dict (keys: boxes, labels, scores, etc.)
-            prediction_index: The index of this item in the dataset
-        """
-        result = self.format_batch(batch, prediction_index)
-        if result is None:
-            return pd.DataFrame()
-        return result.reset_index(drop=True)
 
 
 class SingleImage(PredictionDataset):
@@ -252,33 +200,12 @@ class FromCSVFile(PredictionDataset):
     def get_crop_bounds(self, idx):
         return None
 
-    def format_batch(self, batch, idx, sub_idx=None):
-        """Format a single prediction dict into a dataframe with metadata.
-        Override of base class to skip window coordinates (not applicable for
-        full images).
 
-        Args:
-            batch: A single prediction dict (keys: boxes, labels, scores, etc.)
-            idx: The dataset index (image index)
-            sub_idx: Unused (kept for compatibility with base class signature)
-        """
-        geom_type = self.determine_geometry_type(batch)
-        result = format_geometry(batch, geom_type=geom_type)
-        if result is None:
-            return None
+class _CropsWithMetadata(list):
+    """List of crops with metadata attached for correct batch collation."""
 
-        result["image_path"] = self.get_image_basename(idx)
-
-        return result
-
-
-class _IndexedCrops(list):
-    """List of crops with the dataset index attached for correct batch
-    collation."""
-
-    def __init__(self, index: int, crops: list, metadata: list | None = None):
+    def __init__(self, crops: list, metadata: list | None = None):
         super().__init__(crops)
-        self.index = index
         self.metadata = metadata or []
 
 
@@ -304,7 +231,6 @@ class MultiImage(PredictionDataset):
         self.paths = paths
         self.patch_size = patch_size
         self.patch_overlap = patch_overlap
-        self.batch_indices = []
         self.return_metadata = return_metadata
 
         image = self.load_and_preprocess_image(image_path=self.paths[0])
@@ -393,33 +319,21 @@ class MultiImage(PredictionDataset):
         return windows
 
     def __getitem__(self, idx):
-        """Return crops with dataset index so collate_fn can use global
-        indices."""
+        """Return one image's crops with per-crop metadata attached."""
         crops = self.get_crop(idx)
         metadata = None
         if self.return_metadata:
             metadata = self.get_metadata(idx, crop_count=len(crops))
-        return _IndexedCrops(idx, crops, metadata=metadata)
+        return _CropsWithMetadata(crops, metadata=metadata)
 
     def collate_fn(self, batch):
-        """Collate the batch into a single list of crops.
-
-        Keep track of the lengths of each sublist using global dataset
-        indices (item.index), not batch position, so postprocess assigns
-        image_path correctly.
-        """
-        # item.index is the global dataset index; sublist is the list of crops
+        """Flatten each image's crop list into one batch, with metadata if
+        requested."""
+        flattened_batch = [crop for item in batch for crop in item]
         if self.return_metadata:
-            flattened_batch = [crop for item in batch for crop in item]
             metadata = [meta for item in batch for meta in item.metadata]
             return {"images": flattened_batch, "metadata": metadata}
-
-        batch_indices = [
-            [item.index, sub_idx] for item in batch for sub_idx in range(len(item))
-        ]
-        self.batch_indices.append(batch_indices)
-        flattened_batch = [crop for item in batch for crop in item]
-        return {"images": flattened_batch, "batch_indices": batch_indices}
+        return flattened_batch
 
     def __len__(self):
         return len(self.paths)
@@ -451,36 +365,6 @@ class MultiImage(PredictionDataset):
             }
             for window_idx in range(crop_count)
         ]
-
-    def postprocess(self, batch, prediction_index, original_batch_structure):
-        """Postprocess flattened batch of predictions from multiple images.
-
-        Args:
-            batch: List of prediction dicts (all windows from all images in batch)
-            prediction_index: Index of this batch from trainer.predict
-        """
-        if prediction_index >= len(original_batch_structure):
-            raise ValueError(
-                f"prediction_index {prediction_index} exceeds batch_indices length {len(original_batch_structure)}. "
-                "This may indicate a mismatch between collate_fn calls and postprocess calls."
-            )
-
-        current_batch_indices = original_batch_structure[prediction_index]
-        formatted_results = []
-
-        # current_batch_indices[i] = [image_idx, window_idx] corresponds to batch[i]
-        for batch_position, (image_idx, window_idx) in enumerate(current_batch_indices):
-            prediction = batch[batch_position]
-
-            # Format with correct image index and window index
-            result = self.format_batch(prediction, image_idx, window_idx)
-            if result is not None:
-                formatted_results.append(result)
-
-        if len(formatted_results) > 0:
-            return pd.concat(formatted_results).reset_index(drop=True)
-        else:
-            return pd.DataFrame()
 
 
 class TiledRaster(PredictionDataset):

--- a/src/deepforest/main.py
+++ b/src/deepforest/main.py
@@ -73,7 +73,6 @@ class deepforest(pl.LightningModule):
         self.existing_val_dataloader = existing_val_dataloader
 
         self.model = model
-        self.original_batch_structure = []
 
         if self.model is None:
             self.create_model()
@@ -714,7 +713,6 @@ class deepforest(pl.LightningModule):
                 results = self._gather_prediction_frames(image_results)
 
         elif dataloader_strategy == "batch":
-            self.original_batch_structure.clear()
             ds = prediction.MultiImage(
                 paths=paths,
                 patch_overlap=patch_overlap,
@@ -1030,9 +1028,6 @@ class deepforest(pl.LightningModule):
         if isinstance(batch, dict):
             images = batch["images"]
             metadata = batch.get("metadata")
-            batch_indices = batch.get("batch_indices")
-            if batch_indices is not None:
-                self.original_batch_structure.append(batch_indices)
         else:
             images = batch
             metadata = None

--- a/tests/test_datasets_prediction.py
+++ b/tests/test_datasets_prediction.py
@@ -145,3 +145,28 @@ def test_MultiImage_metadata_batch():
     assert len(batch["images"]) == 4
     assert len(batch["metadata"]) == 4
     assert all(item["image_path"] == os.path.basename(path) for item in batch["metadata"])
+
+
+def test_MultiImage_collate_preserves_window_indexing():
+    """collate_fn must keep each crop tied to its source image and window when a
+    batch spans multiple images (both images are 400x400 so MultiImage accepts
+    them)."""
+    path_a = get_data("OSBS_029.png")
+    path_b = get_data("SOAP_031.png")
+    ds = MultiImage(
+        paths=[path_a, path_b],
+        patch_size=300,
+        patch_overlap=0,
+        return_metadata=True,
+    )
+
+    batch = ds.collate_fn([ds[0], ds[1]])  # a batch spanning both images
+    windows = ds.window_list()
+    n = len(windows)
+
+    assert len(batch["images"]) == len(batch["metadata"]) == 2 * n
+    expected = [(os.path.basename(path_a), w) for w in windows] + [
+        (os.path.basename(path_b), w) for w in windows
+    ]
+    actual = [(m["image_path"], m["window_bounds"]) for m in batch["metadata"]]
+    assert actual == expected

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -572,6 +572,39 @@ def test_predict_tile_batch_uses_global_image_indices(m, tmp_path):
     assert sorted(unique_paths) == expected_basenames
 
 
+def test_predict_step_assigns_metadata_in_order(m, monkeypatch):
+    """predict_step must zip each prediction to its own metadata so image_path
+    and window offsets stay correctly associated across a multi-image batch."""
+    metadata = [
+        {"image_path": "a.png", "window_bounds": (0, 0, 100, 100)},
+        {"image_path": "b.png", "window_bounds": (50, 0, 100, 100)},
+        {"image_path": "b.png", "window_bounds": (0, 60, 100, 100)},
+    ]
+    batch = {
+        "images": [torch.rand(3, 100, 100) for _ in metadata],
+        "metadata": metadata,
+    }
+
+    def fake_forward(images):
+        return [
+            {
+                "boxes": torch.tensor([[1.0, 2.0, 3.0, 4.0]]),
+                "labels": torch.tensor([0]),
+                "scores": torch.tensor([0.9]),
+            }
+            for _ in images
+        ]
+
+    monkeypatch.setattr(m.model, "forward", fake_forward)
+
+    results = m.predict_step(batch, 0)
+    assert len(results) == len(metadata)
+    for frame, meta in zip(results, metadata):
+        assert (frame["image_path"] == meta["image_path"]).all()
+        assert (frame["window_xmin"] == meta["window_bounds"][0]).all()
+        assert (frame["window_ymin"] == meta["window_bounds"][1]).all()
+
+
 # test equivalence for within and out of memory dataset strategies
 def test_predict_tile_equivalence(m):
     path = get_data("test_tiled.tif")


### PR DESCRIPTION
There's a lot of code that is no longer used, as we have moved to a more robust way of tracking where image crops came from when predicting over multiple images. This PR removes that so there's less confusion, and adds a test to check that windows are properly preserved via metadata.

