### PR TITLE
test: assert release model eval scores on sample data

### DIFF
--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -45,6 +45,32 @@ def test_evaluate_image(m):
     assert result["class_recall"]["precision"].iloc[0] > 0.5
 
 
+def test_release_model_regression(m):
+    """Assert the release model produces stable eval scores on the sample data.
+
+    Unlike the loose bounds in the other evaluation tests, this pins the scores
+    of weecology/deepforest-tree on OSBS_029 so that any drift in the model
+    outputs over time is detected. The small tolerance catches genuine changes
+    (a single box moves box_recall by ~1/61 > 0.01) while tolerating float noise
+    across platforms. Update these values intentionally when the release model
+    changes. See https://github.com/weecology/DeepForest/issues/1233
+    """
+    csv_file = get_data("OSBS_029.csv")
+    predictions = m.predict_file(csv_file=csv_file, root_dir=os.path.dirname(csv_file))
+    ground_truth = read_file(csv_file)
+    predictions.label = 0  # Model outputs numeric class IDs
+    result = evaluate.__evaluate_wrapper__(
+        predictions=predictions,
+        ground_df=ground_truth,
+        numeric_to_label_dict={0: "Tree"},
+        iou_threshold=0.4,
+        geometry_type="box",
+    )
+
+    assert result["box_precision"] == pytest.approx(0.80, abs=0.01)
+    assert result["box_recall"] == pytest.approx(0.72, abs=0.01)
+
+
 def test_evaluate_boxes(m):
     csv_file = get_data("OSBS_029.csv")
     predictions = m.predict_file(csv_file=csv_file, root_dir=os.path.dirname(csv_file))


### PR DESCRIPTION
## Description

Adds a regression test `test_release_model_regression` in `tests/test_evaluate.py` that runs the release model (`weecology/deepforest-tree`) on the `OSBS_029` sample data (which ships with ground truth) and pins the evaluation scores, so that drift in the model outputs over time is detected.

The existing evaluation tests only use loose bounds (e.g. `box_recall > 0.5`), so a genuine change in the model outputs would not be caught. This test pins, at `iou_threshold=0.4`:

- `box_precision == 0.80`
- `box_recall == 0.72`

These values come from integer match counts (44/55 and 44/61), so they are stable across platforms. They are asserted with `pytest.approx(..., abs=0.01)` so that a single changed detection (~1/61 ≈ 0.016) trips the test while float noise does not. The expected values are meant to be updated intentionally when the release model changes.

**Testing:** `pytest tests/test_evaluate.py::test_release_model_regression -v` passes locally (Python 3.12, CPU). Test-only addition — no breaking changes.

## Related Issue(s)

Related to #1233

This overlaps with the earlier draft #1249 by @musaqlain, which has been inactive for ~2 months. Opened as a small, self-contained alternative in case that one is stalled — happy to defer to it or align with whatever the maintainers prefer.

## AI-Assisted Development

- [x] I used AI tools (e.g., GitHub Copilot, ChatGPT, etc.) in developing this PR
- [x] I understand all the code I'm submitting
- [x] I have reviewed and validated all AI-generated code

**AI tools used (if applicable):**
Claude (Anthropic) helped investigate the codebase and draft the test; I reviewed the code and ran it locally.