### PR TITLE
test: add CUDA regression test for predict_image (#1390)

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -447,6 +447,63 @@ def test_predict_image_fromfile(m):
     assert not prediction.empty
 
 
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_predict_image_on_cuda(m):
+    """Regression test for #1390: model on CUDA must not raise a device mismatch in predict_image."""
+    m.model.to("cuda")
+    try:
+        prediction = m.predict_image(
+            path=get_data(path="2019_YELL_2_528000_4978000_image_crop2.png")
+        )
+    finally:
+        m.model.to("cpu")
+    assert isinstance(prediction, pd.DataFrame)
+    assert not prediction.empty
+
+
+def test_predict_image_device_alignment(m, monkeypatch):
+    """Regression test for #1390: ensure input tensors match model device during predict_image."""
+    observed_devices = []
+    orig_forward = m.model.forward
+
+    def spy_forward(images, *args, **kwargs):
+        model_device = next(m.model.parameters()).device
+        if isinstance(images, torch.Tensor):
+            observed_devices.append((images.device, model_device))
+        elif isinstance(images, list):
+            for img in images:
+                observed_devices.append((img.device, model_device))
+        return orig_forward(images, *args, **kwargs)
+
+    monkeypatch.setattr(m.model, "forward", spy_forward)
+
+    path = get_data(path="2019_YELL_2_528000_4978000_image_crop2.png")
+    prediction = m.predict_image(path=path)
+
+    assert isinstance(prediction, pd.DataFrame)
+    assert len(observed_devices) > 0
+    for input_device, model_device in observed_devices:
+        assert input_device == model_device
+
+
+def test_predict_image_routes_through_trainer(m, monkeypatch):
+    """Regression test for #1390: predict_image must route through trainer.predict for device management."""
+    trainer_predict_called = False
+    orig_predict = m.trainer.predict
+
+    def mock_predict(*args, **kwargs):
+        nonlocal trainer_predict_called
+        trainer_predict_called = True
+        return orig_predict(*args, **kwargs)
+
+    monkeypatch.setattr(m.trainer, "predict", mock_predict)
+    path = get_data(path="2019_YELL_2_528000_4978000_image_crop2.png")
+    prediction = m.predict_image(path=path)
+
+    assert trainer_predict_called
+    assert isinstance(prediction, pd.DataFrame)
+
+
 def test_predict_image_fromarray(m):
     image_path = get_data(path="2019_YELL_2_528000_4978000_image_crop2.png")
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -449,16 +449,25 @@ def test_predict_image_fromfile(m):
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 def test_predict_image_on_cuda(m):
-    """Regression test for #1390: model on CUDA must not raise a device mismatch in predict_image."""
-    m.model.to("cuda")
+    """Regression test for #1390: predict_image executes on GPU without device mismatch."""
+    orig_accelerator = m.config.accelerator
+    orig_devices = m.config.devices
+    m.config.accelerator = "gpu"
+    m.config.devices = 1
+    m.create_trainer()
+    m.to("cuda")
     try:
         prediction = m.predict_image(
             path=get_data(path="2019_YELL_2_528000_4978000_image_crop2.png")
         )
+        assert isinstance(prediction, pd.DataFrame)
+        assert not prediction.empty
+        assert next(m.parameters()).device.type == "cuda"
     finally:
-        m.model.to("cpu")
-    assert isinstance(prediction, pd.DataFrame)
-    assert not prediction.empty
+        m.to("cpu")
+        m.config.accelerator = orig_accelerator
+        m.config.devices = orig_devices
+        m.create_trainer()
 
 
 def test_predict_image_device_alignment(m, monkeypatch):


### PR DESCRIPTION
## Description

This PR adds regression test coverage for Issue #1390 (`predict_image fails on CUDA: input tensor not moved to model device`).

### Context & Forensic Audit
- Issue #1390 reported that `deepforest.main.deepforest.predict_image()` failed when the underlying detector was on CUDA (`RuntimeError: Input type (torch.FloatTensor) and weight type (torch.cuda.FloatTensor) should be the same...`).
- At the time #1390 was opened, `predict_image()` delegated to a private helper `deepforest.predict._predict_image_` that constructed CPU tensors directly (`torch.tensor(image) / 255`) and called `model(image.unsqueeze(0))`, bypassing PyTorch Lightning.
- PR #1391 proposed a one-line fix (`image.to(next(model.parameters()).device)`) in `_predict_image_` along with a test `test_predict_image_on_cuda`.
- In review discussions on PR #1391, maintainers (@jveitchmichaelis, @bw4sz) concluded that the proper architectural pattern was to route `predict_image()` through `trainer.predict(self, dataloader)`.
- PR #1398 ("Use trainer.predict for single images") was subsequently merged into `main` (commit `6490646`), deleting `_predict_image_` and bringing `predict_image()` into `trainer.predict`.
- However, PR #1398 referenced PR #1391 rather than `Closes #1390`, leaving Issue #1390 open without the regression test suite.

### Changes
- `tests/test_main.py`:
  - Added `test_predict_image_on_cuda`: Verifies that `predict_image` executes without device mismatch on CUDA (auto-skipped on CPU runners).
  - Added `test_predict_image_device_alignment`: Deterministic regression test asserting that input tensors match the model parameter device at model invocation.
  - Added `test_predict_image_routes_through_trainer`: Verifies `predict_image` routes through `trainer.predict` for PyTorch Lightning device placement.

## Related Issue(s)

Closes #1390
Related to #1391
Related to #1398

## AI-Assisted Development

- [x] I used AI tools (e.g., GitHub Copilot, ChatGPT, etc.) in developing this PR
- [x] I understand all the code I'm submitting
- [x] I have reviewed and validated all AI-generated code

**AI tools used (if applicable):**
Antigravity (Google DeepMind)
