### PR TITLE
remove setuptools as a runtime dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,6 @@ dependencies = [
     "safetensors<0.6.0",
     "scikit-image>=0.25.2",
     "scipy>=1.15.3",
-    "setuptools",
     "shapely>2.0.0",
     "slidingwindow",
     "supervision",


### PR DESCRIPTION
`setuptools` is blocking later versions of torch, torchvision etc and is not needed for runtime. Confirm by running `uv sync --upgrade` and see that torch is pinned to ~2.1.0. This PR removes it. Should not affect builds which use a separate dependency group.