### PR TITLE
fix: automatically override num_workers=0 for TiledRaster prediction …

### DIFF
--- a/docs/development/cluster.md
+++ b/docs/development/cluster.md
@@ -17,7 +17,7 @@ Use the same launch pattern for `train`, `evaluate`, and `predict`:
 - `devices=<gpus_per_node>` is the number of GPUs on each node
 - `num_nodes=<nnodes>` is the total number of nodes
 - `strategy=ddp` enables distributed data parallel execution (use `auto` for single-GPU jobs)
-- `workers=0` is required for large-tile prediction with `dataloader_strategy="window"`
+- `workers=0` is used for large-tile prediction with `dataloader_strategy="window"` (DeepForest sets this automatically, warning if a higher value was configured)
 
 ## Environment
 

--- a/docs/user_guide/07_scaling.md
+++ b/docs/user_guide/07_scaling.md
@@ -47,7 +47,7 @@ The `dataloader_strategy` parameter has three options:
 
 * **batch**: Loads the entire image into GPU memory and creates views of the image as batches. Requires the entire tile to fit into GPU memory. CPU parallelization is possible for loading images.
 
-* **window**: Loads only the desired window of the image from the raster dataset. Most memory efficient option, but cannot parallelize across windows due to Python's Global Interpreter Lock, workers must be set to 0.
+* **window**: Loads only the desired window of the image from the raster dataset. Most memory efficient option, but cannot parallelize across windows due to Python's Global Interpreter Lock. DeepForest automatically sets `workers=0` for this strategy (emitting a warning if a higher value was configured), so no manual change is required.
 
 ## Data Loading
 

--- a/src/deepforest/main.py
+++ b/src/deepforest/main.py
@@ -513,12 +513,21 @@ class deepforest(pl.LightningModule):
             local_indices = [rank] if rank < len(ds) else []
             sampler = distributed.FixedOrderSampler(local_indices)
 
+        num_workers = self.config.workers
+        if isinstance(ds, prediction.TiledRaster) and num_workers > 0:
+            warnings.warn(
+                "workers > 0 is not supported for TiledRaster (out-of-memory datasets). "
+                "Setting num_workers=0 for this prediction dataloader.",
+                stacklevel=2,
+            )
+            num_workers = 0
+
         loader = torch.utils.data.DataLoader(
             ds,
             batch_size=batch_size,
             shuffle=False,
             sampler=sampler,
-            num_workers=self.config.workers,
+            num_workers=num_workers,
             collate_fn=ds.collate_fn,
             pin_memory=self.config.predict.pin_memory,
         )
@@ -710,13 +719,6 @@ class deepforest(pl.LightningModule):
                         return_metadata=True,
                     )
                 else:
-                    # Check for workers config when using out of memory dataset
-                    if self.config.workers > 0:
-                        raise ValueError(
-                            "workers must be 0 when using out-of-memory dataset "
-                            "(dataloader_strategy='window'). Set config['workers']=0 and recreate "
-                            "trainer self.create_trainer()."
-                        )
                     ds = prediction.TiledRaster(
                         path=image_path,
                         patch_overlap=patch_overlap,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -526,6 +526,26 @@ def test_predict_tile(m, path, dataloader_strategy):
     plot_results(prediction, show=False)
 
 
+def test_predict_tile_window_auto_workers(m):
+    """Test that predict_tile with window strategy automatically overrides workers > 0 with a warning."""
+    m.create_model()
+    m.config.workers = 2
+    m.create_trainer()
+    m.load_model("weecology/deepforest-tree")
+    image_path = get_data("test_tiled.tif")
+
+    with pytest.warns(UserWarning, match="workers > 0 is not supported for TiledRaster"):
+        prediction = m.predict_tile(
+            path=image_path,
+            patch_size=300,
+            dataloader_strategy="window",
+            patch_overlap=0,
+        )
+
+    assert isinstance(prediction, pd.DataFrame)
+    assert not prediction.empty
+
+
 @pytest.fixture()
 def batch_with_empty_image():
     """A prediction batch with one real image and one empty (all-black) image."""


### PR DESCRIPTION
# fix: automatically set num_workers=0 for TiledRaster prediction dataset

## Description

This PR improves usability when predicting on out-of-memory rasters (`TiledRaster` / `dataloader_strategy="window"`). 

Previously, if `config.workers > 0`, `predict_tile` raised a strict `ValueError`, halting execution and requiring users to manually mutate `config.workers` and recreate the trainer.

**Changes:**
1. In `predict_dataloader`, if `isinstance(ds, prediction.TiledRaster)` and `num_workers > 0`, `num_workers` is automatically overridden to `0` with an informative warning (`UserWarning`), eliminating script crashes.
2. Removed the halting `ValueError` check in `predict_tile`.
3. Added unit test `test_predict_tile_window_auto_workers` in `tests/test_main.py`.

## Related Issue(s)

Relates to #1392 (this improves the `workers` usability discussed in that thread; it does not fully resolve the original not-tiled raster problem, so it does not close the issue).

## AI-Assisted Development

- [x] I used AI tools (e.g., GitHub Copilot, ChatGPT, etc.) in developing this PR
- [x] I understand all the code I'm submitting
- [x] I have reviewed and validated all AI-generated code

**AI tools used (if applicable):**
Google Antigravity AI assistant and Claude Code for design implementation, unit testing, and pre-commit validation.
