### PR TITLE
feat: print informative message when validating coordinates during da…

### DIFF
--- a/src/deepforest/datasets/training.py
+++ b/src/deepforest/datasets/training.py
@@ -69,6 +69,7 @@ class TrainingDataset(Dataset):
 
         self._validate_labels()
         if validate_coordinates:
+            print(f"Validating coordinates for {len(self.image_names)} images")
             self._validate_coordinates()
 
         # Pin data to memory if desired

--- a/src/deepforest/datasets/training.py
+++ b/src/deepforest/datasets/training.py
@@ -69,7 +69,11 @@ class TrainingDataset(Dataset):
 
         self._validate_labels()
         if validate_coordinates:
-            print(f"Validating coordinates for {len(self.image_names)} images")
+            print(
+                f"Validating coordinates for {len(self.image_names)} images. "
+                "This may take a while for large datasets. To skip this check, "
+                "set validate_coordinates=False in your config."
+            )
             self._validate_coordinates()
 
         # Pin data to memory if desired

--- a/tests/test_datasets_training_boxes.py
+++ b/tests/test_datasets_training_boxes.py
@@ -267,6 +267,7 @@ def test_BoxDataset_validate_coordinates_prints(capsys):
     BoxDataset(csv_file=csv_path, root_dir=root_dir, validate_coordinates=True)
     captured = capsys.readouterr()
     assert "Validating coordinates" in captured.out
+    assert "validate_coordinates=False" in captured.out
 
 
 def test_BoxDataset_validate_coordinates_disabled(tmp_path, raster_path):

--- a/tests/test_datasets_training_boxes.py
+++ b/tests/test_datasets_training_boxes.py
@@ -260,6 +260,15 @@ def test_BoxDataset_validate_coordinates(tmp_path, raster_path):
             BoxDataset(csv_file=csv_path, root_dir=root_dir)
 
 
+def test_BoxDataset_validate_coordinates_prints(capsys):
+    """Test that BoxDataset prints a message when validate_coordinates is True."""
+    csv_path = get_data("example.csv")
+    root_dir = os.path.dirname(csv_path)
+    BoxDataset(csv_file=csv_path, root_dir=root_dir, validate_coordinates=True)
+    captured = capsys.readouterr()
+    assert "Validating coordinates" in captured.out
+
+
 def test_BoxDataset_validate_coordinates_disabled(tmp_path, raster_path):
     """Setting validate_coordinates=False should skip coordinate checks."""
     root_dir = os.path.dirname(raster_path)


### PR DESCRIPTION
# feat: add informative message when validate_coordinates is enabled

## Description

This PR adds a clear stdout log message when `validate_coordinates=True` (default) during `TrainingDataset` initialization, informing the user about the validation process:

```python
Validating coordinates for N images  
  proofbyhuman/antigravity