### PR TITLE
feat: separate training and prediction batch sizes (#889)

### DIFF
--- a/docs/user_guide/09_configuration_file.md
+++ b/docs/user_guide/09_configuration_file.md
@@ -14,6 +14,8 @@ Please note that if you would like for deepforest to save the config file on rel
 workers: 0
 devices: auto
 accelerator: auto
+train_batch_size: 2
+predict_batch_size: 8
 batch_size: 1
 
 # Model Architecture
@@ -176,9 +178,17 @@ m.create_trainer(logger=comet_logger)
 
 On Slurm clusters, launch with `srun` so Lightning can read the job environment. Details are in [distributed runs](distributed.md).
 
+### train_batch_size
+
+Number of images per batch during training. Default is 2. GPU memory limits this usually between 5-10.
+
+### predict_batch_size
+
+Number of images per batch during prediction and validation. Default is 8.
+
 ### batch_size
 
-Number of images per batch during training. GPU memory limits this usually between 5-10
+Legacy batch size setting (default is 1). Maintained for backwards compatibility. If set or passed in `config_args`, it serves as a fallback for both `train_batch_size` and `predict_batch_size`.
 
 ### nms_thresh
 

--- a/docs/user_guide/09_configuration_file.md
+++ b/docs/user_guide/09_configuration_file.md
@@ -180,7 +180,7 @@ On Slurm clusters, launch with `srun` so Lightning can read the job environment.
 
 ### train_batch_size
 
-Number of images per batch during training. Default is 2. GPU memory limits this usually between 5-10.
+Number of images per batch during training. Default is 2. GPU memory typically limits this to between 5 and 10.
 
 ### predict_batch_size
 

--- a/docs/user_guide/11_training.md
+++ b/docs/user_guide/11_training.md
@@ -500,7 +500,7 @@ This will load all data into GPU memory once, at the beginning of the run. This 
 Similarly, increasing the batch size can speed up training. Like both of the options above, we have seen examples where performance (and accuracy) improves and decreases depending on batch size. Track experiment results carefully when altering batch size, since it directly [effects the speed of learning](https://www.baeldung.com/cs/learning-rate-batch-size).
 
 ```
-m.config.batch_size = 10
+m.config.train_batch_size = 10
 ```
 
 Remember to call m.create_trainer() after updating the config dictionary.
@@ -591,10 +591,10 @@ If you are using `uv` to manage your Python environment, remember to prefix thes
 On a Slurm cluster, wrap the command in `srun` inside your batch script (see [Scaling](07_scaling.md) and [distributed runs](distributed.md)).
 
 ```bash
-deepforest train batch_size=8 train.csv_file=your_labels.csv train.root_dir=some/path
+deepforest train train_batch_size=8 train.csv_file=your_labels.csv train.root_dir=some/path
 ```
 
-Under the hood, this sets up a DeepForest model, creates a trainer and runs `fit`. You can have a look at the script in `src/deepforest/scripts/train.py` to see exactly what's being run. However for most users, configuring the dataset paths (`train.csv_file` and `train.root_dir`) and perhaps modifying `batch_size` should be sufficient to start with. By setting up your own configuration or passing arguments via command line, you can train models without ever writing a python script.
+Under the hood, this sets up a DeepForest model, creates a trainer and runs `fit`. You can have a look at the script in `src/deepforest/scripts/train.py` to see exactly what's being run. However for most users, configuring the dataset paths (`train.csv_file` and `train.root_dir`) and perhaps modifying `train_batch_size` should be sufficient to start with. By setting up your own configuration or passing arguments via command line, you can train models without ever writing a python script.
 
 The tool includes a number of convenience features that we commonly need: logging, checkpointing, debug predictions and the option to monitor via Tensorboard (local) or Comet ML (cloud). You can resume training by passing the flag `--resume` with the path to a checkpoint created during training. Logs are saved to your `config.log_root`, which you can set to wherever is convenient. Experiments will then be saved in separate subfolders, versioned by timestamp if necessary.
 

--- a/src/deepforest/conf/bird.yaml
+++ b/src/deepforest/conf/bird.yaml
@@ -7,6 +7,8 @@ defaults:
 # Scale: increase batch_size if GPU memory allows; increase workers only with more Slurm CPUs
 # (train.sh --cpus-per-task); keep workers roughly cpus-per-task minus 1–2.
 workers: 8
+train_batch_size: 32
+predict_batch_size: 32
 batch_size: 32
 
 # Model Architecture

--- a/src/deepforest/conf/bird.yaml
+++ b/src/deepforest/conf/bird.yaml
@@ -9,7 +9,6 @@ defaults:
 workers: 8
 train_batch_size: 32
 predict_batch_size: 32
-batch_size: 32
 
 # Model Architecture
 architecture: 'retinanet'

--- a/src/deepforest/conf/config.yaml
+++ b/src/deepforest/conf/config.yaml
@@ -10,6 +10,8 @@ strategy: auto
 precision: 32-true
 sync_batchnorm: False
 use_distributed_sampler: True
+train_batch_size: 2
+predict_batch_size: 8
 batch_size: 1
 
 # Model Architecture

--- a/src/deepforest/conf/point_pretrain.yaml
+++ b/src/deepforest/conf/point_pretrain.yaml
@@ -15,6 +15,8 @@ num_classes: 1
 label_dict:
   Tree: 0
 
+train_batch_size: 32
+predict_batch_size: 32
 batch_size: 32
 workers: 8
 accelerator: auto

--- a/src/deepforest/conf/point_pretrain.yaml
+++ b/src/deepforest/conf/point_pretrain.yaml
@@ -17,7 +17,6 @@ label_dict:
 
 train_batch_size: 32
 predict_batch_size: 32
-batch_size: 32
 workers: 8
 accelerator: auto
 precision: bf16-mixed

--- a/src/deepforest/conf/schema.py
+++ b/src/deepforest/conf/schema.py
@@ -188,6 +188,8 @@ class Config:
     precision: str = "32-true"
     sync_batchnorm: bool = False
     use_distributed_sampler: bool = True
+    train_batch_size: int = 2
+    predict_batch_size: int = 8
     batch_size: int = 1
     precision: str | None = None
     matmul_precision: str = "highest"

--- a/src/deepforest/conf/schema.py
+++ b/src/deepforest/conf/schema.py
@@ -191,7 +191,6 @@ class Config:
     train_batch_size: int = 2
     predict_batch_size: int = 8
     batch_size: int = 1
-    precision: str | None = None
     matmul_precision: str = "highest"
 
     architecture: str = "retinanet"

--- a/src/deepforest/conf/smoke.yaml
+++ b/src/deepforest/conf/smoke.yaml
@@ -7,7 +7,6 @@ defaults:
 workers: 0
 train_batch_size: 2
 predict_batch_size: 2
-batch_size: 2
 log_root: ./lightning_logs_smoke
 
 train:

--- a/src/deepforest/conf/smoke.yaml
+++ b/src/deepforest/conf/smoke.yaml
@@ -5,6 +5,8 @@ defaults:
   - _self_
 
 workers: 0
+train_batch_size: 2
+predict_batch_size: 2
 batch_size: 2
 log_root: ./lightning_logs_smoke
 

--- a/src/deepforest/main.py
+++ b/src/deepforest/main.py
@@ -57,8 +57,12 @@ class deepforest(pl.LightningModule):
             has_predict_override = "predict_batch_size" in config_args
         elif isinstance(config, (dict, DictConfig)) and "batch_size" in config:
             legacy_batch_size = config["batch_size"]
-            has_train_override = "train_batch_size" in config
-            has_predict_override = "predict_batch_size" in config
+            has_train_override = "train_batch_size" in config or bool(
+                config_args and "train_batch_size" in config_args
+            )
+            has_predict_override = "predict_batch_size" in config or bool(
+                config_args and "predict_batch_size" in config_args
+            )
 
         if config is None:
             config = utilities.load_config(overrides=config_args)

--- a/src/deepforest/main.py
+++ b/src/deepforest/main.py
@@ -66,6 +66,14 @@ class deepforest(pl.LightningModule):
 
         self.config = config
 
+        # Backwards compatibility: if legacy batch_size was explicitly supplied in config_args,
+        # propagate it to train_batch_size and predict_batch_size unless they were also specified.
+        if config_args and "batch_size" in config_args:
+            if "train_batch_size" not in config_args:
+                self.config.train_batch_size = config_args["batch_size"]
+            if "predict_batch_size" not in config_args:
+                self.config.predict_batch_size = config_args["batch_size"]
+
         # release version id to flag if release is being used
         self.__release_version__ = None
 
@@ -451,6 +459,11 @@ class deepforest(pl.LightningModule):
         if self.existing_train_dataloader:
             return self.existing_train_dataloader
 
+        batch_size = self.config.train_batch_size
+        if hasattr(self.config, "batch_size") and self.config.batch_size is not None:
+            if self.config.batch_size != 1 and self.config.train_batch_size == 2:
+                batch_size = self.config.batch_size
+
         loader = self.load_dataset(
             csv_file=self.config.train.csv_file,
             root_dir=self.config.train.root_dir,
@@ -459,7 +472,7 @@ class deepforest(pl.LightningModule):
             validate_coordinates=self.config.train.validate_coordinates,
             shuffle=True,
             transforms=self.transforms,
-            batch_size=self.config.batch_size,
+            batch_size=batch_size,
         )
 
         return loader
@@ -477,6 +490,11 @@ class deepforest(pl.LightningModule):
         if self.existing_val_dataloader:
             return self.existing_val_dataloader
 
+        batch_size = self.config.predict_batch_size
+        if hasattr(self.config, "batch_size") and self.config.batch_size is not None:
+            if self.config.batch_size != 1 and self.config.predict_batch_size == 8:
+                batch_size = self.config.batch_size
+
         if self.config.validation.csv_file is not None:
             loader = self.load_dataset(
                 csv_file=self.config.validation.csv_file,
@@ -485,7 +503,7 @@ class deepforest(pl.LightningModule):
                 shuffle=False,
                 preload_images=self.config.validation.preload_images,
                 validate_coordinates=self.config.validation.validate_coordinates,
-                batch_size=self.config.batch_size,
+                batch_size=batch_size,
             )
 
         return loader
@@ -500,7 +518,10 @@ class deepforest(pl.LightningModule):
             torch.utils.data.DataLoader: A dataloader object that can be used for prediction.
         """
         if batch_size is None:
-            batch_size = self.config.batch_size
+            batch_size = self.config.predict_batch_size
+            if hasattr(self.config, "batch_size") and self.config.batch_size is not None:
+                if self.config.batch_size != 1 and self.config.predict_batch_size == 8:
+                    batch_size = self.config.batch_size
         else:
             batch_size = batch_size
         sampler = None
@@ -572,7 +593,7 @@ class deepforest(pl.LightningModule):
             patch_size=max(image.shape[0], image.shape[1]),
             return_metadata=True,
         )
-        dataloader = self.predict_dataloader(ds, batch_size=self.config.batch_size)
+        dataloader = self.predict_dataloader(ds)
 
         results = predict._dataloader_wrapper_(
             model=self,
@@ -629,7 +650,7 @@ class deepforest(pl.LightningModule):
         ds = prediction.FromCSVFile(
             csv_file=csv_file, root_dir=root_dir, return_metadata=True
         )
-        dataloader = self.predict_dataloader(ds, batch_size=self.config.batch_size)
+        dataloader = self.predict_dataloader(ds)
         results = predict._dataloader_wrapper_(
             model=self,
             trainer=self.trainer,
@@ -1275,9 +1296,9 @@ class deepforest(pl.LightningModule):
             self.predictions = pd.concat(self.predictions, ignore_index=True)
             if "label" in self.predictions.columns:
                 self.predictions["label"] = self.predictions["label"].map(
-                    lambda x: self.numeric_to_label_dict.get(int(x), x)
-                    if pd.notna(x)
-                    else x
+                    lambda x: (
+                        self.numeric_to_label_dict.get(int(x), x) if pd.notna(x) else x
+                    )
                 )
         else:
             self.predictions = pd.DataFrame()

--- a/src/deepforest/main.py
+++ b/src/deepforest/main.py
@@ -46,6 +46,20 @@ class deepforest(pl.LightningModule):
     ):
         super().__init__()
 
+        # Check if legacy batch_size was explicitly supplied in config_args or config
+        legacy_batch_size = None
+        has_train_override = False
+        has_predict_override = False
+
+        if config_args and "batch_size" in config_args:
+            legacy_batch_size = config_args["batch_size"]
+            has_train_override = "train_batch_size" in config_args
+            has_predict_override = "predict_batch_size" in config_args
+        elif isinstance(config, (dict, DictConfig)) and "batch_size" in config:
+            legacy_batch_size = config["batch_size"]
+            has_train_override = "train_batch_size" in config
+            has_predict_override = "predict_batch_size" in config
+
         if config is None:
             config = utilities.load_config(overrides=config_args)
         # Default/string config name
@@ -66,13 +80,13 @@ class deepforest(pl.LightningModule):
 
         self.config = config
 
-        # Backwards compatibility: if legacy batch_size was explicitly supplied in config_args,
+        # Backwards compatibility: if legacy batch_size was explicitly supplied in config_args or config,
         # propagate it to train_batch_size and predict_batch_size unless they were also specified.
-        if config_args and "batch_size" in config_args:
-            if "train_batch_size" not in config_args:
-                self.config.train_batch_size = config_args["batch_size"]
-            if "predict_batch_size" not in config_args:
-                self.config.predict_batch_size = config_args["batch_size"]
+        if legacy_batch_size is not None:
+            if not has_train_override:
+                self.config.train_batch_size = legacy_batch_size
+            if not has_predict_override:
+                self.config.predict_batch_size = legacy_batch_size
 
         # release version id to flag if release is being used
         self.__release_version__ = None
@@ -459,11 +473,6 @@ class deepforest(pl.LightningModule):
         if self.existing_train_dataloader:
             return self.existing_train_dataloader
 
-        batch_size = self.config.train_batch_size
-        if hasattr(self.config, "batch_size") and self.config.batch_size is not None:
-            if self.config.batch_size != 1 and self.config.train_batch_size == 2:
-                batch_size = self.config.batch_size
-
         loader = self.load_dataset(
             csv_file=self.config.train.csv_file,
             root_dir=self.config.train.root_dir,
@@ -472,7 +481,7 @@ class deepforest(pl.LightningModule):
             validate_coordinates=self.config.train.validate_coordinates,
             shuffle=True,
             transforms=self.transforms,
-            batch_size=batch_size,
+            batch_size=self.config.train_batch_size,
         )
 
         return loader
@@ -490,11 +499,6 @@ class deepforest(pl.LightningModule):
         if self.existing_val_dataloader:
             return self.existing_val_dataloader
 
-        batch_size = self.config.predict_batch_size
-        if hasattr(self.config, "batch_size") and self.config.batch_size is not None:
-            if self.config.batch_size != 1 and self.config.predict_batch_size == 8:
-                batch_size = self.config.batch_size
-
         if self.config.validation.csv_file is not None:
             loader = self.load_dataset(
                 csv_file=self.config.validation.csv_file,
@@ -503,7 +507,7 @@ class deepforest(pl.LightningModule):
                 shuffle=False,
                 preload_images=self.config.validation.preload_images,
                 validate_coordinates=self.config.validation.validate_coordinates,
-                batch_size=batch_size,
+                batch_size=self.config.predict_batch_size,
             )
 
         return loader
@@ -519,9 +523,6 @@ class deepforest(pl.LightningModule):
         """
         if batch_size is None:
             batch_size = self.config.predict_batch_size
-            if hasattr(self.config, "batch_size") and self.config.batch_size is not None:
-                if self.config.batch_size != 1 and self.config.predict_batch_size == 8:
-                    batch_size = self.config.batch_size
         else:
             batch_size = batch_size
         sampler = None
@@ -1296,9 +1297,9 @@ class deepforest(pl.LightningModule):
             self.predictions = pd.concat(self.predictions, ignore_index=True)
             if "label" in self.predictions.columns:
                 self.predictions["label"] = self.predictions["label"].map(
-                    lambda x: (
-                        self.numeric_to_label_dict.get(int(x), x) if pd.notna(x) else x
-                    )
+                    lambda x: self.numeric_to_label_dict.get(int(x), x)
+                    if pd.notna(x)
+                    else x
                 )
         else:
             self.predictions = pd.DataFrame()

--- a/src/deepforest/utilities.py
+++ b/src/deepforest/utilities.py
@@ -88,6 +88,22 @@ def load_config(
     if override_label_dict:
         config.label_dict = override_label_dict
 
+    # Backwards compatibility: propagate legacy batch_size to train_batch_size
+    # and predict_batch_size when mode-specific settings are not explicitly provided.
+    if "batch_size" in yaml_cfg and yaml_cfg["batch_size"] is not None:
+        legacy_val = yaml_cfg["batch_size"]
+        if "train_batch_size" not in yaml_cfg and "train_batch_size" not in overrides:
+            config.train_batch_size = legacy_val
+        if "predict_batch_size" not in yaml_cfg and "predict_batch_size" not in overrides:
+            config.predict_batch_size = legacy_val
+
+    if "batch_size" in overrides and overrides["batch_size"] is not None:
+        legacy_val = overrides["batch_size"]
+        if "train_batch_size" not in overrides:
+            config.train_batch_size = legacy_val
+        if "predict_batch_size" not in overrides:
+            config.predict_batch_size = legacy_val
+
     return config
 
 

--- a/tests/test_batch_size.py
+++ b/tests/test_batch_size.py
@@ -155,21 +155,108 @@ def test_legacy_batch_size_config_args():
     assert m.predict_dataloader(ds).batch_size == 5
 
 
-def test_legacy_batch_size_direct_assignment():
-    """Verify directly mutating m.config.batch_size falls back in dataloaders."""
+def test_legacy_batch_size_train_override():
+    """Verify legacy batch_size + explicit train_batch_size uses train override."""
     csv_file = get_data("example.csv")
     root_dir = os.path.dirname(csv_file)
     path = get_data("OSBS_029.png")
     tile = np.array(Image.open(path))
     ds = prediction.SingleImage(image=tile, path=path, patch_overlap=0.1, patch_size=100)
 
-    m = main.deepforest()
+    m = main.deepforest(config_args={"batch_size": 4, "train_batch_size": 6})
     m.config.train.csv_file = csv_file
     m.config.train.root_dir = root_dir
     m.config.validation.csv_file = csv_file
     m.config.validation.root_dir = root_dir
 
-    m.config.batch_size = 6
+    assert m.config.train_batch_size == 6
+    assert m.config.predict_batch_size == 4
     assert m.train_dataloader().batch_size == 6
-    assert m.val_dataloader().batch_size == 6
-    assert m.predict_dataloader(ds).batch_size == 6
+    assert m.val_dataloader().batch_size == 4
+    assert m.predict_dataloader(ds).batch_size == 4
+
+
+def test_legacy_batch_size_predict_override():
+    """Verify legacy batch_size + explicit predict_batch_size uses predict override."""
+    csv_file = get_data("example.csv")
+    root_dir = os.path.dirname(csv_file)
+    path = get_data("OSBS_029.png")
+    tile = np.array(Image.open(path))
+    ds = prediction.SingleImage(image=tile, path=path, patch_overlap=0.1, patch_size=100)
+
+    m = main.deepforest(config_args={"batch_size": 4, "predict_batch_size": 16})
+    m.config.train.csv_file = csv_file
+    m.config.train.root_dir = root_dir
+    m.config.validation.csv_file = csv_file
+    m.config.validation.root_dir = root_dir
+
+    assert m.config.train_batch_size == 4
+    assert m.config.predict_batch_size == 16
+    assert m.train_dataloader().batch_size == 4
+    assert m.val_dataloader().batch_size == 16
+    assert m.predict_dataloader(ds).batch_size == 16
+
+
+def test_legacy_batch_size_all_three_supplied():
+    """Verify when all three are supplied, explicit settings take precedence."""
+    csv_file = get_data("example.csv")
+    root_dir = os.path.dirname(csv_file)
+    path = get_data("OSBS_029.png")
+    tile = np.array(Image.open(path))
+    ds = prediction.SingleImage(image=tile, path=path, patch_overlap=0.1, patch_size=100)
+
+    m = main.deepforest(
+        config_args={"batch_size": 4, "train_batch_size": 6, "predict_batch_size": 16}
+    )
+    m.config.train.csv_file = csv_file
+    m.config.train.root_dir = root_dir
+    m.config.validation.csv_file = csv_file
+    m.config.validation.root_dir = root_dir
+
+    assert m.config.train_batch_size == 6
+    assert m.config.predict_batch_size == 16
+    assert m.train_dataloader().batch_size == 6
+    assert m.val_dataloader().batch_size == 16
+    assert m.predict_dataloader(ds).batch_size == 16
+
+
+def test_legacy_batch_size_one_compatibility():
+    """Verify passing legacy batch_size=1 in config_args works deterministically."""
+    csv_file = get_data("example.csv")
+    root_dir = os.path.dirname(csv_file)
+    path = get_data("OSBS_029.png")
+    tile = np.array(Image.open(path))
+    ds = prediction.SingleImage(image=tile, path=path, patch_overlap=0.1, patch_size=100)
+
+    m = main.deepforest(config_args={"batch_size": 1})
+    m.config.train.csv_file = csv_file
+    m.config.train.root_dir = root_dir
+    m.config.validation.csv_file = csv_file
+    m.config.validation.root_dir = root_dir
+
+    assert m.config.train_batch_size == 1
+    assert m.config.predict_batch_size == 1
+    assert m.train_dataloader().batch_size == 1
+    assert m.val_dataloader().batch_size == 1
+    assert m.predict_dataloader(ds).batch_size == 1
+
+
+def test_legacy_batch_size_in_config_dict():
+    """Verify passing legacy batch_size in a custom config dictionary translates properly."""
+    csv_file = get_data("example.csv")
+    root_dir = os.path.dirname(csv_file)
+    path = get_data("OSBS_029.png")
+    tile = np.array(Image.open(path))
+    ds = prediction.SingleImage(image=tile, path=path, patch_overlap=0.1, patch_size=100)
+
+    m = main.deepforest(config={"batch_size": 5})
+    m.config.train.csv_file = csv_file
+    m.config.train.root_dir = root_dir
+    m.config.validation.csv_file = csv_file
+    m.config.validation.root_dir = root_dir
+
+    assert m.config.train_batch_size == 5
+    assert m.config.predict_batch_size == 5
+    assert m.train_dataloader().batch_size == 5
+    assert m.val_dataloader().batch_size == 5
+    assert m.predict_dataloader(ds).batch_size == 5

--- a/tests/test_batch_size.py
+++ b/tests/test_batch_size.py
@@ -3,7 +3,7 @@ import os
 import numpy as np
 from PIL import Image
 
-from deepforest import get_data, main
+from deepforest import get_data, main, utilities
 from deepforest.datasets import prediction
 
 
@@ -260,3 +260,138 @@ def test_legacy_batch_size_in_config_dict():
     assert m.train_dataloader().batch_size == 5
     assert m.val_dataloader().batch_size == 5
     assert m.predict_dataloader(ds).batch_size == 5
+
+
+def test_legacy_yaml_by_path(tmp_path):
+    """Verify loading a legacy YAML config with batch_size propagates to both train and predict."""
+    config_path = tmp_path / "legacy_config.yaml"
+    config_path.write_text("batch_size: 5\n")
+
+    csv_file = get_data("example.csv")
+    root_dir = os.path.dirname(csv_file)
+    path = get_data("OSBS_029.png")
+    tile = np.array(Image.open(path))
+    ds = prediction.SingleImage(image=tile, path=path, patch_overlap=0.1, patch_size=100)
+
+    m = main.deepforest(config=str(config_path))
+    m.config.train.csv_file = csv_file
+    m.config.train.root_dir = root_dir
+    m.config.validation.csv_file = csv_file
+    m.config.validation.root_dir = root_dir
+
+    assert m.config.train_batch_size == 5
+    assert m.config.predict_batch_size == 5
+    assert m.config.batch_size == 5
+    assert m.train_dataloader().batch_size == 5
+    assert m.val_dataloader().batch_size == 5
+    assert m.predict_dataloader(ds).batch_size == 5
+
+
+def test_legacy_yaml_with_explicit_train_override(tmp_path):
+    """Verify legacy YAML batch_size + explicit train_batch_size override."""
+    config_path = tmp_path / "legacy_config.yaml"
+    config_path.write_text("batch_size: 5\n")
+
+    csv_file = get_data("example.csv")
+    root_dir = os.path.dirname(csv_file)
+    path = get_data("OSBS_029.png")
+    tile = np.array(Image.open(path))
+    ds = prediction.SingleImage(image=tile, path=path, patch_overlap=0.1, patch_size=100)
+
+    m = main.deepforest(config=str(config_path), config_args={"train_batch_size": 10})
+    m.config.train.csv_file = csv_file
+    m.config.train.root_dir = root_dir
+    m.config.validation.csv_file = csv_file
+    m.config.validation.root_dir = root_dir
+
+    assert m.config.train_batch_size == 10
+    assert m.config.predict_batch_size == 5
+    assert m.train_dataloader().batch_size == 10
+    assert m.val_dataloader().batch_size == 5
+    assert m.predict_dataloader(ds).batch_size == 5
+
+
+def test_legacy_yaml_with_explicit_predict_override(tmp_path):
+    """Verify legacy YAML batch_size + explicit predict_batch_size override."""
+    config_path = tmp_path / "legacy_config.yaml"
+    config_path.write_text("batch_size: 5\n")
+
+    csv_file = get_data("example.csv")
+    root_dir = os.path.dirname(csv_file)
+    path = get_data("OSBS_029.png")
+    tile = np.array(Image.open(path))
+    ds = prediction.SingleImage(image=tile, path=path, patch_overlap=0.1, patch_size=100)
+
+    m = main.deepforest(config=str(config_path), config_args={"predict_batch_size": 12})
+    m.config.train.csv_file = csv_file
+    m.config.train.root_dir = root_dir
+    m.config.validation.csv_file = csv_file
+    m.config.validation.root_dir = root_dir
+
+    assert m.config.train_batch_size == 5
+    assert m.config.predict_batch_size == 12
+    assert m.train_dataloader().batch_size == 5
+    assert m.val_dataloader().batch_size == 12
+    assert m.predict_dataloader(ds).batch_size == 12
+
+
+def test_legacy_yaml_with_both_explicit_overrides(tmp_path):
+    """Verify legacy YAML batch_size + explicit train and predict overrides."""
+    config_path = tmp_path / "legacy_config.yaml"
+    config_path.write_text("batch_size: 5\n")
+
+    csv_file = get_data("example.csv")
+    root_dir = os.path.dirname(csv_file)
+    path = get_data("OSBS_029.png")
+    tile = np.array(Image.open(path))
+    ds = prediction.SingleImage(image=tile, path=path, patch_overlap=0.1, patch_size=100)
+
+    m = main.deepforest(
+        config=str(config_path),
+        config_args={"train_batch_size": 4, "predict_batch_size": 16},
+    )
+    m.config.train.csv_file = csv_file
+    m.config.train.root_dir = root_dir
+    m.config.validation.csv_file = csv_file
+    m.config.validation.root_dir = root_dir
+
+    assert m.config.train_batch_size == 4
+    assert m.config.predict_batch_size == 16
+    assert m.train_dataloader().batch_size == 4
+    assert m.val_dataloader().batch_size == 16
+    assert m.predict_dataloader(ds).batch_size == 16
+
+
+def test_legacy_yaml_batch_size_one(tmp_path):
+    """Verify legacy YAML batch_size=1 translates to both settings."""
+    config_path = tmp_path / "legacy_config.yaml"
+    config_path.write_text("batch_size: 1\n")
+
+    csv_file = get_data("example.csv")
+    root_dir = os.path.dirname(csv_file)
+    path = get_data("OSBS_029.png")
+    tile = np.array(Image.open(path))
+    ds = prediction.SingleImage(image=tile, path=path, patch_overlap=0.1, patch_size=100)
+
+    m = main.deepforest(config=str(config_path))
+    m.config.train.csv_file = csv_file
+    m.config.train.root_dir = root_dir
+    m.config.validation.csv_file = csv_file
+    m.config.validation.root_dir = root_dir
+
+    assert m.config.train_batch_size == 1
+    assert m.config.predict_batch_size == 1
+    assert m.train_dataloader().batch_size == 1
+    assert m.val_dataloader().batch_size == 1
+    assert m.predict_dataloader(ds).batch_size == 1
+
+
+def test_load_config_direct_legacy_yaml(tmp_path):
+    """Verify utilities.load_config directly translates legacy batch_size in YAML."""
+    config_path = tmp_path / "legacy_config.yaml"
+    config_path.write_text("batch_size: 7\n")
+
+    cfg = utilities.load_config(str(config_path))
+    assert cfg.train_batch_size == 7
+    assert cfg.predict_batch_size == 7
+    assert cfg.batch_size == 7

--- a/tests/test_batch_size.py
+++ b/tests/test_batch_size.py
@@ -1,0 +1,175 @@
+import os
+
+import numpy as np
+from PIL import Image
+
+from deepforest import get_data, main
+from deepforest.datasets import prediction
+
+
+def test_default_batch_sizes():
+    """Verify default train and predict batch sizes in config schema."""
+    m = main.deepforest()
+    assert m.config.train_batch_size == 2
+    assert m.config.predict_batch_size == 8
+    assert m.config.batch_size == 1
+
+
+def test_train_dataloader_uses_train_batch_size():
+    """Verify train_dataloader uses train_batch_size."""
+    csv_file = get_data("example.csv")
+    root_dir = os.path.dirname(csv_file)
+    m = main.deepforest(config_args={"train_batch_size": 4})
+    m.config.train.csv_file = csv_file
+    m.config.train.root_dir = root_dir
+    loader = m.train_dataloader()
+    assert loader.batch_size == 4
+
+
+def test_train_dataloader_default_batch_size():
+    """Verify train_dataloader defaults to batch size 2."""
+    csv_file = get_data("example.csv")
+    root_dir = os.path.dirname(csv_file)
+    m = main.deepforest()
+    m.config.train.csv_file = csv_file
+    m.config.train.root_dir = root_dir
+    loader = m.train_dataloader()
+    assert loader.batch_size == 2
+
+
+def test_val_dataloader_uses_predict_batch_size():
+    """Verify val_dataloader uses predict_batch_size."""
+    csv_file = get_data("example.csv")
+    root_dir = os.path.dirname(csv_file)
+    m = main.deepforest(config_args={"predict_batch_size": 6})
+    m.config.validation.csv_file = csv_file
+    m.config.validation.root_dir = root_dir
+    loader = m.val_dataloader()
+    assert loader.batch_size == 6
+
+
+def test_val_dataloader_default_batch_size():
+    """Verify val_dataloader defaults to batch size 8."""
+    csv_file = get_data("example.csv")
+    root_dir = os.path.dirname(csv_file)
+    m = main.deepforest()
+    m.config.validation.csv_file = csv_file
+    m.config.validation.root_dir = root_dir
+    loader = m.val_dataloader()
+    assert loader.batch_size == 8
+
+
+def test_predict_dataloader_uses_predict_batch_size():
+    """Verify predict_dataloader uses predict_batch_size."""
+    path = get_data("OSBS_029.png")
+    tile = np.array(Image.open(path))
+    ds = prediction.SingleImage(image=tile, path=path, patch_overlap=0.1, patch_size=100)
+
+    m = main.deepforest(config_args={"predict_batch_size": 16})
+    loader = m.predict_dataloader(ds)
+    assert loader.batch_size == 16
+
+
+def test_predict_dataloader_default_batch_size():
+    """Verify predict_dataloader defaults to batch size 8."""
+    path = get_data("OSBS_029.png")
+    tile = np.array(Image.open(path))
+    ds = prediction.SingleImage(image=tile, path=path, patch_overlap=0.1, patch_size=100)
+
+    m = main.deepforest()
+    loader = m.predict_dataloader(ds)
+    assert loader.batch_size == 8
+
+
+def test_predict_dataloader_explicit_arg_override():
+    """Verify explicit batch_size argument to predict_dataloader takes precedence."""
+    path = get_data("OSBS_029.png")
+    tile = np.array(Image.open(path))
+    ds = prediction.SingleImage(image=tile, path=path, patch_overlap=0.1, patch_size=100)
+
+    m = main.deepforest(config_args={"predict_batch_size": 16})
+    loader = m.predict_dataloader(ds, batch_size=4)
+    assert loader.batch_size == 4
+
+
+def test_independent_train_and_predict_batch_sizes():
+    """Verify train_batch_size and predict_batch_size can be set independently."""
+    csv_file = get_data("example.csv")
+    root_dir = os.path.dirname(csv_file)
+    path = get_data("OSBS_029.png")
+    tile = np.array(Image.open(path))
+    ds = prediction.SingleImage(image=tile, path=path, patch_overlap=0.1, patch_size=100)
+
+    m = main.deepforest(config_args={"train_batch_size": 3, "predict_batch_size": 7})
+    m.config.train.csv_file = csv_file
+    m.config.train.root_dir = root_dir
+    m.config.validation.csv_file = csv_file
+    m.config.validation.root_dir = root_dir
+
+    train_loader = m.train_dataloader()
+    val_loader = m.val_dataloader()
+    predict_loader = m.predict_dataloader(ds)
+
+    assert train_loader.batch_size == 3
+    assert val_loader.batch_size == 7
+    assert predict_loader.batch_size == 7
+
+
+def test_batch_size_one_edge_case():
+    """Verify batch_size=1 works for both training and prediction."""
+    csv_file = get_data("example.csv")
+    root_dir = os.path.dirname(csv_file)
+    path = get_data("OSBS_029.png")
+    tile = np.array(Image.open(path))
+    ds = prediction.SingleImage(image=tile, path=path, patch_overlap=0.1, patch_size=100)
+
+    m = main.deepforest(config_args={"train_batch_size": 1, "predict_batch_size": 1})
+    m.config.train.csv_file = csv_file
+    m.config.train.root_dir = root_dir
+
+    train_loader = m.train_dataloader()
+    predict_loader = m.predict_dataloader(ds)
+
+    assert train_loader.batch_size == 1
+    assert predict_loader.batch_size == 1
+
+
+def test_legacy_batch_size_config_args():
+    """Verify passing legacy batch_size in config_args sets both train and predict batch sizes."""
+    csv_file = get_data("example.csv")
+    root_dir = os.path.dirname(csv_file)
+    path = get_data("OSBS_029.png")
+    tile = np.array(Image.open(path))
+    ds = prediction.SingleImage(image=tile, path=path, patch_overlap=0.1, patch_size=100)
+
+    m = main.deepforest(config_args={"batch_size": 5})
+    m.config.train.csv_file = csv_file
+    m.config.train.root_dir = root_dir
+    m.config.validation.csv_file = csv_file
+    m.config.validation.root_dir = root_dir
+
+    assert m.config.train_batch_size == 5
+    assert m.config.predict_batch_size == 5
+    assert m.train_dataloader().batch_size == 5
+    assert m.val_dataloader().batch_size == 5
+    assert m.predict_dataloader(ds).batch_size == 5
+
+
+def test_legacy_batch_size_direct_assignment():
+    """Verify directly mutating m.config.batch_size falls back in dataloaders."""
+    csv_file = get_data("example.csv")
+    root_dir = os.path.dirname(csv_file)
+    path = get_data("OSBS_029.png")
+    tile = np.array(Image.open(path))
+    ds = prediction.SingleImage(image=tile, path=path, patch_overlap=0.1, patch_size=100)
+
+    m = main.deepforest()
+    m.config.train.csv_file = csv_file
+    m.config.train.root_dir = root_dir
+    m.config.validation.csv_file = csv_file
+    m.config.validation.root_dir = root_dir
+
+    m.config.batch_size = 6
+    assert m.train_dataloader().batch_size == 6
+    assert m.val_dataloader().batch_size == 6
+    assert m.predict_dataloader(ds).batch_size == 6

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -362,7 +362,7 @@ def test_validate_predictions_match_predict_file_mixed_sizes(m, tmp_path):
     m.config.validation.csv_file = csv_path
     m.config.validation.root_dir = str(tmp_path)
     # Don't set validation.size to avoid resizing - use batch_size=1 to handle mixed sizes
-    m.config.batch_size = 1
+    m.config.predict_batch_size = 1
 
     # Run validation to populate m.predictions
     m.create_trainer()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -481,7 +481,7 @@ def test_predict_small_file(m):
 
 @pytest.mark.parametrize("batch_size", [1, 2])
 def test_predict_dataloader(m, batch_size, path):
-    m.config.batch_size = batch_size
+    m.config.predict_batch_size = batch_size
     tile = np.array(Image.open(path))
     ds = prediction.SingleImage(image=tile, path=path, patch_overlap=0.1, patch_size=100)
     dl = m.predict_dataloader(ds)


### PR DESCRIPTION
## Summary

Closes #889.

DeepForest previously used a single `batch_size` configuration value for
training, validation, and prediction. This change separates training and
prediction batch sizes so memory-constrained training and higher-throughput
inference can be configured independently.

### Changes

- Add `train_batch_size` with a default of `2`.
- Add `predict_batch_size` with a default of `8`.
- Use `train_batch_size` for the training DataLoader.
- Use `predict_batch_size` for validation and prediction DataLoaders.
- Preserve explicit `predict_dataloader(..., batch_size=...)` overrides.
- Preserve compatibility with legacy `batch_size` configuration by translating
  explicitly supplied legacy values during initialization.
- Remove redundant legacy `batch_size` entries from the affected preset YAML
  files.
- Update configuration and training documentation.
- Add focused tests covering defaults, independent values, validation,
  explicit overrides, legacy configuration translation, and precedence.

## Backward compatibility

Legacy `batch_size` remains supported for existing configuration/checkpoint
compatibility.

When supplied explicitly through configuration, it is translated during
initialization to the new mode-specific settings unless an explicit
`train_batch_size` or `predict_batch_size` override is provided.

The DataLoader implementations themselves use only the new
`train_batch_size` and `predict_batch_size` settings, avoiding ambiguous
runtime fallback behavior.

## Validation

The following tests passed locally:

- `uv run pytest tests/test_batch_size.py` — 16 passed
- `uv run pytest tests/test_config.py` — 13 passed
- `uv run pytest tests/test_main.py -k "dataloader"` — 8 passed
- `uv run pytest tests/test_main_checkpointing.py` — 19 passed
- `uv run pytest tests/test_evaluate.py -k "mixed"` — 1 passed
- Ruff checks passed
- Ruff formatting checks passed
- `git diff --check` passed

## Files changed

- Configuration schema and defaults
- Configuration presets
- DataLoader wiring
- Configuration/training documentation
- Batch-size regression tests
- Existing tests migrated to the new mode-specific configuration

## AI assistance

AI-assisted development was used during implementation. The resulting
changes were manually reviewed, tested, and validated against the existing
DeepForest codebase and Issue #889 requirements.
