### PR TITLE
fix: provide user-friendly error message for Hugging Face HTTP 401 au…

### DIFF
--- a/src/deepforest/main.py
+++ b/src/deepforest/main.py
@@ -150,9 +150,19 @@ class deepforest(pl.LightningModule):
         model_class = importlib.import_module(
             f"deepforest.models.{self.config.architecture}"
         )
-        self.model = model_class.Model(config=self.config).create_model(
-            pretrained=model_name, revision=revision
-        )
+        try:
+            self.model = model_class.Model(config=self.config).create_model(
+                pretrained=model_name, revision=revision
+            )
+        except Exception as e:
+            error_str = str(e)
+            if "401" in error_str or "Unauthorized" in error_str:
+                raise ValueError(
+                    f"Hugging Face authentication error (HTTP 401) when loading model '{model_name}'. "
+                    "Please check your credentials, set the HF_TOKEN environment variable, "
+                    f"or run `huggingface-cli login`. Original error: {e}"
+                ) from e
+            raise
 
         self.config.num_classes = self.model.num_classes
         self.set_labels(self.model.label_dict)

--- a/src/deepforest/model.py
+++ b/src/deepforest/model.py
@@ -618,7 +618,18 @@ class CropModel(LightningModule, PyTorchModelHubMixin):
                 the repo default branch.
         """
         # Download config to determine architecture and labels before loading weights
-        cfg_path = hf_hub_download(repo_id, "config.json", revision=revision)
+        try:
+            cfg_path = hf_hub_download(repo_id, "config.json", revision=revision)
+        except Exception as e:
+            error_str = str(e)
+            if "401" in error_str or "Unauthorized" in error_str:
+                raise ValueError(
+                    f"Hugging Face authentication error (HTTP 401) when loading crop model '{repo_id}'. "
+                    "Please check your credentials, set the HF_TOKEN environment variable, "
+                    f"or run `huggingface-cli login`. Original error: {e}"
+                ) from e
+            raise
+
         with open(cfg_path) as f:
             cfg = json.load(f)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -212,6 +212,15 @@ def test_load_model(m):
     assert not boxes.empty
 
 
+def test_load_model_hf_auth_error(m):
+    """Test that load_model catches 401 HTTP errors and raises a clear ValueError."""
+    from unittest.mock import patch
+
+    with patch("deepforest.models.retinanet.Model.create_model", side_effect=Exception("401 Client Error: Unauthorized for url")):
+        with pytest.raises(ValueError, match="Hugging Face authentication error"):
+            m.load_model("nonexistent/private-model")
+
+
 def test_train_empty_train_csv(m, tmp_path):
     empty_csv = pd.DataFrame({
         "image_path": ["OSBS_029.png", "OSBS_029.tif"],


### PR DESCRIPTION
# fix: provide user-friendly error message for Hugging Face HTTP 401 authentication errors

## Description

This PR improves error reporting when downloading models or crop models from Hugging Face Hub.

Previously, if a user attempted to load a private/gated model without valid credentials or an expired token, Hugging Face raised an unhandled `HTTPError: 401 Client Error`.

**Changes:**
1. Wrapped `model_class.Model().create_model()` in `deepforest.load_model` (`src/deepforest/main.py`) and `hf_hub_download` in `CropModel.from_pretrained` (`src/deepforest/model.py`) to catch HTTP 401 / Unauthorized exceptions.
2. Raises a clear `ValueError` explaining how to configure the `HF_TOKEN` environment variable or run `huggingface-cli login`.
3. Added unit test `test_load_model_hf_auth_error` in `tests/test_main.py`.

## Related Issue(s)

Closes #1401

## AI-Assisted Development

- [x] I used AI tools (e.g., GitHub Copilot, ChatGPT, etc.) in developing this PR
- [x] I understand all the code I'm submitting
- [x] I have reviewed and validated all AI-generated code

**AI tools used (if applicable):**
Google Antigravity AI assistant for design implementation, unit testing, and pre-commit validation.