### PR TITLE
build: require numpy >= 2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "hydra-core",
     "kornia>=0.8.2",
     "matplotlib",
-    "numpy",
+    "numpy>=2.0.0",
     "omegaconf",
     "opencv-python-headless>=4.5.4",
     "pandas",


### PR DESCRIPTION
Fixes #1422

## Description

Require numpy >= 2.0.0 in `pyproject.toml`. The `np.typing.NDArray` annotations in `src/deepforest/visualize.py` and `src/deepforest/datasets/training.py` are evaluated at module import time, and on numpy < 2.0 `np.typing` is only accessible if some earlier import has executed `import numpy.typing` — an incidental side effect that depends on which packages are installed and their versions (e.g. pandas 3.x triggers it at module level, pandas 2.x does not).

As discussed in #1422, pinning the floor is preferred over deferring annotation evaluation: numpy 2.0.0 is over two years old, the rest of the dependency stack already requires modern releases, and pinning eliminates this class of version-dependent behavior.

```diff
-    "numpy",
+    "numpy>=2.0.0",
```

## Verification

- Dependency declaration is constraint-only — no code paths affected.
- The remaining dependencies (geopandas, rasterio, kornia, pytorch-lightning, etc.) all support numpy 2.x.