### PR TITLE
fix: handle empty predictions in batch formatting and add format_prediction (#1101)

### DIFF
--- a/src/deepforest/main.py
+++ b/src/deepforest/main.py
@@ -1114,13 +1114,10 @@ class deepforest(pl.LightningModule):
             predictions = self.predict_step(images, 0)
 
         # convert predictions to dataframes
-        results = []
-        for pred in predictions:
-            if len(pred["boxes"]) == 0:
-                continue
-            geom_type = utilities.determine_geometry_type(pred)
-            result = utilities.format_geometry(pred, geom_type=geom_type)
-            results.append(result)
+        results = [
+            utilities.format_prediction(pred, scores=True, geom_type=self.model.task)
+            for pred in predictions
+        ]
 
         return results
 

--- a/src/deepforest/main.py
+++ b/src/deepforest/main.py
@@ -1114,8 +1114,9 @@ class deepforest(pl.LightningModule):
             predictions = self.predict_step(images, 0)
 
         # convert predictions to dataframes
+        geom_type = getattr(self.model, "task", None)
         results = [
-            utilities.format_prediction(pred, scores=True, geom_type=self.model.task)
+            utilities.format_prediction(pred, scores=True, geom_type=geom_type)
             for pred in predictions
         ]
 

--- a/src/deepforest/utilities.py
+++ b/src/deepforest/utilities.py
@@ -334,19 +334,34 @@ def determine_geometry_type(df):
         columns = df.columns
         if "geometry" in columns:
             df = gpd.GeoDataFrame(geometry=df["geometry"])
-            # Indexing [0] means an empty DataFrame raises an IndexError here.
-            geometry_type = df.geometry.type.unique()[0]
-            if geometry_type in ("Polygon", "MultiPolygon"):
-                # Polygons that exactly fill their envelope are really boxes.
-                if (
-                    geometry_type == "Polygon"
-                    and (df.geometry.area == df.envelope.area).all()
-                ):
-                    return "box"
+            unique_types = df.geometry.dropna().type.unique()
+            if len(unique_types) > 0:
+                geometry_type = unique_types[0]
+                if geometry_type in ("Polygon", "MultiPolygon"):
+                    # Polygons that exactly fill their envelope are really boxes.
+                    if (
+                        geometry_type == "Polygon"
+                        and (df.geometry.area == df.envelope.area).all()
+                    ):
+                        return "box"
+                    return "polygon"
+                if geometry_type == "Point":
+                    return "point"
+                raise ValueError(f"Unsupported geometry type in DataFrame: {geometry_type}")
+            # Empty geometry series or all NaN: infer from other columns if available
+            if (
+                "xmin" in columns
+                and "ymin" in columns
+                and "xmax" in columns
+                and "ymax" in columns
+            ):
+                return "box"
+            elif "polygon" in columns:
                 return "polygon"
-            if geometry_type == "Point":
+            elif "x" in columns and "y" in columns:
                 return "point"
-            raise ValueError(f"Unsupported geometry type in DataFrame: {geometry_type}")
+            # Default for empty GeoDataFrame with only geometry column
+            return "box"
         elif (
             "xmin" in columns
             and "ymin" in columns
@@ -378,6 +393,55 @@ def determine_geometry_type(df):
         raise ValueError(f"Could not determine geometry type from type {type(df)}")
 
     return geometry_type
+
+
+def format_prediction(
+    prediction: dict, scores: bool = True, geom_type: str | None = None
+) -> pd.DataFrame:
+    """Format a single model prediction dictionary into a pandas DataFrame.
+
+    If the prediction has no detections, returns an empty DataFrame with
+    the appropriate columns for the geometry type. For non-empty predictions,
+    delegates to format_geometry.
+
+    Args:
+        prediction (dict): Dictionary with keys for boxes, points, or masks/polygons,
+            along with labels and optional scores.
+        scores (bool): Whether to include the 'score' column. Defaults to True.
+        geom_type (str, optional): One of 'box', 'point', or 'polygon'. If None,
+            inferred automatically from prediction keys.
+
+    Returns:
+        pd.DataFrame: Formatted DataFrame with detections, or an empty DataFrame
+            with the proper schema if no detections exist.
+    """
+    if geom_type is None:
+        geom_type = determine_geometry_type(prediction)
+
+    formatted = format_geometry(prediction, scores=scores, geom_type=geom_type)
+    if formatted is not None:
+        return formatted
+
+    # Return empty DataFrame with correct column schema for geometry type
+    if geom_type == "box":
+        cols = ["xmin", "ymin", "xmax", "ymax", "label"]
+        if scores:
+            cols.append("score")
+        cols.append("geometry")
+    elif geom_type == "point":
+        cols = ["x", "y", "label"]
+        if scores:
+            cols.append("score")
+        cols.append("geometry")
+    elif geom_type == "polygon":
+        cols = ["label"]
+        if scores:
+            cols.append("score")
+        cols.append("geometry")
+    else:
+        raise ValueError(f"Unsupported geometry type: {geom_type}")
+
+    return pd.DataFrame(columns=cols)
 
 
 def format_geometry(predictions, scores=True, geom_type=None):

--- a/src/deepforest/utilities.py
+++ b/src/deepforest/utilities.py
@@ -347,7 +347,9 @@ def determine_geometry_type(df):
                     return "polygon"
                 if geometry_type == "Point":
                     return "point"
-                raise ValueError(f"Unsupported geometry type in DataFrame: {geometry_type}")
+                raise ValueError(
+                    f"Unsupported geometry type in DataFrame: {geometry_type}"
+                )
             # Empty geometry series or all NaN: infer from other columns if available
             if (
                 "xmin" in columns

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1569,3 +1569,37 @@ def test_predict_batch_preserves_length_with_empty_predictions():
         "geometry",
     ]
     assert len(results[1]) == 1
+
+
+def test_predict_batch_custom_model_without_task():
+    """Test that predict_batch handles custom models lacking a task attribute."""
+    m = main.deepforest()
+
+    class CustomDetector(torch.nn.Module):
+
+        def forward(self, images):
+            return [
+                {
+                    "boxes": torch.tensor([[10.0, 10.0, 20.0, 20.0]]),
+                    "labels": torch.tensor([0]),
+                    "scores": torch.tensor([0.95]),
+                }
+            ]
+
+    m.model = CustomDetector()
+    m.config.skip_empty = False
+
+    images = torch.rand((1, 3, 50, 50))
+    results = m.predict_batch(images)
+
+    assert len(results) == 1
+    assert not results[0].empty
+    assert list(results[0].columns) == [
+        "xmin",
+        "ymin",
+        "xmax",
+        "ymax",
+        "label",
+        "score",
+        "geometry",
+    ]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1493,3 +1493,79 @@ def test_detections_per_img_and_topk_candidates_config():
     m.create_model()
     assert m.model.detections_per_img == 500
     assert m.model.topk_candidates == 2000
+
+
+def test_predict_batch_point_model():
+    """Test that predict_batch executes without KeyError: 'boxes' on point models."""
+    m = main.deepforest()
+
+    class MockPointDetector(torch.nn.Module):
+
+        def __init__(self):
+            super().__init__()
+            self.task = "point"
+
+        def forward(self, images):
+            return [
+                {
+                    "points": torch.tensor([[10.0, 20.0]]),
+                    "labels": torch.tensor([0]),
+                    "scores": torch.tensor([0.9]),
+                }
+            ]
+
+    m.model = MockPointDetector()
+    m.config.skip_empty = False
+
+    # Input batch of 1 image
+    images = torch.rand((1, 3, 50, 50))
+    results = m.predict_batch(images)
+
+    assert len(results) == 1
+    assert isinstance(results[0], pd.DataFrame)
+    assert len(results[0]) == 1
+    assert list(results[0].columns) == ["x", "y", "label", "score", "geometry"]
+
+
+def test_predict_batch_preserves_length_with_empty_predictions():
+    """Test that predict_batch preserves 1 DataFrame per input image even when predictions are empty."""
+    m = main.deepforest()
+
+    class MockBoxDetector(torch.nn.Module):
+
+        def __init__(self):
+            super().__init__()
+            self.task = "box"
+
+        def forward(self, images):
+            return [
+                {
+                    "boxes": torch.zeros((0, 4)),
+                    "labels": torch.zeros(0, dtype=torch.int64),
+                    "scores": torch.zeros(0),
+                },
+                {
+                    "boxes": torch.tensor([[10.0, 10.0, 20.0, 20.0]]),
+                    "labels": torch.tensor([0]),
+                    "scores": torch.tensor([0.95]),
+                },
+            ]
+
+    m.model = MockBoxDetector()
+    m.config.skip_empty = False
+
+    images = torch.rand((2, 3, 50, 50))
+    results = m.predict_batch(images)
+
+    assert len(results) == 2
+    assert results[0].empty
+    assert list(results[0].columns) == [
+        "xmin",
+        "ymin",
+        "xmax",
+        "ymax",
+        "label",
+        "score",
+        "geometry",
+    ]
+    assert len(results[1]) == 1

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1059,3 +1059,116 @@ def test_drop_empty_images_tolerates_tiny_variation():
     filtered_images, _ = utilities.drop_empty_images([near_uniform])
 
     assert len(filtered_images) == 0
+
+
+def test_format_prediction_box():
+    prediction = {
+        "boxes": torch.tensor([[10, 20, 30, 40]]),
+        "labels": torch.tensor([0]),
+        "scores": torch.tensor([0.95]),
+    }
+    result = utilities.format_prediction(prediction)
+    assert isinstance(result, pd.DataFrame)
+    assert len(result) == 1
+    assert list(result.columns) == [
+        "xmin",
+        "ymin",
+        "xmax",
+        "ymax",
+        "label",
+        "score",
+        "geometry",
+    ]
+
+
+def test_format_prediction_box_empty():
+    prediction = {
+        "boxes": torch.zeros((0, 4)),
+        "labels": torch.zeros(0, dtype=torch.int64),
+        "scores": torch.zeros(0),
+    }
+    result = utilities.format_prediction(prediction, scores=True)
+    assert isinstance(result, pd.DataFrame)
+    assert result.empty
+    assert list(result.columns) == [
+        "xmin",
+        "ymin",
+        "xmax",
+        "ymax",
+        "label",
+        "score",
+        "geometry",
+    ]
+
+    # Without score column
+    result_no_score = utilities.format_prediction(prediction, scores=False)
+    assert list(result_no_score.columns) == [
+        "xmin",
+        "ymin",
+        "xmax",
+        "ymax",
+        "label",
+        "geometry",
+    ]
+
+
+def test_format_prediction_point():
+    prediction = {
+        "points": torch.tensor([[15, 25]]),
+        "labels": torch.tensor([0]),
+        "scores": torch.tensor([0.88]),
+    }
+    result = utilities.format_prediction(prediction, geom_type="point")
+    assert isinstance(result, pd.DataFrame)
+    assert len(result) == 1
+    assert list(result.columns) == ["x", "y", "label", "score", "geometry"]
+
+
+def test_format_prediction_point_empty():
+    prediction = {
+        "points": torch.zeros((0, 2)),
+        "labels": torch.zeros(0, dtype=torch.int64),
+        "scores": torch.zeros(0),
+    }
+    result = utilities.format_prediction(prediction, geom_type="point")
+    assert isinstance(result, pd.DataFrame)
+    assert result.empty
+    assert list(result.columns) == ["x", "y", "label", "score", "geometry"]
+
+
+def test_format_prediction_polygon():
+    masks = torch.zeros((1, 1, 50, 50), dtype=torch.float32)
+    masks[0, 0, 10:30, 10:30] = 1.0
+    prediction = {
+        "masks": masks,
+        "labels": torch.tensor([0]),
+        "scores": torch.tensor([0.9]),
+    }
+    result = utilities.format_prediction(prediction, geom_type="polygon")
+    assert isinstance(result, pd.DataFrame)
+    assert len(result) == 1
+    assert list(result.columns) == ["label", "score", "geometry"]
+
+
+def test_format_prediction_polygon_empty():
+    prediction = {
+        "masks": torch.zeros((0, 1, 50, 50), dtype=torch.float32),
+        "labels": torch.zeros(0, dtype=torch.int64),
+        "scores": torch.zeros(0),
+    }
+    result = utilities.format_prediction(prediction, geom_type="polygon")
+    assert isinstance(result, pd.DataFrame)
+    assert result.empty
+    assert list(result.columns) == ["label", "score", "geometry"]
+
+
+def test_determine_geometry_type_empty_geodataframe():
+    empty_gdf = gpd.GeoDataFrame(columns=["geometry"])
+    geom_type = utilities.determine_geometry_type(empty_gdf)
+    assert geom_type == "box"
+
+    empty_point_gdf = gpd.GeoDataFrame(columns=["geometry", "x", "y"])
+    assert utilities.determine_geometry_type(empty_point_gdf) == "point"
+
+    empty_poly_gdf = gpd.GeoDataFrame(columns=["geometry", "polygon"])
+    assert utilities.determine_geometry_type(empty_poly_gdf) == "polygon"


### PR DESCRIPTION
## Summary

Fixes #1101.

When an image has zero detections, prediction formatting previously required ad-hoc handling for empty prediction dictionaries. `predict_batch` also assumed box predictions and could drop empty results, causing failures or loss of image-to-result alignment for non-box models.

This PR introduces `utilities.format_prediction()` as a unified empty-safe formatting entry point while preserving the existing `format_geometry()` behavior for existing consumers.

### Changes

1. **Add `utilities.format_prediction()`**
   - Handles empty prediction dictionaries without manufacturing detections.
   - Returns a genuine 0-row `pandas.DataFrame` with the appropriate schema.
   - Supports box, point, and polygon prediction types.
   - Delegates non-empty predictions to `format_geometry()`.

2. **Harden `determine_geometry_type()`**
   - Safely handles empty GeoDataFrames.
   - Avoids `IndexError` when no geometry rows are available.

3. **Update `predict_batch()`**
   - Uses the model task to format predictions.
   - Supports box, point, and polygon predictions.
   - Preserves 1:1 image-to-result alignment, including images with zero detections.

4. **Preserve existing behavior**
   - `format_geometry(empty)` continues to return `None`.
   - Existing validation/callback consumers remain compatible with that contract.

### Difference from previous PR #1318

A previous unmerged PR (#1318) also explored adding `format_prediction()` for issue #1101.

This implementation differs in several important ways:

- Empty predictions are represented as genuine 0-row DataFrames rather than synthetic zero-coordinate detections.
- Geometry-specific schemas are preserved for box, point, and polygon predictions.
- `predict_batch()` no longer assumes every model produces `"boxes"` and preserves batch alignment when predictions are empty.
- Empty GeoDataFrame handling is hardened.
- The change is based on the current `main` branch and is limited to four focused files.

### Testing

- `pytest tests/test_utilities.py tests/test_main.py` — 143 passed
- `ruff check src/deepforest/utilities.py src/deepforest/main.py tests/test_utilities.py tests/test_main.py` — passed
- `git diff --check` — passed

No dependency or lockfile changes are included.
