### PR TITLE
fix: allow empty validation ranks in DDP metrics

### DIFF
--- a/src/deepforest/main.py
+++ b/src/deepforest/main.py
@@ -985,17 +985,20 @@ class deepforest(pl.LightningModule):
         metrics = {}
 
         if self.model.task == "box":
-            # IoU and mAP
-            if len(self.iou_metric.groundtruth_labels) > 0:
+            # IoU and mAP - call compute unconditionally so all DDP ranks participate in collective sync
+            try:
                 metrics.update(self.iou_metric.compute())
-                # Lightning bug: claims this is a warning but it's not. See issue #16218 in Lightning-AI/pytorch-lightning
-                output = self.mAP_metric.compute()
+            except ValueError as e:
+                if "No samples to concatenate" in str(e):
+                    pass
+                else:
+                    raise
 
-                # Remove classes from output dict
-                output = {
-                    key: value for key, value in output.items() if not key == "classes"
-                }
-                metrics.update(output)
+            output = self.mAP_metric.compute()
+
+            # Remove classes from output dict
+            output = {key: value for key, value in output.items() if not key == "classes"}
+            metrics.update(output)
             metrics.update(self.precision_recall_metric.compute())
 
         elif self.model.task == "point":

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1493,3 +1493,52 @@ def test_detections_per_img_and_topk_candidates_config():
     m.create_model()
     assert m.model.detections_per_img == 500
     assert m.model.topk_candidates == 2000
+
+
+def test_compute_epoch_metrics_empty_rank_calls_compute(m, monkeypatch):
+    """Test that a rank with no local groundtruth labels still calls compute()
+    and correctly incorporates synced distributed metrics (fixing #1407)."""
+    m.config.validation.csv_file = get_data("example.csv")
+    m.setup_metrics()
+
+    # Ensure local state has 0 groundtruth labels (simulating an empty rank shard)
+    assert len(m.iou_metric.groundtruth_labels) == 0
+
+    # Simulate torchmetrics returning gathered/synced metrics across DDP ranks
+    mock_iou_results = {"iou": torch.tensor(0.82), "iou/cl_0": torch.tensor(0.82)}
+    monkeypatch.setattr(m.iou_metric, "compute", lambda: mock_iou_results)
+
+    mock_map_results = {"map": torch.tensor(0.75), "classes": torch.tensor([0])}
+    monkeypatch.setattr(m.mAP_metric, "compute", lambda: mock_map_results)
+
+    metrics = m._compute_epoch_metrics()
+    assert "iou" in metrics
+    assert torch.isclose(metrics["iou"], torch.tensor(0.82))
+    assert "map" in metrics
+    assert torch.isclose(metrics["map"], torch.tensor(0.75))
+    assert "classes" not in metrics
+
+
+def test_compute_epoch_metrics_empty_state(m):
+    """Test that _compute_epoch_metrics succeeds even when no validation samples
+    were updated anywhere across the cluster."""
+    m.config.validation.csv_file = get_data("example.csv")
+    m.setup_metrics()
+    metrics = m._compute_epoch_metrics()
+    assert isinstance(metrics, dict)
+    assert "box_precision" in metrics
+    assert "box_recall" in metrics
+
+
+def test_compute_epoch_metrics_unexpected_value_error_raised(m, monkeypatch):
+    """Test that unexpected ValueErrors from iou_metric.compute() are not swallowed."""
+    m.config.validation.csv_file = get_data("example.csv")
+    m.setup_metrics()
+
+    def mock_raise():
+        raise ValueError("Unexpected internal calculation error")
+
+    monkeypatch.setattr(m.iou_metric, "compute", mock_raise)
+
+    with pytest.raises(ValueError, match="Unexpected internal calculation error"):
+        m._compute_epoch_metrics()


### PR DESCRIPTION
## Summary

Fixes #1407.

When running validation with DDP, a rank can receive an empty validation shard while other ranks have validation samples. Previously, `_compute_epoch_metrics()` skipped `IntersectionOverUnion.compute()` when the local rank had no ground-truth labels.

This caused ranks with data to enter TorchMetrics distributed synchronization while the empty rank skipped it, which could result in a distributed validation hang.

### Changes

- Always call `IntersectionOverUnion.compute()` so every DDP rank participates in distributed synchronization.
- Handle the expected zero-sample `ValueError` when the entire validation set is empty.
- Re-raise unexpected `ValueError` exceptions instead of silently swallowing them.
- Add regression tests covering:
  - empty rank still calling `compute()`
  - all-ranks-empty state
  - unexpected `ValueError` propagation

### Validation

- `pytest tests/test_main.py -k "test_compute_epoch_metrics"` -> 3 passed
- `ruff check src/deepforest/main.py` -> passed
- `git diff --check` -> passed
- Python 3.11.9
- torchmetrics 1.9.0
